### PR TITLE
Pia 2267

### DIFF
--- a/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/GiniBank.swift
+++ b/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/GiniBank.swift
@@ -68,7 +68,7 @@ import GiniCaptureSDK
         do {
             amountString = try String.parseAmountStringToBackendFormat(string: paymentInfo.amount)
         } catch {
-            completion(.failure(.amountParsingError))
+            completion(.failure(.amountParsingError(amountString: paymentInfo.amount)))
         }
         paymentService.resolvePaymentRequest(id: paymentRequesId, recipient: paymentInfo.recipient, iban: paymentInfo.iban, amount: amountString, purpose: paymentInfo.purpose, completion: { result in
             DispatchQueue.main.async {

--- a/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/Payment/GiniBankError.swift
+++ b/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/Payment/GiniBankError.swift
@@ -16,4 +16,6 @@ public enum GiniBankError: Error {
     case noRequestId
      /// Error thrown when api return failure.
     case apiError(GiniError)
+    /// Error thrown amount value cannot be parsed to the api format.
+    case amountParsingError
 }

--- a/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/Payment/GiniBankError.swift
+++ b/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/Payment/GiniBankError.swift
@@ -17,5 +17,5 @@ public enum GiniBankError: Error {
      /// Error thrown when api return failure.
     case apiError(GiniError)
     /// Error thrown amount value cannot be parsed to the api format.
-    case amountParsingError
+    case amountParsingError(amountString: String)
 }

--- a/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/String+Utils.swift
+++ b/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/String+Utils.swift
@@ -16,4 +16,12 @@ extension String {
             return String(format: resource.localizedGiniBankFormat, arguments: args)
         }
     }
+    
+    public static func parseAmountStringToBackendFormat(string: String) throws -> String {
+        if let doubleStringValue =  Double(string), doubleStringValue > 0 {
+            return String(doubleStringValue) + ":EUR"
+        } else {
+            throw GiniBankError.amountParsingError
+        }
+    }
 }

--- a/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/String+Utils.swift
+++ b/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/String+Utils.swift
@@ -18,10 +18,12 @@ extension String {
     }
     
     public static func parseAmountStringToBackendFormat(string: String) throws -> String {
-        if let doubleStringValue =  Double(string), doubleStringValue > 0 {
-            return String(doubleStringValue) + ":EUR"
+        if let doubleStringValue =  Double(string) {
+            // It's needed because String representation of Double adds `0`
+            let truncatedZeroString = String(format: "%g", doubleStringValue)
+            return String(truncatedZeroString) + ":EUR"
         } else {
-            throw GiniBankError.amountParsingError
+            throw GiniBankError.amountParsingError(amountString: string)
         }
     }
 }

--- a/BankSDK/GiniBankSDK/Tests/GiniBankSDKTests/GiniBankSDKTests.swift
+++ b/BankSDK/GiniBankSDK/Tests/GiniBankSDKTests/GiniBankSDKTests.swift
@@ -10,6 +10,44 @@ import XCTest
 @testable import GiniBankSDK
 
 final class GiniBankSDKTests: XCTestCase {
-    func testExample() throws {
+    
+    func testParseAmountStringToBackendFormat(){
+        let amountToPay = "28"
+        let parsedAmount = try! String.parseAmountStringToBackendFormat(string: "28.00")
+        XCTAssertEqual(parsedAmount, amountToPay + ":EUR")
+    }
+    
+    func testParseAmountStringToBackendFormat1(){
+        let amountToPay = "28"
+        let parsedAmount = try! String.parseAmountStringToBackendFormat(string: amountToPay)
+        XCTAssertEqual(parsedAmount, amountToPay + ":EUR")
+    }
+    
+    func testParseAmountStringToBackendFormat2(){
+        let amountToPay = "28.12"
+        let parsedAmount = try! String.parseAmountStringToBackendFormat(string: amountToPay)
+        XCTAssertEqual(parsedAmount, amountToPay + ":EUR")
+    }
+    
+    func testParseAmountStringToBackendFormat3(){
+        let amountToPay = "28.1"
+        let parsedAmount = try! String.parseAmountStringToBackendFormat(string: amountToPay)
+        XCTAssertEqual(parsedAmount, amountToPay + ":EUR")
+    }
+    
+    func testParseAmountStringToBackendFormat4(){
+        let amountToPay = "28.10"
+        let parsedAmount = try! String.parseAmountStringToBackendFormat(string: amountToPay)
+        XCTAssertEqual(parsedAmount, "28.1:EUR")
+    }
+    
+    func testParseAmountStringToBackendFormat5(){
+        let amountToPay = "28.10:EUR"
+        XCTAssertNotEqual(try? String.parseAmountStringToBackendFormat(string: amountToPay), "28.1:EUR")
+    }
+    
+    func testParseAmountStringToBackendFormat6(){
+        let amountToPay = "28,10"
+        XCTAssertNotEqual(try? String.parseAmountStringToBackendFormat(string: amountToPay), "28.1:EUR")
     }
 }

--- a/BankSDK/GiniBankSDKExample/GiniBankSDKExample.xcodeproj/project.pbxproj
+++ b/BankSDK/GiniBankSDKExample/GiniBankSDKExample.xcodeproj/project.pbxproj
@@ -57,6 +57,7 @@
 		F4B78A6025E6AB4B00CBE2E4 /* testPDF.pdf in Resources */ = {isa = PBXBuildFile; fileRef = F407A42425E580F000BC5F36 /* testPDF.pdf */; };
 		F4BB7CF226984E5D003FD77E /* CustomMenuItemViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4BB7CF126984E5D003FD77E /* CustomMenuItemViewController.swift */; };
 		F4DF824F25EFA8ED00A8D755 /* ScreenAPICoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4DF824E25EFA8ED00A8D755 /* ScreenAPICoordinator.swift */; };
