### PR TITLE
Pia 1983 release

### DIFF
--- a/BankAPILibrary/GiniBankAPILibrary/Documentation/sections/Documentation.md
+++ b/BankAPILibrary/GiniBankAPILibrary/Documentation/sections/Documentation.md
@@ -1,5 +1,5 @@
 <p align="center">
-<img src="img/repo-logo.png" width="250">
+<img src="img/logo.png" width="250">
 </p>
 
 # Gini Bank API Library for iOS

--- a/BankAPILibrary/GiniBankAPILibrary/Documentation/source/Installation.md
+++ b/BankAPILibrary/GiniBankAPILibrary/Documentation/source/Installation.md
@@ -8,14 +8,14 @@ Gini Bank API Library can either be installed by using Swift Package Manager or 
 The [Swift Package Manager](https://swift.org/package-manager/)  is a tool for managing the distribution of Swift code.
 Once you have your Swift package set up, adding `GiniBankAPILibrary` as a dependency is as easy as adding it to the dependencies value of your `Package.swift`
 
-```swif
+```swift
 dependencies: [
     .package(url: "https://github.com/gini/bank-api-library-ios.git", .exact("1.0.0"))
 ]
 ```
 
 In case that you want to use the certificate pinning in the library, add `GiniBankAPILibraryPinning`:
-```swif
+```swift
 dependencies: [
     .package(url: "https://github.com/gini/bank-api-library-pinning-ios.git", .exact("1.0.0"))
 ]

--- a/BankAPILibrary/GiniBankAPILibrary/README.md
+++ b/BankAPILibrary/GiniBankAPILibrary/README.md
@@ -1,5 +1,6 @@
-![Gini Bank API Library for iOS](./GiniBank_Logo.png?raw=true)
-
+<p align="center">
+<img src="./Documentation/jazzy-theme/assets/img/logo.png" width="250">
+</p>
 # Gini Bank API Library for iOS
 
 [![Platform](https://img.shields.io/badge/platform-iOS-lightgrey.svg)]()

--- a/BankAPILibrary/GiniBankAPILibrary/Sources/GiniBankAPILibrary/GiniBankAPILibraryVersion.swift
+++ b/BankAPILibrary/GiniBankAPILibrary/Sources/GiniBankAPILibrary/GiniBankAPILibraryVersion.swift
@@ -5,4 +5,4 @@
 //  Created by Nadya Karaban on 28.10.21.
 //
 
-public let GiniBankAPILibraryVersion = "0.0.1"
+public let GiniBankAPILibraryVersion = "1.0.0"

--- a/BankAPILibrary/GiniBankAPILibraryPinning/Package-release.swift
+++ b/BankAPILibrary/GiniBankAPILibraryPinning/Package-release.swift
@@ -17,7 +17,7 @@ let package = Package(
         // .package(url: /* package url */, from: "1.0.0"),
         
         .package(name: "TrustKit", url: "https://github.com/datatheorem/TrustKit.git", from: "2.0.0"),
-        .package(name: "GiniBankAPILibrary", url: "https://github.com/gini/bank-api-library-ios.git", .exact("0.0.1")),
+        .package(name: "GiniBankAPILibrary", url: "https://github.com/gini/bank-api-library-ios.git", .exact("1.0.0")),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/BankAPILibrary/GiniBankAPILibraryPinning/README.md
+++ b/BankAPILibrary/GiniBankAPILibraryPinning/README.md
@@ -1,7 +1,6 @@
 <p align="center">
-<img src="./GiniBank_Logo.png" width="250">
+<img src="./Documentation/jazzy-theme/assets/img/logo.png" width="250">
 </p>
-
 # Gini Bank API Library Pinning for iOS
 
 [![Platform](https://img.shields.io/badge/platform-iOS-lightgrey.svg)]()

--- a/BankAPILibrary/GiniBankAPILibraryPinning/Sources/GiniBankAPILibraryPinning/GiniBankAPILibraryPinningVersion.swift
+++ b/BankAPILibrary/GiniBankAPILibraryPinning/Sources/GiniBankAPILibraryPinning/GiniBankAPILibraryPinningVersion.swift
@@ -5,4 +5,4 @@
 //  Created by Nadya Karaban on 15.10.21.
 //
 
-public let GiniBankAPILibraryPinningVersion = "0.0.1"
+public let GiniBankAPILibraryPinningVersion = "1.0.0"

--- a/BankSDK/GiniBankSDK/Documentation/source/Installation.md
+++ b/BankSDK/GiniBankSDK/Documentation/source/Installation.md
@@ -8,16 +8,16 @@ Gini Bank SDK can either be installed by using Swift Package Manager or by manua
 The [Swift Package Manager](https://swift.org/package-manager/)  is a tool for managing the distribution of Swift code.
 Once you have your Swift package set up, adding `GiniBankSDK` as a dependency is as easy as adding it to the dependencies value of your `Package.swift`
 
-```swif
+```swift
 dependencies: [
-    .package(url: "https://github.com/gini/bank-sdk-ios.git", .exact("1.0.0"))
+    .package(url: "https://github.com/gini/bank-sdk-ios.git", .exact("1.1.0"))
 ]
 ```
 **Note: Availible from iOS 12**
 In case that you want to use the certificate pinning in the library, add `GiniBankSDKPinning`:
-```swif
+```swift
 dependencies: [
-    .package(url: "https://github.com/gini/bank-sdk-pinning-ios.git", .exact("1.0.0"))
+    .package(url: "https://github.com/gini/bank-sdk-pinning-ios.git", .exact("1.1.0"))
 ]
 ```
 

--- a/BankSDK/GiniBankSDK/Package-release.swift
+++ b/BankSDK/GiniBankSDK/Package-release.swift
@@ -16,7 +16,7 @@ let package = Package(
     dependencies: [
         // Dependencies declare other packages that this package depends on.
         // .package(url: /* package url */, from: "1.0.0"),
-        .package(name: "GiniCaptureSDK", url: "https://github.com/gini/capture-sdk-ios.git", .exact("0.0.2")),
+        .package(name: "GiniCaptureSDK", url: "https://github.com/gini/capture-sdk-ios.git", .exact("1.1.0")),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/BankSDK/GiniBankSDK/Sources/GiniBankSDKVersion.swift
+++ b/BankSDK/GiniBankSDK/Sources/GiniBankSDKVersion.swift
@@ -5,4 +5,4 @@
 //  Created by Nadya Karaban on 04.11.21.
 //
 
-public let GiniBankSDKVersion = "0.0.2"
+public let GiniBankSDKVersion = "1.1.0"

--- a/BankSDK/GiniBankSDKPinning/Package-release.swift
+++ b/BankSDK/GiniBankSDKPinning/Package-release.swift
@@ -16,8 +16,8 @@ let package = Package(
     dependencies: [
         // Dependencies declare other packages that this package depends on.
         // .package(url: /* package url */, from: "1.0.0"),
-        .package(name: "GiniCaptureSDKPinning", url: "https://github.com/gini/capture-sdk-pinning-ios.git", .exact("0.0.2")),
-        .package(name: "GiniBankSDK", url: "https://github.com/gini/bank-sdk-ios.git", .exact("0.0.2")),
+        .package(name: "GiniCaptureSDKPinning", url: "https://github.com/gini/capture-sdk-pinning-ios.git", .exact("1.1.0")),
+        .package(name: "GiniBankSDK", url: "https://github.com/gini/bank-sdk-ios.git", .exact("1.1.0")),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/BankSDK/GiniBankSDKPinning/Sources/GiniBankSDKPinningVersion.swift
+++ b/BankSDK/GiniBankSDKPinning/Sources/GiniBankSDKPinningVersion.swift
@@ -5,4 +5,4 @@
 //  Created by Nadya Karaban on 04.11.21.
 //
 
-public let GiniBankSDKPinningVersion = "0.0.2"
+public let GiniBankSDKPinningVersion = "1.1.0"

--- a/CaptureSDK/GiniCaptureSDK/Documentation/source/Installation.md
+++ b/CaptureSDK/GiniCaptureSDK/Documentation/source/Installation.md
@@ -8,16 +8,16 @@ Gini Capture SDK can either be installed by using Swift Package Manager or by ma
 The [Swift Package Manager](https://swift.org/package-manager/)  is a tool for managing the distribution of Swift code.
 Once you have your Swift package set up, adding `GiniCaptureSDK` as a dependency is as easy as adding it to the dependencies value of your `Package.swift`
 
-```swif
+```swift
 dependencies: [
-    .package(url: "https://github.com/gini/capture-sdk-ios.git", .exact("1.0.0"))
+    .package(url: "https://github.com/gini/capture-sdk-ios.git", .exact("1.1.0"))
 ]
 ```
 
 In case that you want to use the certificate pinning in the library, add `GiniCaptureSDKPinning`:
-```swif
+```swift
 dependencies: [
-    .package(url: "https://github.com/gini/capture-sdk-pinning-ios.git", .exact("1.0.0"))
+    .package(url: "https://github.com/gini/capture-sdk-pinning-ios.git", .exact("1.1.0"))
 ]
 ```
 

--- a/CaptureSDK/GiniCaptureSDK/Package-release.swift
+++ b/CaptureSDK/GiniCaptureSDK/Package-release.swift
@@ -16,7 +16,7 @@ let package = Package(
     dependencies: [
         // Dependencies declare other packages that this package depends on.
         // .package(url: /* package url */, from: "1.0.0"),
-        .package(name: "GiniBankAPILibrary", url: "https://github.com/gini/bank-api-library-ios.git", .exact("0.0.1")),
+        .package(name: "GiniBankAPILibrary", url: "https://github.com/gini/bank-api-library-ios.git", .exact("1.0.0")),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDKVersion.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDKVersion.swift
@@ -5,4 +5,4 @@
 //  Created by Nadya Karaban on 29.10.21.
 //
 
-public let GiniCaptureSDKVersion = "0.0.2"
+public let GiniCaptureSDKVersion = "1.1.0"

--- a/CaptureSDK/GiniCaptureSDKPinning/Package-release.swift
+++ b/CaptureSDK/GiniCaptureSDKPinning/Package-release.swift
@@ -16,8 +16,8 @@ let package = Package(
     dependencies: [
         // Dependencies declare other packages that this package depends on.
         // .package(url: /* package url */, from: "1.0.0"),
-        .package(name: "GiniBankAPILibraryPinning", url: "https://github.com/gini/bank-api-library-pinning-ios.git", .exact("0.0.1")),
-        .package(name: "GiniCaptureSDK", url: "https://github.com/gini/capture-sdk-ios.git", .exact("0.0.2")),
+        .package(name: "GiniBankAPILibraryPinning", url: "https://github.com/gini/bank-api-library-pinning-ios.git", .exact("1.0.0")),
+        .package(name: "GiniCaptureSDK", url: "https://github.com/gini/capture-sdk-ios.git", .exact("1.1.0")),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/CaptureSDK/GiniCaptureSDKPinning/Sources/GiniCaptureSDKPinningVersion.swift
+++ b/CaptureSDK/GiniCaptureSDKPinning/Sources/GiniCaptureSDKPinningVersion.swift
@@ -5,4 +5,4 @@
 //  Created by Nadya Karaban on 29.10.21.
 //
 
-public let GiniCaptureSDKPinningVersion = "0.0.2"
+public let GiniCaptureSDKPinningVersion = "1.1.0"

--- a/HealthAPILibrary/GiniHealthAPILibrary/Documentation/source/Installation.md
+++ b/HealthAPILibrary/GiniHealthAPILibrary/Documentation/source/Installation.md
@@ -8,14 +8,14 @@ Gini Health API Library can either be installed by using Swift Package Manager o
 The [Swift Package Manager](https://swift.org/package-manager/)  is a tool for managing the distribution of Swift code.
 Once you have your Swift package set up, adding `GiniHealthAPILibrary` as a dependency is as easy as adding it to the dependencies value of your `Package.swift`
 
-```swif
+```swift
 dependencies: [
     .package(url: "https://github.com/gini/health-api-library-ios.git", .exact("1.0.0"))
 ]
 ```
 
 In case that you want to use the certificate pinning in the library, add `GiniHealthAPILibraryPinning`:
-```swif
+```swift
 dependencies: [
     .package(url: "https://github.com/gini/health-api-library-pinning-ios.git", .exact("1.0.0"))
 ]

--- a/HealthAPILibrary/GiniHealthAPILibrary/Sources/GiniHealthAPILibrary/GiniHealthAPILibraryVersion.swift
+++ b/HealthAPILibrary/GiniHealthAPILibrary/Sources/GiniHealthAPILibrary/GiniHealthAPILibraryVersion.swift
@@ -5,4 +5,4 @@
 //  Created by Nadya Karaban on 15.10.21.
 //
 
-public let GiniHealthAPILibraryVersion = "0.0.1"
+public let GiniHealthAPILibraryVersion = "1.0.0"

--- a/HealthAPILibrary/GiniHealthAPILibraryPinning/Package-release.swift
+++ b/HealthAPILibrary/GiniHealthAPILibraryPinning/Package-release.swift
@@ -17,7 +17,7 @@ let package = Package(
         // .package(url: /* package url */, from: "1.0.0"),
         
         .package(name: "TrustKit", url: "https://github.com/datatheorem/TrustKit.git", from: "2.0.0"),
-        .package(name: "GiniHealthAPILibrary", url: "https://github.com/gini/health-api-library-ios.git", .exact("0.0.1")),
+        .package(name: "GiniHealthAPILibrary", url: "https://github.com/gini/health-api-library-ios.git", .exact("1.0.0")),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/HealthAPILibrary/GiniHealthAPILibraryPinning/Sources/GiniHealthAPILibraryPinning/GiniHealthAPILibraryPinningVersion.swift
+++ b/HealthAPILibrary/GiniHealthAPILibraryPinning/Sources/GiniHealthAPILibraryPinning/GiniHealthAPILibraryPinningVersion.swift
@@ -5,4 +5,4 @@
 //  Created by Nadya Karaban on 15.10.21.
 //
 
-public let GiniHealthAPILibraryPinningVersion = "0.0.1"
+public let GiniHealthAPILibraryPinningVersion = "1.0.0"

--- a/HealthSDK/GiniHealthSDK/Documentation/source/Installation.md
+++ b/HealthSDK/GiniHealthSDK/Documentation/source/Installation.md
@@ -8,14 +8,14 @@ Gini Health SDK can either be installed by using Swift Package Manager or by man
 The [Swift Package Manager](https://swift.org/package-manager/)  is a tool for managing the distribution of Swift code.
 Once you have your Swift package set up, adding `GiniHealthSDK` as a dependency is as easy as adding it to the dependencies value of your `Package.swift`
 
-```swif
+```swift
 dependencies: [
     .package(url: "https://github.com/gini/health-sdk-ios.git", .exact("1.0.0"))
 ]
 ```
 
 In case that you want to use the certificate pinning in the library, add `GiniHealthAPILibraryPinning`:
-```swif
+```swift
 dependencies: [
     .package(url: "https://github.com/gini/health-sdk-pinning-ios.git", .exact("1.0.0"))
 ]

--- a/HealthSDK/GiniHealthSDK/Package-release.swift
+++ b/HealthSDK/GiniHealthSDK/Package-release.swift
@@ -16,7 +16,7 @@ let package = Package(
     dependencies: [
         // Dependencies declare other packages that this package depends on.
         // .package(url: /* package url */, from: "1.0.0"),
-        .package(name: "GiniHealthAPILibrary", url: "https://github.com/gini/health-api-library-ios.git", .exact("0.0.1")),
+        .package(name: "GiniHealthAPILibrary", url: "https://github.com/gini/health-api-library-ios.git", .exact("1.0.0")),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/HealthSDK/GiniHealthSDK/Sources/GiniHealthSDK/GiniHealthSDKVersion.swift
+++ b/HealthSDK/GiniHealthSDK/Sources/GiniHealthSDK/GiniHealthSDKVersion.swift
@@ -5,4 +5,4 @@
 //  Created by Nadya Karaban on 15.10.21.
 //
 
-public let GiniHealthSDKVersion = "0.0.1"
+public let GiniHealthSDKVersion = "1.0.0"

--- a/HealthSDK/GiniHealthSDKPinning/Package-release.swift
+++ b/HealthSDK/GiniHealthSDKPinning/Package-release.swift
@@ -15,8 +15,8 @@ let package = Package(
     dependencies: [
         // Dependencies declare other packages that this package depends on.
         // .package(url: /* package url */, from: "1.0.0"),
-        .package(name: "GiniHealthAPILibraryPinning", url: "https://github.com/gini/health-api-library-pinning-ios.git", .exact("0.0.1")),
-        .package(name: "GiniHealthSDK", url: "https://github.com/gini/health-sdk-ios.git", .exact("0.0.1")),
+        .package(name: "GiniHealthAPILibraryPinning", url: "https://github.com/gini/health-api-library-pinning-ios.git", .exact("1.0.0")),
+        .package(name: "GiniHealthSDK", url: "https://github.com/gini/health-sdk-ios.git", .exact("1.0.0")),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/HealthSDK/GiniHealthSDKPinning/Sources/GiniHealthSDKPinning/GiniHealthSDKPinningVersion.swift
+++ b/HealthSDK/GiniHealthSDKPinning/Sources/GiniHealthSDKPinning/GiniHealthSDKPinningVersion.swift
@@ -5,4 +5,4 @@
 //  Created by Nadya Karaban on 15.10.21.
 //
 
-public let GiniHealthSDKPinningVersion = "0.0.1"
+public let GiniHealthSDKPinningVersion = "1.0.0"


### PR DESCRIPTION
• Use 1.0.0 version for new libs and SDKs:
  -  Health API Library;
  -  Bank API Library;
  -  Health SDK.
  
• Bump minor in the current version of existing libs and SDKs 1.1.0:
  - Capture SDK;
  - Bank SDK.
  
• Fix versions in installation guides.


