### PR TITLE
Fix the forced dark mode keyboard appearance

### DIFF
--- a/HealthSDK/GiniHealthSDK/Sources/GiniHealthSDK/Core/PaymentReviewViewController.swift
+++ b/HealthSDK/GiniHealthSDK/Sources/GiniHealthSDK/Core/PaymentReviewViewController.swift
@@ -345,15 +345,10 @@ public final class PaymentReviewViewController: UIViewController, UIGestureRecog
     // MARK: - Input fields configuration
 
     fileprivate func applyDefaultStyle(_ field: UITextField) {
-        if #available(iOS 13.0, *) {
-            field.borderStyle = .roundedRect
-            field.overrideUserInterfaceStyle = .dark
-        } else {
-            field.leftView = UIView(frame: CGRect(x: 0, y: 0, width: 10, height: field.frame.height))
-            field.leftViewMode = .always
-            field.rightView = UIView(frame: CGRect(x: 0, y: 0, width: 10, height: field.frame.height))
-            field.rightViewMode = .always
-        }
+        field.leftView = UIView(frame: CGRect(x: 0, y: 0, width: 10, height: field.frame.height))
+        field.leftViewMode = .always
+        field.rightView = UIView(frame: CGRect(x: 0, y: 0, width: 10, height: field.frame.height))
+        field.rightViewMode = .always
         field.layer.cornerRadius = self.giniHealthConfiguration.paymentInputFieldCornerRadius
         field.layer.borderWidth = giniHealthConfiguration.paymentInputFieldBorderWidth
         field.backgroundColor = UIColor.from(giniColor: giniHealthConfiguration.paymentInputFieldBackgroundColor)


### PR DESCRIPTION
fix(GiniHealthSDK): Fixes the forced dark mode keyboard appearance.
`field.overrideUserInterfaceStyle = .dark` triggered always the keyboard in the dark mode appearance.

PIA-2354