### PR TITLE
Pia 2483 document initializer

### DIFF
--- a/BankAPILibrary/GiniBankAPILibrary/Sources/GiniBankAPILibrary/Documents/Document.swift
+++ b/BankAPILibrary/GiniBankAPILibrary/Sources/GiniBankAPILibrary/Documents/Document.swift
@@ -46,6 +46,30 @@ public struct Document {
         case progress
         case sourceClassification
     }
+    
+    public init(compositeDocuments: [CompositeDocument]?,
+                creationDate: Date,
+                id: String,
+                name: String,
+                origin: Origin,
+                pageCount: Int,
+                pages: [Page]?,
+                links: Links,
+                partialDocuments: [PartialDocumentInfo]?,
+                progress: Progress,
+                sourceClassification: SourceClassification){
+        self.compositeDocuments = compositeDocuments
+        self.creationDate = creationDate
+        self.id = id
+        self.name = name
+        self.origin = origin
+        self.pageCount = pageCount
+        self.pages = pages
+        self.links = links
+        self.partialDocuments = partialDocuments
+        self.progress = progress
+        self.sourceClassification = sourceClassification
+    }
 }
 
 // MARK: - Inner types
@@ -110,6 +134,14 @@ extension Document {
         public let processed: URL
         public let document: URL
         public let pages: URL?
+        
+        public init(extractions: URL, layout: URL, processed: URL, document: URL, pages: URL?) {
+            self.extractions = extractions
+            self.layout = layout
+            self.processed = processed
+            self.document = document
+            self.pages = pages
+        }
     }
     
     /// The document's layout, formed by an array of pages

--- a/BankAPILibrary/GiniBankAPILibrary/Sources/GiniBankAPILibrary/Documents/Document.swift
+++ b/BankAPILibrary/GiniBankAPILibrary/Sources/GiniBankAPILibrary/Documents/Document.swift
@@ -47,7 +47,7 @@ public struct Document {
         case sourceClassification
     }
     
