### PR TITLE
fix(GiniBankSDK): Fix Return Assistant storyboard and line item xib crashes

### DIFF
--- a/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/ReturnAssistant/DigitalInvoiceViewController.swift
+++ b/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/ReturnAssistant/DigitalInvoiceViewController.swift
@@ -199,7 +199,7 @@ public class DigitalInvoiceViewController: UIViewController {
     
     fileprivate func showDigitalInvoiceOnboarding() {
         if onboardingWillBeShown && !didShowOnboardInCurrentSession {
-            let bundle = Bundle(for: type(of: self))
+            let bundle = giniBankBundle()
             let storyboard = UIStoryboard(name: "DigitalInvoiceOnboarding", bundle: bundle)
             let digitalInvoiceOnboardingViewController = storyboard.instantiateViewController(withIdentifier: "digitalInvoiceOnboardingViewController") as! DigitalInvoiceOnboardingViewController
             digitalInvoiceOnboardingViewController.delegate = self

--- a/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Resources/DigitalInvoiceOnboarding.storyboard
+++ b/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Resources/DigitalInvoiceOnboarding.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -12,7 +12,7 @@
         <!--Digital Invoice Onboarding View Controller-->
         <scene sceneID="jcM-d7-3Dk">
             <objects>
-                <viewController storyboardIdentifier="digitalInvoiceOnboardingViewController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="bsW-Wu-97S" customClass="DigitalInvoiceOnboardingViewController" customModule="GiniPayBank" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="digitalInvoiceOnboardingViewController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="bsW-Wu-97S" customClass="DigitalInvoiceOnboardingViewController" customModule="GiniBankSDK" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="sZ4-c8-lTq">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>

--- a/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Resources/DigitalLineItemTableViewCell.xib
+++ b/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Resources/DigitalLineItemTableViewCell.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -11,15 +11,17 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <view contentMode="scaleToFill" id="iN0-l3-epB" customClass="DigitalLineItemTableViewCell" customModule="GiniPayBank" customModuleProvider="target">
+        <view contentMode="scaleToFill" id="iN0-l3-epB" customClass="DigitalLineItemTableViewCell" customModule="GiniBankSDK">
             <rect key="frame" x="0.0" y="0.0" width="414" height="149"/>
-            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <autoresizingMask key="autoresizingMask"/>
             <subviews>
-                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="W0B-Jq-NI4" userLabel="Shadow cast view">
+                <view contentMode="scaleToFill" id="W0B-Jq-NI4" userLabel="Shadow cast view">
                     <rect key="frame" x="0.0" y="0.0" width="414" height="149"/>
+                    <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                     <subviews>
-                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="utZ-Ul-3Ih">
+                        <view contentMode="scaleToFill" id="utZ-Ul-3Ih">
                             <rect key="frame" x="0.0" y="0.0" width="414" height="149"/>
+                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                             <subviews>
                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Article 1/2" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Mp2-C5-5Lg">
                                     <rect key="frame" x="10" y="15" width="76" height="21"/>
@@ -99,7 +101,7 @@
                             </constraints>
                         </view>
                         <button opaque="NO" contentMode="scaleToFill" semanticContentAttribute="forceRightToLeft" horizontalHuggingPriority="1000" horizontalCompressionResistancePriority="1000" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ogc-mD-pz6">
-                            <rect key="frame" x="323" y="15" width="81" height="34"/>
+                            <rect key="frame" x="328.5" y="15" width="75.5" height="34"/>
                             <fontDescription key="fontDescription" type="system" weight="medium" pointSize="16"/>
                             <color key="tintColor" systemColor="labelColor"/>
                             <inset key="contentEdgeInsets" minX="24" minY="0.0" maxX="10" maxY="14"/>
@@ -143,11 +145,11 @@
                 <outlet property="quantityLabel" destination="hFr-mI-xcl" id="Ql1-j9-IOn"/>
                 <outlet property="shadowCastView" destination="W0B-Jq-NI4" id="iia-id-Obi"/>
             </connections>
-            <point key="canvasLocation" x="137.68115942028987" y="-27.455357142857142"/>
+            <point key="canvasLocation" x="137.68115942028987" y="-27.790178571428569"/>
         </view>
     </objects>
     <resources>
-        <image name="editIcon" width="18" height="17"/>
+        <image name="editIcon" width="12.5" height="12.5"/>
         <image name="garbage-bin-icon" width="20" height="22"/>
         <systemColor name="labelColor">
             <color white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>


### PR DESCRIPTION
Since iOS 15 and Xcode 13 a crash started happening in UITableViewCells related to the autoresizing
masks. By removing `translatesAutoresizingMaskIntoConstraints="NO"` from the line item view cell
xib's (`DigitalLineItemTableViewCell.xib`) root view and shadow view the crash was fixed.
Solution source: https://stackoverflow.com/a/69439370/276129

Due to switching to Swift Packages some referenced classes in the storyboard and xib had to be
updated. Also getting the bundle instance had to be updated.