### PR TITLE
Pia 2146 network service

### DIFF
--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Networking/AccountingDocumentService.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Networking/AccountingDocumentService.swift
@@ -4,7 +4,7 @@
 //
 //  Created by Enrique del Pozo Gómez on 1/14/19.
 //
-
+// MARK: - TODO DELETE
 import Foundation
 import GiniBankAPILibrary
 
@@ -145,8 +145,8 @@ fileprivate extension AccountingDocumentService {
             analysisCancellationToken = CancellationToken()
         }
         
-        documentService.extractions(for: document,
-                                    cancellationToken: analysisCancellationToken!,
-                                    completion: handleResults(completion: completion))
+//        documentService.extractions(for: document,
+//                                    cancellationToken: analysisCancellationToken!,
+//                                    completion: handleResults(completion: completion))
     }
 }

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Networking/DocumentService.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Networking/DocumentService.swift
@@ -69,32 +69,30 @@ public final class DocumentService: DocumentServiceProtocol {
     
     public func cancelAnalysis() {
         if let compositeDocument = document {
-            captureNetworkService.delete(document: compositeDocument) {[weak self] result in
+            captureNetworkService.delete(document: compositeDocument) { result in
                 switch result {
-                case .success:
-                    self?.analysisCancellationToken?.cancel()
-                    self?.analysisCancellationToken = nil
-                    self?.document = nil
-                case .failure(_):
+                case .success, .failure(_) :
                     break
                 }
             }
         }
+        analysisCancellationToken?.cancel()
+        analysisCancellationToken = nil
+        document = nil
     }
     
     public func remove(document: GiniCaptureDocument) {
         if let index = partialDocuments.index(forKey: document.id) {
             if let document = partialDocuments[document.id]?
                 .document {
-                captureNetworkService.delete(document: document) {[weak self] result in
+                captureNetworkService.delete(document: document) { result in
                     switch result {
-                    case .success:
-                        self?.partialDocuments.remove(at: index)
-                    case .failure(_):
+                    case .success, .failure(_):
                         break
                     }
                 }
             }
+            partialDocuments.remove(at: index)
         }
     }
     

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Networking/DocumentService.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Networking/DocumentService.swift
@@ -56,7 +56,7 @@ public final class DocumentService: DocumentServiceProtocol {
     
     public func cancelAnalysis() {
         if let compositeDocument = document {
-            delete(compositeDocument)
+            defaultCaptureNetworkService.delete(document: compositeDocument)
         }
         
         analysisCancellationToken?.cancel()
@@ -68,7 +68,7 @@ public final class DocumentService: DocumentServiceProtocol {
         if let index = partialDocuments.index(forKey: document.id) {
             if let document = partialDocuments[document.id]?
                 .document {
-                delete(document)
+                defaultCaptureNetworkService.delete(document: document)
             }
             partialDocuments.remove(at: index)
         }
@@ -125,25 +125,4 @@ public final class DocumentService: DocumentServiceProtocol {
         }
     }
     
-}
-
-// MARK: - File private methods
-
-fileprivate extension DocumentService {
-    
-    func delete(_ document: Document) {
-        documentService.delete(document) { result in
-            switch result {
-            case .success:
-                Log(message: "Deleted \(document.sourceClassification.rawValue) document with id: \(document.id)",
-                    event: "🗑")
-            case .failure(let error):
-                let message = "Error deleting \(document.sourceClassification.rawValue) document with" +
-                    " id: \(document.id)"
-                Log(message: message,event: .error)
-                let errorLog = ErrorLog(description: message, error: error)
-                GiniConfiguration.shared.errorLogger.handleErrorLog(error: errorLog)
-            }
-        }
-    }
 }

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Networking/DocumentServiceProtocol.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Networking/DocumentServiceProtocol.swift
@@ -18,13 +18,13 @@ public protocol DocumentServiceProtocol: AnyObject {
     var analysisCancellationToken: CancellationToken? { get set }
     
     func cancelAnalysis()
-    func remove(document: GiniCaptureDocument) // delete
-    func resetToInitialState() // cleanup
+    func remove(document: GiniCaptureDocument)
+    func resetToInitialState()
     func sendFeedback(with updatedExtractions: [Extraction])
-    func startAnalysis(completion: @escaping AnalysisCompletion) // analyze
+    func startAnalysis(completion: @escaping AnalysisCompletion)
     func sortDocuments(withSameOrderAs documents: [GiniCaptureDocument])
     func upload(document: GiniCaptureDocument,
-                completion: UploadDocumentCompletion?) // upload
-    func update(imageDocument: GiniImageDocument) // ??
+                completion: UploadDocumentCompletion?)
+    func update(imageDocument: GiniImageDocument)
     func log(errorEvent: ErrorEvent)
 }

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Networking/DocumentServiceProtocol.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Networking/DocumentServiceProtocol.swift
@@ -18,14 +18,14 @@ public protocol DocumentServiceProtocol: AnyObject {
     var analysisCancellationToken: CancellationToken? { get set }
     
     func cancelAnalysis()
-    func remove(document: GiniCaptureDocument)
-    func resetToInitialState()
+    func remove(document: GiniCaptureDocument) // delete
+    func resetToInitialState() // cleanup
     func sendFeedback(with updatedExtractions: [Extraction])
-    func startAnalysis(completion: @escaping AnalysisCompletion)
+    func startAnalysis(completion: @escaping AnalysisCompletion) // analyze
     func sortDocuments(withSameOrderAs documents: [GiniCaptureDocument])
     func upload(document: GiniCaptureDocument,
-                completion: UploadDocumentCompletion?)
-    func update(imageDocument: GiniImageDocument)
+                completion: UploadDocumentCompletion?) // upload
+    func update(imageDocument: GiniImageDocument) // ??
     func log(errorEvent: ErrorEvent)
 }
 

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Networking/DocumentServiceProtocol.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Networking/DocumentServiceProtocol.swift
@@ -28,25 +28,3 @@ public protocol DocumentServiceProtocol: AnyObject {
     func update(imageDocument: GiniImageDocument) // ??
     func log(errorEvent: ErrorEvent)
 }
-
-extension DocumentServiceProtocol {
-    
-    func handleResults(completion: @escaping AnalysisCompletion) -> (CompletionResult<ExtractionResult>) {
-        return { result in
-            switch result {
-            case .success(let extractionResult):
-                Log(message: "Finished analysis process with no errors", event: .success)
-                completion(.success(extractionResult))
-            case .failure(let error):
-                switch error {
-                case .requestCancelled:
-                    Log(message: "Cancelled analysis process", event: .error)
-                default:
-                    Log(message: "Finished analysis process with error: \(error)", event: .error)
-                    completion(.failure(error))
-                }
-            }
-        }
-        
-    }
-}

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Networking/Extensions/GiniCapture+GiniCaptureDelegate.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Networking/Extensions/GiniCapture+GiniCaptureDelegate.swift
@@ -46,6 +46,35 @@ extension GiniCapture {
         return screenCoordinator.start(withDocuments: importedDocuments)
     }
     
+    /**
+     Returns a view controller which will handle the analysis process.
+     It's the easiest way to get started with the Gini Capture SDK as it comes pre-configured and handles
+     all screens and transitions out of the box with the custom networking.
+     
+     - parameter importedDocuments: There should be either images or one PDF, and they should be validated before calling this     method.
+     - parameter resultsDelegate: Results delegate object where you can get the results of the analysis.
+     - parameter configuration: The configuration to set.
+     - parameter documentMetadata: Additional HTTP headers to send when uploading documents.
+     - parameter trackingDelegate: A delegate object to receive user events.
+     - parameter networkingService:A delegate object which implement protocol for the document processing events.
+
+     - note: Screen API with custom networking only.
+
+     - returns: A presentable view controller.
+     */
+    public class func viewController(importedDocuments: [GiniCaptureDocument]? = nil,
+                                     configuration: GiniConfiguration,
+                                     resultsDelegate: GiniCaptureResultsDelegate,
+                                     documentMetadata: Document.Metadata? = nil,
+                                     trackingDelegate: GiniCaptureTrackingDelegate? = nil,
+                                     networkingService: GiniCaptureNetworkService) -> UIViewController {
+        GiniCapture.setConfiguration(configuration)
+        let screenCoordinator = GiniNetworkingScreenAPICoordinator(resultsDelegate: resultsDelegate, giniConfiguration: configuration, documentMetadata: documentMetadata, trackingDelegate: trackingDelegate, captureNetworkService: networkingService)
+        
+        configuration.giniErrorLogger = GiniErrorLogger(documentService: screenCoordinator.documentService)
+        return screenCoordinator.start(withDocuments: importedDocuments)
+    }
+    
     public class func removeStoredCredentials(for client: Client) throws {
         let lib = GiniBankAPI.Builder(client: client).build()
         

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Networking/GiniCaptureNetworkService.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Networking/GiniCaptureNetworkService.swift
@@ -1,5 +1,5 @@
 //
-//  File.swift
+//  GiniCaptureNetworkService.swift
 //  
 //
 //  Created by Alpár Szotyori on 12.01.22.
@@ -9,7 +9,7 @@ import Foundation
 import GiniBankAPILibrary
 
 public protocol GiniCaptureNetworkService {
-    func delete(document: GiniCaptureDocument)
+    func delete(document: Document)
     func cleanup()
     func analyse(partialDocuments: [PartialDocumentInfo], metadata: Document.Metadata?, completion: @escaping AnalysisCompletion)
     func upload(document: GiniCaptureDocument,
@@ -25,8 +25,20 @@ class DefaultCaptureNetworkService: GiniCaptureNetworkService {
         self.documentService = lib.documentService()
     }
     
-    func delete(document: GiniCaptureDocument) {
-        
+    func delete(document: Document) {
+        documentService.delete(document) { result in
+            switch result {
+            case .success:
+                Log(message: "Deleted \(document.sourceClassification.rawValue) document with id: \(document.id)",
+                    event: "🗑")
+            case .failure(let error):
+                let message = "Error deleting \(document.sourceClassification.rawValue) document with" +
+                    " id: \(document.id)"
+                Log(message: message,event: .error)
+                let errorLog = ErrorLog(description: message, error: error)
+                GiniConfiguration.shared.errorLogger.handleErrorLog(error: errorLog)
+            }
+        }
     }
     
     func cleanup() {

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Networking/GiniCaptureNetworkService.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Networking/GiniCaptureNetworkService.swift
@@ -71,27 +71,25 @@ class DefaultCaptureNetworkService: GiniCaptureNetworkService {
     
     func upload(document: GiniCaptureDocument, metadata: Document.Metadata?, completion: @escaping UploadDocumentCompletion) {
         Log(message: "Creating document...", event: "📝")
-        
+
         let fileName = "Partial-\(NSDate().timeIntervalSince1970)"
-        
+
         documentService.createDocument(fileName: fileName,
                                        docType: nil,
                                        type: .partial(document.data),
                                        metadata: metadata) { result in
-                                        switch result {
-                                        case .success(let createdDocument):
-                                            Log(message: "Created document with id: \(createdDocument.id) " +
-                                                "for vision document \(document.id)", event: "📄")
-                                            completion(.success(createdDocument))
-                                        case .failure(let error):
-                                            let message = "Document creation failed"
-                                            Log(message: message, event: .error)
-                                            let errorLog = ErrorLog(description: message, error: error)
-                                            GiniConfiguration.shared.errorLogger.handleErrorLog(error: errorLog)
-                                            completion(.failure(error))
-                                        }
+            switch result {
+            case let .success(createdDocument):
+                Log(message: "Created document with id: \(createdDocument.id) " +
+                    "for vision document \(document.id)", event: "📄")
+                completion(.success(createdDocument))
+            case let .failure(error):
+                let message = "Document creation failed"
+                Log(message: message, event: .error)
+                let errorLog = ErrorLog(description: message, error: error)
+                GiniConfiguration.shared.errorLogger.handleErrorLog(error: errorLog)
+                completion(.failure(error))
+            }
         }
     }
-    
-    
 }

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Networking/GiniCaptureNetworkService.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Networking/GiniCaptureNetworkService.swift
@@ -1,0 +1,65 @@
+//
+//  File.swift
+//  
+//
+//  Created by Alpár Szotyori on 12.01.22.
+//
+
+import Foundation
+import GiniBankAPILibrary
+
+public protocol GiniCaptureNetworkService {
+    func delete(document: GiniCaptureDocument)
+    func cleanup()
+    func analyse(completion: @escaping AnalysisCompletion)
+    func upload(document: GiniCaptureDocument,
+                metadata: Document.Metadata?,
+                completion: @escaping UploadDocumentCompletion)
+}
+
+class DefaultCaptureNetworkService: GiniCaptureNetworkService {
+    
+    var documentService: DefaultDocumentService
+    
+    public init(lib: GiniBankAPI) {
+        self.documentService = lib.documentService()
+    }
+    
+    func delete(document: GiniCaptureDocument) {
+        
+    }
+    
+    func cleanup() {
+        
+    }
+    
+    func analyse(completion: @escaping AnalysisCompletion) {
+        
+    }
+    
+    func upload(document: GiniCaptureDocument, metadata: Document.Metadata?, completion: @escaping UploadDocumentCompletion) {
+        Log(message: "Creating document...", event: "📝")
+        
+        let fileName = "Partial-\(NSDate().timeIntervalSince1970)"
+        
+        documentService.createDocument(fileName: fileName,
+                                       docType: nil,
+                                       type: .partial(document.data),
+                                       metadata: metadata) { result in
+                                        switch result {
+                                        case .success(let createdDocument):
+                                            Log(message: "Created document with id: \(createdDocument.id) " +
+                                                "for vision document \(document.id)", event: "📄")
+                                            completion(.success(createdDocument))
+                                        case .failure(let error):
+                                            let message = "Document creation failed"
+                                            Log(message: message, event: .error)
+                                            let errorLog = ErrorLog(description: message, error: error)
+                                            GiniConfiguration.shared.errorLogger.handleErrorLog(error: errorLog)
+                                            completion(.failure(error))
+                                        }
+        }
+    }
+    
+    
+}

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Networking/GiniCaptureNetworkService.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Networking/GiniCaptureNetworkService.swift
@@ -8,7 +8,7 @@
 import Foundation
 import GiniBankAPILibrary
 
-public protocol GiniCaptureNetworkService {
+public protocol GiniCaptureNetworkService: AnyObject  {
     func delete(document: Document,
                 completion: @escaping (Result<String, GiniError>) -> Void)
     func cleanup()

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Networking/GiniNetworkingScreenAPICoordinator.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Networking/GiniNetworkingScreenAPICoordinator.swift
@@ -59,6 +59,22 @@ import GiniBankAPILibrary
         self.resultsDelegate = resultsDelegate
         self.trackingDelegate = trackingDelegate
     }
+     
+     public init(resultsDelegate: GiniCaptureResultsDelegate,
+          giniConfiguration: GiniConfiguration,
+          documentMetadata: Document.Metadata?,
+          trackingDelegate: GiniCaptureTrackingDelegate?,
+          captureNetworkService: GiniCaptureNetworkService) {
+
+         self.documentService = DocumentService(giniCaptureNetworkService: captureNetworkService, metadata: documentMetadata)
+         
+         super.init(withDelegate: nil,
+                    giniConfiguration: giniConfiguration)
+         
+         self.visionDelegate = self
+         self.resultsDelegate = resultsDelegate
+         self.trackingDelegate = trackingDelegate
+     }
     
     convenience init(client: Client,
                      resultsDelegate: GiniCaptureResultsDelegate,

--- a/CaptureSDK/GiniCaptureSDKExample/Example Swift/AppDelegate.swift
+++ b/CaptureSDK/GiniCaptureSDKExample/Example Swift/AppDelegate.swift
@@ -10,9 +10,8 @@ import UIKit
 
 @UIApplicationMain
 final class AppDelegate: UIResponder, UIApplicationDelegate {
-    
     var coordinator: AppCoordinator!
-    
+
     func application(_ application: UIApplication,
                      didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         let window = UIWindow(frame: UIScreen.main.bounds)
@@ -21,12 +20,11 @@ final class AppDelegate: UIResponder, UIApplicationDelegate {
 
         return true
     }
-    
+
     func application(_ app: UIApplication,
                      open url: URL,
                      options: [UIApplication.OpenURLOptionsKey: Any] = [:]) -> Bool {
         coordinator.processExternalDocument(withUrl: url, sourceApplication: options[.sourceApplication] as? String)
         return true
     }
-    
 }

--- a/CaptureSDK/GiniCaptureSDKExample/Example Swift/CustomMenuItemViewController.swift
+++ b/CaptureSDK/GiniCaptureSDKExample/Example Swift/CustomMenuItemViewController.swift
@@ -6,12 +6,11 @@
 //  Copyright © 2021 Gini GmbH. All rights reserved.
 //
 
-import UIKit
 import GiniCaptureSDK
+import UIKit
 final class CustomMenuItemViewController: UIViewController {
-    
     override func viewDidLoad() {
         super.viewDidLoad()
-        self.view.backgroundColor = Colors.Gini.blue
+        view.backgroundColor = Colors.Gini.blue
     }
 }

--- a/CaptureSDK/GiniCaptureSDKExample/Example Swift/ResultTableViewController.swift
+++ b/CaptureSDK/GiniCaptureSDKExample/Example Swift/ResultTableViewController.swift
@@ -6,15 +6,14 @@
 //  Copyright © 2016 Gini. All rights reserved.
 //
 
-import UIKit
 import GiniBankAPILibrary
+import UIKit
 
 /**
  Presents a dictionary of results from the analysis process in a table view.
  Values from the dictionary will be used as the cells titles and keys as the cells subtitles.
  */
 final class ResultTableViewController: UITableViewController {
-    
     /**
      The result collection from the analysis process.
      */
@@ -29,11 +28,11 @@ extension ResultTableViewController {
     override func numberOfSections(in tableView: UITableView) -> Int {
         return 1
     }
-    
+
     override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         return result.count
     }
-    
+
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = tableView.dequeueReusableCell(withIdentifier: "resultCell", for: indexPath)
         cell.textLabel?.text = result[indexPath.row].value

--- a/CaptureSDK/GiniCaptureSDKExample/Example Swift/ScreenAPICoordinator.swift
+++ b/CaptureSDK/GiniCaptureSDKExample/Example Swift/ScreenAPICoordinator.swift
@@ -137,6 +137,9 @@ extension ScreenAPICoordinator: GiniCaptureResultsDelegate {
     func giniCaptureAnalysisDidFinishWith(result: AnalysisResult, sendFeedbackBlock: @escaping ([String: Extraction]) -> Void) {
         showResultsScreen(results: result.extractions.map { $0.value })
         self.sendFeedbackBlock = sendFeedbackBlock
+        DispatchQueue.main.asyncAfter(deadline: .now() + 2.5) {
+            sendFeedbackBlock(result.extractions)
+        }
     }
 
     func giniCaptureDidCancelAnalysis() {

--- a/CaptureSDK/GiniCaptureSDKExample/Example Swift/ScreenAPICoordinator.swift
+++ b/CaptureSDK/GiniCaptureSDKExample/Example Swift/ScreenAPICoordinator.swift
@@ -51,8 +51,7 @@ final class ScreenAPICoordinator: NSObject, Coordinator {
                                                         api: .default,
                                                         userApi: .default,
                                                         trackingDelegate: self)
-// MARK: - Screen API with custom networking
-        
+// MARK: - Screen API with custom networking        
 //        let viewController = GiniCapture.viewController(importedDocuments: visionDocuments,
 //                                                        configuration: visionConfiguration,
 //                                                        resultsDelegate: self,

--- a/CaptureSDK/GiniCaptureSDKExample/Example Swift/ScreenAPICoordinator.swift
+++ b/CaptureSDK/GiniCaptureSDKExample/Example Swift/ScreenAPICoordinator.swift
@@ -15,24 +15,6 @@ protocol ScreenAPICoordinatorDelegate: AnyObject {
     func screenAPI(coordinator: ScreenAPICoordinator, didFinish: ())
 }
 
-class TrackingDelegate: GiniCaptureTrackingDelegate {
-    func onAnalysisScreenEvent(event: Event<AnalysisScreenEventType>) {
-        print("✏️ Analysis: \(event.type.rawValue), info: \(event.info ?? [:])")
-    }
-
-    func onOnboardingScreenEvent(event: Event<OnboardingScreenEventType>) {
-        print("✏️ Onboarding: \(event.type.rawValue)")
-    }
-
-    func onCameraScreenEvent(event: Event<CameraScreenEventType>) {
-        print("✏️ Camera: \(event.type.rawValue)")
-    }
-
-    func onReviewScreenEvent(event: Event<ReviewScreenEventType>) {
-        print("✏️ Review: \(event.type.rawValue)")
-    }
-}
-
 final class ScreenAPICoordinator: NSObject, Coordinator {
     weak var delegate: ScreenAPICoordinatorDelegate?
     var childCoordinators: [Coordinator] = []
@@ -41,8 +23,6 @@ final class ScreenAPICoordinator: NSObject, Coordinator {
     }
 
     var screenAPIViewController: UINavigationController!
-
-    private let trackingDelegate = TrackingDelegate()
 
     let client: Client
     let documentMetadata: Document.Metadata?
@@ -70,7 +50,15 @@ final class ScreenAPICoordinator: NSObject, Coordinator {
                                                         documentMetadata: documentMetadata,
                                                         api: .default,
                                                         userApi: .default,
-                                                        trackingDelegate: trackingDelegate)
+                                                        trackingDelegate: self)
+// MARK: - Screen API with custom networking
+        
+//        let viewController = GiniCapture.viewController(importedDocuments: visionDocuments,
+//                                                        configuration: visionConfiguration,
+//                                                        resultsDelegate: self,
+//                                                        documentMetadata: documentMetadata,
+//                                                        trackingDelegate: trackingDelegate,
+//                                                        networkingService: self)
         screenAPIViewController = RootNavigationController(rootViewController: viewController)
         screenAPIViewController.navigationBar.barTintColor = visionConfiguration.navigationBarTintColor
         screenAPIViewController.navigationBar.tintColor = visionConfiguration.navigationBarTitleColor
@@ -134,7 +122,8 @@ extension ScreenAPICoordinator: NoResultsScreenDelegate {
 // MARK: - GiniCaptureResultsDelegate
 
 extension ScreenAPICoordinator: GiniCaptureResultsDelegate {
-    func giniCaptureAnalysisDidFinishWith(result: AnalysisResult, sendFeedbackBlock: @escaping ([String: Extraction]) -> Void) {
+    func giniCaptureAnalysisDidFinishWith(result: AnalysisResult,
+                                          sendFeedbackBlock: @escaping ([String: Extraction]) -> Void) {
         showResultsScreen(results: result.extractions.map { $0.value })
         self.sendFeedbackBlock = sendFeedbackBlock
         DispatchQueue.main.asyncAfter(deadline: .now() + 2.5) {
@@ -154,5 +143,61 @@ extension ScreenAPICoordinator: GiniCaptureResultsDelegate {
             screenAPIViewController.setNavigationBarHidden(false, animated: false)
             screenAPIViewController.pushViewController(customNoResultsScreen, animated: true)
         }
+    }
+}
+
+// MARK: - GiniCaptureNetworkService
+
+extension ScreenAPICoordinator: GiniCaptureNetworkService {
+    func delete(document: Document, completion: @escaping (Result<String, GiniError>) -> Void) {
+        print("custom networking - delete called")
+    }
+
+    func cleanup() {
+        print("custom networking - cleanup called")
+    }
+
+    func analyse(partialDocuments: [PartialDocumentInfo],
+                 metadata: Document.Metadata?,
+                 cancellationToken: CancellationToken,
+                 completion: @escaping (Result<(document: Document,
+                                                extractionResult: ExtractionResult), GiniError>) -> Void) {
+        print("custom networking - analyse called")
+    }
+
+    func upload(document: GiniCaptureDocument,
+                metadata: Document.Metadata?,
+                completion: @escaping UploadDocumentCompletion) {
+        print("custom networking - upload called")
+    }
+
+    func sendFeedback(document: Document,
+                      updatedExtractions: [Extraction],
+                      completion: @escaping (Result<Void, GiniError>) -> Void) {
+        print("custom networking - sendFeedback called")
+    }
+
+    func log(errorEvent: ErrorEvent, completion: @escaping (Result<Void, GiniError>) -> Void) {
+        print("custom networking - log error event called")
+    }
+}
+
+// MARK: - GiniCaptureTrackingDelegate
+
+extension ScreenAPICoordinator: GiniCaptureTrackingDelegate {
+    func onAnalysisScreenEvent(event: Event<AnalysisScreenEventType>) {
+        print("✏️ Analysis: \(event.type.rawValue), info: \(event.info ?? [:])")
+    }
+
+    func onOnboardingScreenEvent(event: Event<OnboardingScreenEventType>) {
+        print("✏️ Onboarding: \(event.type.rawValue)")
+    }
+
+    func onCameraScreenEvent(event: Event<CameraScreenEventType>) {
+        print("✏️ Camera: \(event.type.rawValue)")
+    }
+
+    func onReviewScreenEvent(event: Event<ReviewScreenEventType>) {
+        print("✏️ Review: \(event.type.rawValue)")
     }
 }

--- a/CaptureSDK/GiniCaptureSDKExample/Example Swift/UIViewController.swift
+++ b/CaptureSDK/GiniCaptureSDKExample/Example Swift/UIViewController.swift
@@ -10,6 +10,7 @@ import GiniCaptureSDK
 import UIKit
 
 extension UIViewController {
+    // swiftlint:disable:next function_body_length
     func showErrorDialog(for error: Error, positiveAction: (() -> Void)?) {
         let message: String
         var cancelActionTitle: String = NSLocalizedString("ginicapture.camera.errorPopup.cancelButton",
@@ -18,7 +19,6 @@ extension UIViewController {
         var confirmActionTitle: String? = NSLocalizedString("ginicapture.camera.errorPopup.pickanotherfileButton",
                                                             bundle: Bundle(for: GiniCapture.self),
                                                             comment: "pick another file button title")
-
         switch error {
         case let validationError as DocumentValidationError:
             message = validationError.message
@@ -62,7 +62,6 @@ extension UIViewController {
                                  cancelActionTitle: cancelActionTitle,
                                  confirmActionTitle: confirmActionTitle,
                                  confirmAction: positiveAction)
-
         present(dialog, animated: true, completion: nil)
     }
 

--- a/CaptureSDK/GiniCaptureSDKExample/Tests/AlbumsPickerViewControllerTests.swift
+++ b/CaptureSDK/GiniCaptureSDKExample/Tests/AlbumsPickerViewControllerTests.swift
@@ -39,7 +39,8 @@ class AlbumsPickerViewControllerTests: XCTestCase {
     }
 
     func testTableCellHeight() {
-        XCTAssertEqual(albumsViewController.tableView(albumsViewController.albumsTableView, heightForRowAt: IndexPath(row: 1, section: 0)),
+        XCTAssertEqual(albumsViewController.tableView(albumsViewController.albumsTableView,
+                                                      heightForRowAt: IndexPath(row: 1, section: 0)),
                        AlbumsPickerTableViewCell.height,
                        "table view cell heght should match AlbumsPickerTableViewCell height")
     }
@@ -57,7 +58,8 @@ class AlbumsPickerViewControllerTests: XCTestCase {
 
     func testFirstCellContent() {
         let firstIndex = IndexPath(row: 0, section: 0)
-        let firstCell = albumsViewController.tableView(albumsViewController.albumsTableView, cellForRowAt: firstIndex) as? AlbumsPickerTableViewCell
+        let firstCell = albumsViewController.tableView(albumsViewController.albumsTableView,
+                                                       cellForRowAt: firstIndex) as? AlbumsPickerTableViewCell
 
         XCTAssertEqual(firstCell?.albumTitleLabel.text, galleryManager.albums[firstIndex.row].title,
                        "album title label text should match the album title for the first cell")
@@ -67,7 +69,8 @@ class AlbumsPickerViewControllerTests: XCTestCase {
 
     func testSecondCellContent() {
         let secondIndex = IndexPath(row: 1, section: 0)
-        let secondCell = albumsViewController.tableView(albumsViewController.albumsTableView, cellForRowAt: secondIndex) as? AlbumsPickerTableViewCell
+        let secondCell = albumsViewController.tableView(albumsViewController.albumsTableView,
+                                                        cellForRowAt: secondIndex) as? AlbumsPickerTableViewCell
 
         XCTAssertEqual(secondCell?.albumTitleLabel.text, galleryManager.albums[secondIndex.row].title,
                        "album title label text should match the album title for the second cell")

--- a/CaptureSDK/GiniCaptureSDKExample/UITests/GINIAnalysisUITests.swift
+++ b/CaptureSDK/GiniCaptureSDKExample/UITests/GINIAnalysisUITests.swift
@@ -1,21 +1,21 @@
 import XCTest
 
 class GINIAnalysisUITests: XCTestCase {
-    
     let app = XCUIApplication()
-    
+
     override func setUp() {
         app.launch()
     }
-    
+
     func testAnalysisIsPresent() {
         app.buttons["Screen API"].tap()
         app.buttons["Auslösen"].tap()
         let reviewScreen = app.navigationBars["1 von 1"]
         _ = reviewScreen.waitForExistence(timeout: 5)
         app.navigationBars["1 von 1"].buttons["Weiter"].tap()
-        
+
         let analysisScreenLeftButton = app.navigationBars.buttons["Abbrechen"]
-        XCTAssert(analysisScreenLeftButton.exists, "navigation bar with title 'Etwas Geduld, analysiere Foto' should be displayed")
+        XCTAssert(analysisScreenLeftButton.exists,
+                  "navigation bar with title 'Etwas Geduld, analysiere Foto' should be displayed")
     }
 }

--- a/CaptureSDK/GiniCaptureSDKExample/UITests/GINICameraUITests.swift
+++ b/CaptureSDK/GiniCaptureSDKExample/UITests/GINICameraUITests.swift
@@ -11,7 +11,9 @@ class GINICameraUITests: XCTestCase {
         app.buttons["Screen API"].tap()
 
         let captureButton = app.buttons["Auslösen"]
-        XCTAssert(captureButton.exists, "capture button should exist indicating that the library was started correctly and is presenting the camera screen on start")
+        XCTAssert(captureButton.exists,
+                  "capture button should exist indicating that" +
+                  " the library was started correctly and is presenting the camera screen on start")
     }
 
     func testCapture() {

--- a/CaptureSDK/GiniCaptureSDKExample/UITests/GINIReviewUITests.swift
+++ b/CaptureSDK/GiniCaptureSDKExample/UITests/GINIReviewUITests.swift
@@ -14,7 +14,9 @@ class GINIReviewUITests: XCTestCase {
         XCTAssert(reviewScreen.waitForExistence(timeout: 5))
 
         let rotationButton = app.buttons["Dokument drehen"]
-        XCTAssert(rotationButton.exists, "rotation button should exist indicating that the library was started correctly and is presenting the review screen after taking an image")
+        XCTAssert(rotationButton.exists,
+                  "rotation button should exist indicating that the library was started correctly"
+                  + "and is presenting the review screen after taking an image")
     }
 
     func testDoubleTapToZoom() {


### PR DESCRIPTION
 Capture SDK:
   - Add Screen API support with custom networking:
    1.   Add default implementation`GiniCaptureNetworkService`;
    2.   Add initializer in GiniCapture networking with non-optional `GiniCaptureNetworkService` parameter.
    
 Capture SDK Example:
  - Fix code style warnings and refactor protocol implementation into the extensions.
