### PR TITLE
Pia 2524 back to camera button

### DIFF
--- a/BankSDK/GiniBankSDK/Documentation/source/Customization guide.md
+++ b/BankSDK/GiniBankSDK/Documentation/source/Customization guide.md
@@ -266,11 +266,13 @@ Some background and text colors use the `GiniColor` type with which you can set 
 
 ##### 4. Go to camera button
 - Background color &#8594; `GiniBankConfiguration.noResultsBottomButtonColor`
+- Text color &#8594; `GiniBankConfiguration.noResultsBottomButtonTextColor`
+- Corner radius &#8594; `GiniBankConfiguration.noResultsBottomButtonCornerRadius`
 - Back button
-    noResultsBottomButtonColor
   - With image and title
       - Image &#8594; <span style="color:#009EDF">*cameraIcon*</span> image asset
       - Title &#8594; <span style="color:#009EDF">*ginicapture.noresults.gotocamera*</span> localized string
+      
 ## Gallery album screen
 
 <br>
@@ -350,8 +352,9 @@ Overriding tips images below will lead to the changes on the [Capturing tips scr
 
 ##### 3. Back to camera button
 - Background color &#8594; `GiniBankConfiguration.noResultsBottomButtonColor`
+- Text color &#8594; `GiniBankConfiguration.noResultsBottomButtonTextColor`
+- Corner radius &#8594; `GiniBankConfiguration.noResultsBottomButtonCornerRadius`
 - Back button
-    noResultsBottomButtonColor
   - With image and title
       - Image &#8594; <span style="color:#009EDF">*cameraIcon*</span> image asset
       - Title &#8594; <span style="color:#009EDF">*ginicapture.noresults.gotocamera*</span> localized string

--- a/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/GiniBankConfiguration.swift
+++ b/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/GiniBankConfiguration.swift
@@ -549,6 +549,16 @@ public final class GiniBankConfiguration: NSObject {
     @objc public var noResultsBottomButtonColor = Colors.Gini.blue
     
     /**
+     Sets the text color of the bottom button to the specified color.
+     */
+    @objc public var noResultsBottomButtonTextColor = GiniColor.init(lightModeColor: .white, darkModeColor: .white)
+    
+    /**
+     Sets the corner radius of the bottom button.
+     */
+    @objc public var noResultsBottomButtonCornerRadius: CGFloat = 0.0
+    
+    /**
      Sets the color of the warning container background to the specified color.
      */
     @objc public var noResultsWarningContainerIconColor = Colors.Gini.rose
@@ -1246,6 +1256,8 @@ public final class GiniBankConfiguration: NSObject {
         configuration.stepIndicatorColor = self.stepIndicatorColor
         
         configuration.noResultsBottomButtonColor = self.noResultsBottomButtonColor
+        configuration.noResultsBottomButtonTextColor = self.noResultsBottomButtonTextColor
+        configuration.noResultsBottomButtonCornerRadius = self.noResultsBottomButtonCornerRadius
         
         configuration.noResultsWarningContainerIconColor = self.noResultsWarningContainerIconColor
         
@@ -1494,6 +1506,8 @@ public final class GiniBankConfiguration: NSObject {
         giniBankConfiguration.stepIndicatorColor = configuration.stepIndicatorColor
         
         giniBankConfiguration.noResultsBottomButtonColor = configuration.noResultsBottomButtonColor
+        giniBankConfiguration.noResultsBottomButtonTextColor = configuration.noResultsBottomButtonTextColor
+        giniBankConfiguration.noResultsBottomButtonCornerRadius = configuration.noResultsBottomButtonCornerRadius
         
         giniBankConfiguration.noResultsWarningContainerIconColor = configuration.noResultsWarningContainerIconColor
         

--- a/CaptureSDK/GiniCaptureSDK/Documentation/source/Customization guide.md
+++ b/CaptureSDK/GiniCaptureSDK/Documentation/source/Customization guide.md
@@ -250,6 +250,8 @@ Some background and text colors use the `GiniColor` type with which you can set 
 
 ##### 2. Go to camera button
 - Background color &#8594; `GiniConfiguration.noResultsBottomButtonColor`
+- Text color &#8594; `GiniConfiguration.noResultsBottomButtonTextColor`
+- Corner radius &#8594; `GiniConfiguration.noResultsBottomButtonCornerRadius`
 
 ## Gallery album screen
 

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Extensions/UIImage.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Extensions/UIImage.swift
@@ -69,4 +69,17 @@ extension UIImage {
         return UIImage(cgImage: downsampledImage)
     }
     
+    func tintedImageWithColor(_ color: UIColor) -> UIImage? {
+        let image = withRenderingMode(.alwaysTemplate)
+        UIGraphicsBeginImageContextWithOptions(size, false, scale)
+        color.set()
+        image.draw(in: CGRect(origin: .zero, size: size))
+
+        guard let imageColored = UIGraphicsGetImageFromCurrentImageContext() else {
+            return nil
+        }
+        UIGraphicsEndImageContext()
+        return imageColored
+    }
+    
 }

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/GiniConfiguration.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/GiniConfiguration.swift
@@ -624,6 +624,16 @@ import UIKit
     @objc public var noResultsBottomButtonColor = Colors.Gini.blue
     
     /**
+     Sets the text color of the bottom button to the specified color.
+     */
+    @objc public var noResultsBottomButtonTextColor = GiniColor.init(lightModeColor: .white, darkModeColor: .white)
+    
+    /**
+     Sets the corner radius of the bottom button.
+     */
+    @objc public var noResultsBottomButtonCornerRadius: CGFloat = 0.0
+    
+    /**
      Sets the color of the warning container background to the specified color.
      */
     @objc public var noResultsWarningContainerIconColor = Colors.Gini.rose

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Help/No results/ImageAnalysisNoResultsViewController.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Help/No results/ImageAnalysisNoResultsViewController.swift
@@ -27,9 +27,13 @@ public final class ImageAnalysisNoResultsViewController: UIViewController {
         bottomButton.translatesAutoresizingMaskIntoConstraints = false
         bottomButton.setTitle(self.bottomButtonText, for: .normal)
         bottomButton.titleLabel?.font = giniConfiguration.customFont.with(weight: .bold, size: 14, style: .caption1)
-        bottomButton.setTitleColor(UIColor.from(giniColor: giniConfiguration.noResultsBottomButtonTextColor), for: .normal)
-        bottomButton.setTitleColor(UIColor.from(giniColor: giniConfiguration.noResultsBottomButtonTextColor).withAlphaComponent(0.5), for: .highlighted)
+        let bottomButtonTextColor = UIColor.from(giniColor: giniConfiguration.noResultsBottomButtonTextColor)
+        bottomButton.setTitleColor(bottomButtonTextColor, for: .normal)
+        bottomButton.setTitleColor(bottomButtonTextColor.withAlphaComponent(0.5), for: .highlighted)
         bottomButton.setImage(self.bottomButtonIconImage, for: .normal)
+        if let highlightedImage = self.bottomButtonIconImage?.tintedImageWithColor(bottomButtonTextColor.withAlphaComponent(0.5)){
+            bottomButton.setImage(highlightedImage, for: .highlighted)
+        }
         bottomButton.addTarget(self, action: #selector(didTapBottomButtonAction), for: .touchUpInside)
         bottomButton.imageEdgeInsets = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 20)
         bottomButton.backgroundColor = giniConfiguration.noResultsBottomButtonColor

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Help/No results/ImageAnalysisNoResultsViewController.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Help/No results/ImageAnalysisNoResultsViewController.swift
@@ -27,11 +27,13 @@ public final class ImageAnalysisNoResultsViewController: UIViewController {
         bottomButton.translatesAutoresizingMaskIntoConstraints = false
         bottomButton.setTitle(self.bottomButtonText, for: .normal)
         bottomButton.titleLabel?.font = giniConfiguration.customFont.with(weight: .bold, size: 14, style: .caption1)
-        bottomButton.setTitleColor(UIColor.white.withAlphaComponent(0.5), for: .highlighted)
+        bottomButton.setTitleColor(UIColor.from(giniColor: giniConfiguration.noResultsBottomButtonTextColor), for: .normal)
+        bottomButton.setTitleColor(UIColor.from(giniColor: giniConfiguration.noResultsBottomButtonTextColor).withAlphaComponent(0.5), for: .highlighted)
         bottomButton.setImage(self.bottomButtonIconImage, for: .normal)
         bottomButton.addTarget(self, action: #selector(didTapBottomButtonAction), for: .touchUpInside)
         bottomButton.imageEdgeInsets = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 20)
-        bottomButton.backgroundColor = GiniConfiguration.shared.noResultsBottomButtonColor
+        bottomButton.backgroundColor = giniConfiguration.noResultsBottomButtonColor
+        bottomButton.layer.cornerRadius = giniConfiguration.noResultsBottomButtonCornerRadius
         return bottomButton
     }()
     


### PR DESCRIPTION
- Add customization options: text color and corner radius for the backToCameraButton on the No Results and Capturing tips screens.
- Make a consistent icon and text highlight style for the back to the camera button.
- Update docs.