+		F4E0218827BD349A0042D000 /* Amount.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4E0218727BD349A0042D000 /* Amount.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -128,6 +129,7 @@
 		F4AD00F725DFDF4400C34E15 /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Images.xcassets; sourceTree = "<group>"; };
 		F4BB7CF126984E5D003FD77E /* CustomMenuItemViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomMenuItemViewController.swift; sourceTree = "<group>"; };
 		F4DF824E25EFA8ED00A8D755 /* ScreenAPICoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenAPICoordinator.swift; sourceTree = "<group>"; };
+		F4E0218727BD349A0042D000 /* Amount.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Amount.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -217,6 +219,7 @@
 			isa = PBXGroup;
 			children = (
 				F4807C36263C20BA00F30FF3 /* AppDelegate.swift */,
+				F4E0218727BD349A0042D000 /* Amount.swift */,
 				F4807F332640177500F30FF3 /* PaymentViewModel.swift */,
 				F4807C3A263C20BA00F30FF3 /* PaymentViewController.swift */,
 				F4807FC8264183C000F30FF3 /* Credentials.plist */,
@@ -486,6 +489,7 @@
 				F414A56325EBB87F00D04A80 /* DocumentAnalysisHelper.swift in Sources */,
 				F4BB7CF226984E5D003FD77E /* CustomMenuItemViewController.swift in Sources */,
 				F4AD00FE25DFDF4500C34E15 /* ComponentAPIOnboardingViewController.swift in Sources */,
+				F4E0218827BD349A0042D000 /* Amount.swift in Sources */,
 				F4AD00D625DFDC8100C34E15 /* SettingsViewController.swift in Sources */,
 				F44AD25E25F2443200668B0C /* GiniButton.swift in Sources */,
 				F4AD00FF25DFDF4500C34E15 /* UIViewController.swift in Sources */,