-    public init(compositeDocuments: [CompositeDocument]?,
+    init(compositeDocuments: [CompositeDocument]?,
                 creationDate: Date,
                 id: String,
                 name: String,
@@ -69,6 +69,27 @@ public struct Document {
         self.partialDocuments = partialDocuments
         self.progress = progress
         self.sourceClassification = sourceClassification
+    }
+    
+    /**
+     It's the easiest way to initialize a `Document` if you are receiving a customized JSON structure from your proxy backend.
+     
+     - parameter creationDate: The document's creation date.
+     - parameter id: The document's unique identifier.
+     - parameter name: The document's file name.
+     - parameter links: Links to related resources, such as extractions, document, processed, layout or pages.
+     - parameter sourceClassification: The document's source classification. We recommend to use `scanned` or `composite`.
+     
+     - note: Screen API with custom networking only.
+     
+     - returns: A `Document` structure.
+     */
+    public init(creationDate: Date,
+                     id: String,
+                     name: String,
+                     links: Links,
+                     sourceClassification: SourceClassification) {
+        self.init(compositeDocuments: [], creationDate: creationDate, id: id, name: name, origin: .upload, pageCount: 1, pages: [], links: links, partialDocuments: [], progress: .completed, sourceClassification: sourceClassification)
     }
 }
 
@@ -135,12 +156,22 @@ extension Document {
         public let document: URL
         public let pages: URL?
         
-        public init(extractions: URL, layout: URL, processed: URL, document: URL, pages: URL?) {
-            self.extractions = extractions
-            self.layout = layout
-            self.processed = processed
-            self.document = document
-            self.pages = pages
+        /**
+         An  initializer for a `Links` structure if you are receiving a customized JSON structure from your proxy backend.
+         For this particular case all links will be pointed to the document's link.
+         
+         - parameter giniAPIDocumentURL: The document's link receive from Gini API. For example "https://pay-api.gini.net/documents/\(documentID)".
+         
+         - note: Screen API with custom networking only.
+         
+         - returns: A `Links` structure.
+         */
+        public init(giniAPIDocumentURL: URL) {
+            self.extractions = giniAPIDocumentURL
+            self.layout = giniAPIDocumentURL
+            self.processed = giniAPIDocumentURL
+            self.document = giniAPIDocumentURL
+            self.pages = nil
         }
     }
     

--- a/BankAPILibrary/GiniBankAPILibrary/Sources/GiniBankAPILibrary/Documents/Document.swift
+++ b/BankAPILibrary/GiniBankAPILibrary/Sources/GiniBankAPILibrary/Documents/Document.swift
@@ -160,7 +160,8 @@ extension Document {
          An  initializer for a `Links` structure if you are receiving a customized JSON structure from your proxy backend.
          For this particular case all links will be pointed to the document's link.
          
-         - parameter giniAPIDocumentURL: The document's link receive from Gini API. For example "https://pay-api.gini.net/documents/\(documentID)".
+         - parameter giniAPIDocumentURL: The document's link received from the Gini API. This must be the same URL that you received in the `Location` header from the Gini API. For example "https://pay-api.gini.net/documents/626626a0-749f-11e2-bfd6-000000000000".
+```.
          
          - note: Screen API with custom networking only.
          

--- a/BankAPILibrary/GiniBankAPILibrary/Sources/GiniBankAPILibrary/Documents/Document.swift
+++ b/BankAPILibrary/GiniBankAPILibrary/Sources/GiniBankAPILibrary/Documents/Document.swift
@@ -157,7 +157,7 @@ extension Document {
         public let pages: URL?
         
         /**
-         An  initializer for a `Links` structure if you are receiving a customized JSON structure from your proxy backend.
+         An initializer for a `Links` structure if you are receiving a customized JSON structure from your proxy backend.
          For this particular case all links will be pointed to the document's link.
          
          - parameter giniAPIDocumentURL: The document's link received from the Gini API. This must be the same URL that you received in the `Location` header from the Gini API. For example "https://pay-api.gini.net/documents/626626a0-749f-11e2-bfd6-000000000000".

--- a/BankAPILibrary/GiniBankAPILibrary/Sources/GiniBankAPILibrary/Documents/Document.swift
+++ b/BankAPILibrary/GiniBankAPILibrary/Sources/GiniBankAPILibrary/Documents/Document.swift
@@ -81,8 +81,6 @@ public struct Document {
      - parameter sourceClassification: The document's source classification. We recommend to use `scanned` or `composite`.
      
      - note: Screen API with custom networking only.
-     
-     - returns: A `Document` structure.
      */
     public init(creationDate: Date,
                      id: String,
@@ -161,11 +159,8 @@ extension Document {
          For this particular case all links will be pointed to the document's link.
          
          - parameter giniAPIDocumentURL: The document's link received from the Gini API. This must be the same URL that you received in the `Location` header from the Gini API. For example "https://pay-api.gini.net/documents/626626a0-749f-11e2-bfd6-000000000000".
-```.
          
          - note: Screen API with custom networking only.
-         
-         - returns: A `Links` structure.
          */
         public init(giniAPIDocumentURL: URL) {
             self.extractions = giniAPIDocumentURL

--- a/BankSDK/GiniBankSDK/Documentation/source/Integration.md
+++ b/BankSDK/GiniBankSDK/Documentation/source/Integration.md
@@ -213,6 +213,9 @@ let viewController = GiniBank.viewController(importedDocuments: visionDocuments,
 
 present(viewController, animated: true, completion: nil)
 ```
+
+We provide an example implementation [here](https://github.com/gini/gini-mobile-ios/blob/main/BankSDK/GiniBankSDKExample/GiniBankSDKExample/Screen%20API/ScreenAPICoordinator.swift#L162).
+
 You may also use the [Gini Bank API Library](https://github.com/gini/bank-api-library-ios) or implement communication with the Gini Bank API yourself.
 
 ## Component API

--- a/BankSDK/GiniBankSDKExample/GiniBankSDKExample/Screen API/ScreenAPICoordinator.swift
+++ b/BankSDK/GiniBankSDKExample/GiniBankSDKExample/Screen API/ScreenAPICoordinator.swift
@@ -194,9 +194,9 @@ extension ScreenAPICoordinator: GiniCaptureNetworkService {
     func upload(document: GiniCaptureDocument, metadata: Document.Metadata?, completion: @escaping UploadDocumentCompletion) {
         print("💻 custom networking - upload document event called")
         let creationDate = Date()
-        if let defaultUrl = URL.init(string: "https://pay-api.gini.net/documentation") {
-            let links = Document.Links.init(extractions: defaultUrl, layout: defaultUrl, processed: defaultUrl, document: defaultUrl, pages: defaultUrl)
-            let manuallyCreatedDoc = Document.init(compositeDocuments: [], creationDate: creationDate, id: "1234", name: "manuallyCreatedDocument", origin: .unknown, pageCount: 1, pages: [], links: links, partialDocuments: [], progress: .completed, sourceClassification: .composite)
+        if let defaultUrl = URL.init(string: "https://pay-api.gini.net/documents/3008db90-c499-11ec-a6b8-d5d497bfXXXX") {
+            let links = Document.Links.init(giniAPIDocumentURL: defaultUrl)
+            let manuallyCreatedDoc = Document.init(creationDate: creationDate, id: "3008db90-c499-11ec-a6b8-d5d497bfXXXX", name: "manuallyCreatedDocument", links: links, sourceClassification: .composite)
             self.manuallyCreatedDocument = manuallyCreatedDoc
             completion(.success(manuallyCreatedDoc))
         } else {

--- a/BankSDK/GiniBankSDKExample/GiniBankSDKExample/Screen API/ScreenAPICoordinator.swift
+++ b/BankSDK/GiniBankSDKExample/GiniBankSDKExample/Screen API/ScreenAPICoordinator.swift
@@ -196,7 +196,7 @@ extension ScreenAPICoordinator: GiniCaptureNetworkService {
         let creationDate = Date()
         if let defaultUrl = URL.init(string: "https://pay-api.gini.net/documents/3008db90-c499-11ec-a6b8-d5d497bfXXXX") {
             let links = Document.Links.init(giniAPIDocumentURL: defaultUrl)
-            let manuallyCreatedDoc = Document.init(creationDate: creationDate, id: "3008db90-c499-11ec-a6b8-d5d497bfXXXX", name: "manuallyCreatedDocument", links: links, sourceClassification: .composite)
+            let manuallyCreatedDoc = Document.init(creationDate: creationDate, id: "3008db90-c499-11ec-a6b8-d5d497bfXXXX", name: "manuallyCreatedDocument", links: links, sourceClassification: .scanned)
             self.manuallyCreatedDocument = manuallyCreatedDoc
             completion(.success(manuallyCreatedDoc))
         } else {

--- a/BankSDK/GiniBankSDKExample/GiniBankSDKExample/Screen API/ScreenAPICoordinator.swift
+++ b/BankSDK/GiniBankSDKExample/GiniBankSDKExample/Screen API/ScreenAPICoordinator.swift
@@ -66,21 +66,21 @@ final class ScreenAPICoordinator: NSObject, Coordinator, UINavigationControllerD
     func start() {
         
 // MARK: - Screen API with default networking
-//    let viewController = GiniBank.viewController(withClient: client,
-//                                                 importedDocuments: visionDocuments,
-//                                                 configuration: configuration,
-//                                                 resultsDelegate: self,
-//                                                 documentMetadata: documentMetadata,
-//                                                 api: .default,
-//                                                 userApi: .default,
-//                                                 trackingDelegate: trackingDelegate)
+    let viewController = GiniBank.viewController(withClient: client,
+                                                 importedDocuments: visionDocuments,
+                                                 configuration: configuration,
+                                                 resultsDelegate: self,
+                                                 documentMetadata: documentMetadata,
+                                                 api: .default,
+                                                 userApi: .default,
+                                                 trackingDelegate: trackingDelegate)
 // MARK: - Screen API with custom networking
-        let viewController = GiniBank.viewController(importedDocuments: visionDocuments,
-                                                        configuration: configuration,
-                                                        resultsDelegate: self,
-                                                        documentMetadata: documentMetadata,
-                                                        trackingDelegate: trackingDelegate,
-                                                        networkingService: self)
+//        let viewController = GiniBank.viewController(importedDocuments: visionDocuments,
+//                                                        configuration: configuration,
+//                                                        resultsDelegate: self,
+//                                                        documentMetadata: documentMetadata,
+//                                                        trackingDelegate: trackingDelegate,
+//                                                        networkingService: self)
 // MARK: - Screen API - UI Only
 //        let viewController = GiniBank.viewController(withDelegate: self, withConfiguration: configuration)
 
@@ -128,7 +128,6 @@ final class ScreenAPICoordinator: NSObject, Coordinator, UINavigationControllerD
 
 
 // MARK: - NoResultsScreenDelegate
-
 extension ScreenAPICoordinator: NoResultsScreenDelegate {
     func noResults(viewController: NoResultViewController, didTapRetry: ()) {
         screenAPIViewController.popToRootViewController(animated: true)
@@ -136,7 +135,6 @@ extension ScreenAPICoordinator: NoResultsScreenDelegate {
 }
 
 // MARK: - GiniCaptureResultsDelegate
-
 extension ScreenAPICoordinator: GiniCaptureResultsDelegate {
     
     func giniCaptureAnalysisDidFinishWith(result: AnalysisResult,
@@ -161,6 +159,7 @@ extension ScreenAPICoordinator: GiniCaptureResultsDelegate {
     }
 }
 
+// MARK: - Screen API with custom networking GiniCaptureNetworkService
 extension ScreenAPICoordinator: GiniCaptureNetworkService {
     func delete(document: Document, completion: @escaping (Result<String, GiniError>) -> Void) {
         print("💻 custom networking - delete document event called")

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Networking/AnalysisResult.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Networking/AnalysisResult.swift
@@ -18,7 +18,7 @@ import GiniBankAPILibrary
      *  Specific extractions obtained in the analysis.
      *
      *  Besides the list of extractions that can be found
-     *  [here](http://developer.gini.net/gini-api/html/document_extractions.html#available-specific-extractions),
+     *  [here](https://pay-api.gini.net/documentation/#specific-extractions),
      *  it can also return the epsPaymentQRCodeUrl extraction, obtained from a EPS QR code.
      */
     public let extractions: [String: Extraction]


### PR DESCRIPTION
 - GiniBankAPILibrary: Add `Document` and `Document.Links` public initializers allowing the use of a customized JSON structure.
 - GiniBankSDKExample: Add manual initialization of pay4 extractions and line items.
 
Maybe I need to ask our backend team and check the critical default values for Document.
