### PR TITLE
Pia 2279 expose document

### DIFF
--- a/BankSDK/GiniBankSDK/Documentation/source/Integration.md
+++ b/BankSDK/GiniBankSDK/Documentation/source/Integration.md
@@ -141,7 +141,7 @@ Also if you're using the [Gini Bank API Library](https://github.com/gini/bank-ap
 The Screen API provides a custom `UIViewController` object, which can be presented modally. It handles the complete process from showing the onboarding until providing a UI for the analysis.
 The Screen API, in turn, offers two different ways of implementation:
 
-#### UI with Default Networking (Recommended)
+### UI with Default Networking (Recommended)
 Using this method you don't need to care about handling the analysis process with the [Gini Bank API Library](https://github.com/gini/bank-api-library-ios), you only need to provide your API credentials and a delegate to get the analysis results.
 
 ```swift
@@ -152,6 +152,8 @@ let viewController = GiniBank.viewController(withClient: client,
 present(viewController, animated: true, completion: nil)
 ```
 Optionally if you want to use _Certificate pinning_, provide metadata for the upload process, you can pass both your public key pinning configuration (see [TrustKit repo](https://github.com/datatheorem/TrustKit) for more information), the metadata information and the _API type_ (the [Gini Pay API](https://pay-api.gini.net/documentation/#gini-pay-api-documentation-v1-0) is used by default) as follows:
+
+#### Certificate Pinning
 
 ```swift
 import TrustKit
@@ -184,12 +186,19 @@ let viewController = GiniBank.viewController(withClient: client,
 present(viewController, animated: true, completion:nil)
 ```
 
-
 > ⚠️  **Important**
 > - The document metadata for the upload process is intended to be used for reporting.
 > - Certification pinning requires iOS 12.
 
-#### UI with Custom Networking
+#### Retrieve the Analyzed Document
+
+The `AnalysisResult` returned in `GiniCaptureResultsDelegate.giniCaptureAnalysisDidFinishWith(result:, sendFeedbackBlock:)` 
+will return the analyzed Gini Bank API document in its `document` property.
+
+When extractions were retrieved without using the Gini Bank API, then the `AnalysisResult.document` will be `nil`. For example when the
+extractions came from an EPS QR Code.
+
+### UI with Custom Networking
 
 You can also provide your own networking by implementing the `GiniCaptureNetworkService` and `GiniCaptureResultsDelegate` protocols. Pass your instances to the `UIViewController` initialiser of GiniCapture as shown below:
 

--- a/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/GiniBankNetworkingScreenApiCoordinator.swift
+++ b/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/GiniBankNetworkingScreenApiCoordinator.swift
@@ -144,19 +144,20 @@ extension GiniBankNetworkingScreenApiCoordinator {
 
                     return (name, $0)
                 })
-
-                let result = AnalysisResult(extractions: extractions, lineItems: result.lineItems, images: images)
-
-                let documentService = self.documentService
+                
+                let result = AnalysisResult(extractions: extractions,
+                                            lineItems: result.lineItems,
+                                            images: images,
+                                            document: self.documentService.document)
 
                 self.resultsDelegate?
                     .giniCaptureAnalysisDidFinishWith(result: result) { updatedExtractions in
                         if let lineItems = result.lineItems {
-                            documentService.sendFeedback(with: updatedExtractions.map { $0.value }, and: ["lineItems": lineItems])
+                            self.documentService.sendFeedback(with: updatedExtractions.map { $0.value }, and: ["lineItems": lineItems])
                         } else {
-                            documentService.sendFeedback(with: updatedExtractions.map { $0.value })
+                            self.documentService.sendFeedback(with: updatedExtractions.map { $0.value })
                         }
-                        documentService.resetToInitialState()
+                        self.documentService.resetToInitialState()
                     }
             } else {
                 self.resultsDelegate?

--- a/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/GiniBankNetworkingScreenApiCoordinator.swift
+++ b/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/GiniBankNetworkingScreenApiCoordinator.swift
@@ -145,19 +145,21 @@ extension GiniBankNetworkingScreenApiCoordinator {
                     return (name, $0)
                 })
                 
+                let documentService = self.documentService
+                
                 let result = AnalysisResult(extractions: extractions,
                                             lineItems: result.lineItems,
                                             images: images,
-                                            document: self.documentService.document)
+                                            document: documentService.document)
 
                 self.resultsDelegate?
                     .giniCaptureAnalysisDidFinishWith(result: result) { updatedExtractions in
                         if let lineItems = result.lineItems {
-                            self.documentService.sendFeedback(with: updatedExtractions.map { $0.value }, and: ["lineItems": lineItems])
+                            documentService.sendFeedback(with: updatedExtractions.map { $0.value }, and: ["lineItems": lineItems])
                         } else {
-                            self.documentService.sendFeedback(with: updatedExtractions.map { $0.value })
+                            documentService.sendFeedback(with: updatedExtractions.map { $0.value })
                         }
-                        self.documentService.resetToInitialState()
+                        documentService.resetToInitialState()
                     }
             } else {
                 self.resultsDelegate?

--- a/BankSDK/GiniBankSDKExample/GiniBankSDKExample/Screen API/ScreenAPICoordinator.swift
+++ b/BankSDK/GiniBankSDKExample/GiniBankSDKExample/Screen API/ScreenAPICoordinator.swift
@@ -89,7 +89,13 @@ final class ScreenAPICoordinator: NSObject, Coordinator, UINavigationControllerD
         screenAPIViewController.interactivePopGestureRecognizer?.delegate = nil
     }
     