--- a/BankSDK/GiniBankSDKExample/GiniBankSDKExampleBank/Amount.swift
+++ b/BankSDK/GiniBankSDKExample/GiniBankSDKExampleBank/Amount.swift
@@ -1,22 +1,24 @@
 //
 //  Amount.swift
-//  Bank
+//  GiniBankSDKExample
 //
-//  Created by Nadya Karaban on 04.05.21.
+//  Created by Nadya Karaban on 16.02.22.
 //
 
 import Foundation
-struct Amount {
+import GinBankSDKExampleBank
+
+public struct Amount {
         
-    var value: Decimal
-    let currencyCode: String
+    public let value: Decimal
+    public let currencyCode: String
     
-    init(value: Decimal, currencyCode: String) {
+    public init(value: Decimal, currencyCode: String) {
         self.value = value
         self.currencyCode = currencyCode
     }
     
-    init?(extractionString: String) {
+public init?(extractionString: String) {
        
         let components = extractionString.components(separatedBy: ":")
         
@@ -32,7 +34,7 @@ struct Amount {
     }
     
     var extractionString: String {
-        return "\(value)"
+        return "\(value):\(currencyCode.uppercased())"
     }
     
     var currencySymbol: String? {
@@ -46,7 +48,7 @@ struct Amount {
             sign = "- "
         }
         
-        let result = (stringWithoutSymbol(from: abs(value)) ?? "") + sign + (currencySymbol ?? "")
+        let result = sign + (currencySymbol ?? "") + (stringWithoutSymbol(from: abs(value)) ?? "")
         
         if result.isEmpty { return nil }
         
@@ -69,21 +71,31 @@ extension Amount: Equatable {}
 
 extension Amount {
     
-    static func *(price: Amount, int: Int) -> Amount {
+    static func *(amount: Amount, int: Int) -> Amount {
         
-        return Amount(value: price.value * Decimal(int),
-                     currencyCode: price.currencyCode)
+        return Amount(value: amount.value * Decimal(int),
+                     currencyCode: amount.currencyCode)
     }
     
-    struct PriceCurrencyMismatchError: Error {}
+    struct AmountCurrencyMismatchError: Error {}
     
     static func +(lhs: Amount, rhs: Amount) throws -> Amount {
         
         if lhs.currencyCode != rhs.currencyCode {
-            throw PriceCurrencyMismatchError()
+            throw AmountCurrencyMismatchError()
         }
         
         return Amount(value: lhs.value + rhs.value,
+                     currencyCode: lhs.currencyCode)
+    }
+    
+    static func -(lhs: Amount, rhs: Amount) throws -> Amount {
+        
+        if lhs.currencyCode != rhs.currencyCode {
+            throw AmountCurrencyMismatchError()
+        }
+        
+        return Amount(value: lhs.value - rhs.value,
                      currencyCode: lhs.currencyCode)
     }
     
@@ -91,3 +103,5 @@ extension Amount {
         return lhs.value >= rhs.value ? lhs : rhs
     }
 }
+
+

--- a/BankSDK/GiniBankSDKExample/GiniBankSDKExampleBank/AppDelegate.swift
+++ b/BankSDK/GiniBankSDKExample/GiniBankSDKExampleBank/AppDelegate.swift
@@ -17,7 +17,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     func application(_ application: UIApplication,
                      didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         window = UIWindow(frame: UIScreen.main.bounds)
-
+        try! apiLib.removeStoredCredentials()
         let paymentViewController = PaymentViewController.instantiate(with: apiLib)
 
         let navigationController = UINavigationController(rootViewController: paymentViewController)


### PR DESCRIPTION
feat(GiniBankSDK): Add amountParsingError and check if the amount is convertible to a `Double`.

Currently, we use only `EUR` as a currency.
The amount string in the `PaymentInfo` must be convertible to a `Double`.
For ex. "12.39" is valid, but "12.39 €" or "12,39" are not valid.