-    fileprivate func showResultsScreen(results: [Extraction]) {
+    fileprivate func showResultsScreen(results: [Extraction], document: Document?) {
+        if let document = document {
+            print("🧾 Showing results for Gini Bank API document id: \(document.id)")
+        } else {
+            print("❓ Showing results for unknown Gini Bank API document")
+        }
+        
         let customResultsScreen = (UIStoryboard(name: "Main", bundle: nil)
             .instantiateViewController(withIdentifier: "resultScreen") as? ResultTableViewController)!
         customResultsScreen.result = results
@@ -133,7 +139,7 @@ extension ScreenAPICoordinator: GiniCaptureResultsDelegate {
     func giniCaptureAnalysisDidFinishWith(result: AnalysisResult,
                                          sendFeedbackBlock: @escaping ([String: Extraction]) -> Void) {
         
-        showResultsScreen(results: result.extractions.map { $0.value })
+        showResultsScreen(results: result.extractions.map { $0.value}, document: result.document)
         self.sendFeedbackBlock = sendFeedbackBlock
     }
     

--- a/CaptureSDK/GiniCaptureSDK/Documentation/source/Integration.md
+++ b/CaptureSDK/GiniCaptureSDK/Documentation/source/Integration.md
@@ -10,7 +10,7 @@ The Gini Capture SDK provides two integration options. A [Screen API](#screen-ap
 The Screen API provides a custom `UIViewController` object, which can be presented modally. It handles the complete process from showing the onboarding until providing a UI for the analysis.
 The Screen API, in turn, offers two different ways of implementation:
 
-#### UI with Default Networking (Recommended)
+### UI with Default Networking (Recommended)
 Using this method you don't need to care about handling the analysis process with the [Gini Bank API Library](https://github.com/gini/bank-api-library-ios), you only need to provide your API credentials and a delegate to get the analysis results.
 
 ```swift
@@ -20,6 +20,8 @@ let viewController = GiniCapture.viewController(withClient: client,
 
 present(viewController, animated: true, completion:nil)
 ```
+
+#### Certificate Pinning
 
 Optionally if you want to use _Certificate pinning_, provide metadata for the upload process, you can pass both your public key pinning configuration (see [TrustKit repo](https://github.com/datatheorem/TrustKit) for more information), the metadata information and the _API type_ (the [Gini Pay API](https://pay-api.gini.net/documentation/#gini-pay-api-documentation-v1-0) is used by default) as follows:
 
@@ -59,7 +61,15 @@ present(viewController, animated: true, completion:nil)
 > - The document metadata for the upload process is intended to be used for reporting.
 > - The multipage is supported only by the `.default` api.
 
-#### UI with Custom Networking
+#### Retrieve the Analyzed Document
+
+The `AnalysisResult` returned in `GiniCaptureResultsDelegate.giniCaptureAnalysisDidFinishWith(result:, sendFeedbackBlock:)` 
+will return the analyzed Gini Bank API document in its `document` property.
+
+When extractions were retrieved without using the Gini Bank API, then the `AnalysisResult.document` will be `nil`. For example when the
+extractions came from an EPS QR Code.
+
+### UI with Custom Networking
 You can also provide your own networking by implementing the `GiniCaptureNetworkService` and `GiniCaptureResultsDelegate` protocols. Pass your instances to the UIViewController initialiser of GiniCapture as shown below.
 
 ```swift

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Networking/AnalysisResult.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Networking/AnalysisResult.swift
@@ -9,24 +9,37 @@ import UIKit
 import GiniBankAPILibrary
 
 @objcMembers public class AnalysisResult: NSObject {
-    /// Images processed in the analysis
+    /**
+     * Images processed in the analysis.
+     */
     public let images: [UIImage]
-    /*
+    
+    /**
      *  Specific extractions obtained in the analysis.
-     *  Besides the list of extractions that can be found here
-     *  (http://developer.gini.net/gini-api/html/document_extractions.html#available-specific-extractions),
+     *
+     *  Besides the list of extractions that can be found
+     *  [here](http://developer.gini.net/gini-api/html/document_extractions.html#available-specific-extractions),
      *  it can also return the epsPaymentQRCodeUrl extraction, obtained from a EPS QR code.
      */
     public let extractions: [String: Extraction]
 
-    /*
+    /**
      *  Line item compound extractions obtained in the analysis.
      */
     public let lineItems: [[Extraction]]?
     
-    public init(extractions: [String: Extraction], lineItems: [[Extraction]]? = nil, images: [UIImage]) {
+    /**
+     *  The analyzed Gini Bank API document.
+     *
+     *  It returns `nil` when extractions were retrieved without using the Gini Bank API.
+     *  For example when the extractions came from an EPS QR code.
+     */
+    public let document: Document?
+    
+    public init(extractions: [String: Extraction], lineItems: [[Extraction]]? = nil, images: [UIImage], document: Document? = nil) {
         self.images = images
         self.extractions = extractions
         self.lineItems = lineItems
+        self.document = document
     }
 }

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Networking/GiniNetworkingScreenAPICoordinator.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Networking/GiniNetworkingScreenAPICoordinator.swift
@@ -112,7 +112,7 @@ import GiniBankAPILibrary
         }
     }
     
-    public func deliver(result: ExtractionResult, analysisDelegate: AnalysisDelegate) {
+    public func deliver(result: ExtractionResult, and document: Document? = nil, to analysisDelegate: AnalysisDelegate) {
         let hasExtactions = result.extractions.count > 0
         
         DispatchQueue.main.async { [weak self] in
@@ -126,13 +126,13 @@ import GiniBankAPILibrary
                 })
                 
                 
-                let result = AnalysisResult(extractions: extractions, lineItems: result.lineItems, images: images)
+                let result = AnalysisResult(extractions: extractions, lineItems: result.lineItems, images: images, document: document)
                 
                 let documentService = self.documentService
                 
                 self.resultsDelegate?.giniCaptureAnalysisDidFinishWith(result: result) { updatedExtractions in
-                            documentService.sendFeedback(with: updatedExtractions.map { $0.value })
-                        documentService.resetToInitialState()
+                    documentService.sendFeedback(with: updatedExtractions.map { $0.value })
+                    documentService.resetToInitialState()
                 }
             } else {
                 self.resultsDelegate?
@@ -150,7 +150,7 @@ extension GiniNetworkingScreenAPICoordinator {
         self.documentService.startAnalysis { result in
             switch result {
             case .success(let extractions):
-                self.deliver(result: extractions, analysisDelegate: networkDelegate)
+                self.deliver(result: extractions, and: self.documentService.document, to: networkDelegate)
             case .failure(let error):
 
                 guard error != .requestCancelled else { return }
@@ -215,7 +215,7 @@ extension GiniNetworkingScreenAPICoordinator: GiniCaptureDelegate {
                 }
             let extractionResult = ExtractionResult(extractions: extractions, lineItems: [], returnReasons: [])
             
-            self.deliver(result: extractionResult, analysisDelegate: networkDelegate)
+            self.deliver(result: extractionResult, to: networkDelegate)
             return
         }
 

--- a/CaptureSDK/GiniCaptureSDKExample/Example Swift/ScreenAPICoordinator.swift
+++ b/CaptureSDK/GiniCaptureSDKExample/Example Swift/ScreenAPICoordinator.swift
@@ -66,7 +66,13 @@ final class ScreenAPICoordinator: NSObject, Coordinator {
         screenAPIViewController.interactivePopGestureRecognizer?.delegate = nil
     }
 
-    fileprivate func showResultsScreen(results: [Extraction]) {
+    fileprivate func showResultsScreen(results: [Extraction], document: Document?) {
+        if let document = document {
+            print("🧾 Showing results for Gini Bank API document id: \(document.id)")
+        } else {
+            print("❓ Showing results for unknown Gini Bank API document")
+        }
+        
         let customResultsScreen = (UIStoryboard(name: "Main", bundle: nil)
             .instantiateViewController(withIdentifier: "resultScreen") as? ResultTableViewController)!
         customResultsScreen.result = results
@@ -123,7 +129,7 @@ extension ScreenAPICoordinator: NoResultsScreenDelegate {
 extension ScreenAPICoordinator: GiniCaptureResultsDelegate {
     func giniCaptureAnalysisDidFinishWith(result: AnalysisResult,
                                           sendFeedbackBlock: @escaping ([String: Extraction]) -> Void) {
-        showResultsScreen(results: result.extractions.map { $0.value })
+        showResultsScreen(results: result.extractions.map { $0.value }, document: result.document)
         self.sendFeedbackBlock = sendFeedbackBlock
         DispatchQueue.main.asyncAfter(deadline: .now() + 2.5) {
             sendFeedbackBlock(result.extractions)


### PR DESCRIPTION
* Add the Gini Bank API Library `Document` to the `AnalysisResult` in Capture SDK.
* Update both Capture SDK and Bank SDK to add the document to `AnalysisResult`, if available.
* Update example apps and documentation.