### PR TITLE
Pia 2526 supporting formats docs

### DIFF
--- a/BankSDK/GiniBankSDK/Documentation/source/Customization guide.md
+++ b/BankSDK/GiniBankSDK/Documentation/source/Customization guide.md
@@ -209,7 +209,9 @@ Some background and text colors use the `GiniColor` type with which you can set 
 	  - Title &#8594; `GiniBankConfiguration.navigationBarHelpScreenTitleBackToMenuButton`
 
 ##### 1. Supported format cells
+- Supported fortmats icon &#8594; <span style="color:#009EDF">*supportedFormatsIcon*</span> image asset
 - Supported formats icon color &#8594; `GiniBankConfiguration.supportedFormatsIconColor`
+- Non supported fortmats icon &#8594; <span style="color:#009EDF">*nonSupportedFormatsIcon*</span> image asset
 - Non supported formats icon color &#8594; `GiniBankConfiguration.nonSupportedFormatsIconColor`
 
 ## Open with tutorial screen

--- a/CaptureSDK/GiniCaptureSDK/Documentation/source/Customization guide.md
+++ b/CaptureSDK/GiniCaptureSDK/Documentation/source/Customization guide.md
@@ -199,7 +199,9 @@ Some background and text colors use the `GiniColor` type with which you can set 
 	  - Title &#8594; `GiniConfiguration.navigationBarHelpScreenTitleBackToMenuButton`
 
 ##### 1. Supported format cells
+- Supported fortmats icon &#8594; <span style="color:#009EDF">*supportedFormatsIcon*</span> image asset
 - Supported formats icon color &#8594; `GiniConfiguration.supportedFormatsIconColor`
+- Non supported fortmats icon &#8594; <span style="color:#009EDF">*nonSupportedFormatsIcon*</span> image asset
 - Non supported formats icon color &#8594; `GiniConfiguration.nonSupportedFormatsIconColor`
 
 ## Open with tutorial screen

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Help/Supported formats/SupportedFormatsViewController.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Help/Supported formats/SupportedFormatsViewController.swift
@@ -23,14 +23,12 @@ final class SupportedFormatsViewController: UITableViewController {
         var sections: [SupportedFormatCollectionSection] =  [
             (.localized(resource: HelpStrings.supportedFormatsSection1Title),
              [.localized(resource: HelpStrings.supportedFormatsSection1Item1Text)],
-             UIImage(named: "supportedFormatsIcon",
-                     in: giniCaptureBundle(),
-                     compatibleWith: nil),
+             UIImageNamedPreferred(named: "supportedFormatsIcon"),
              GiniConfiguration.shared.supportedFormatsIconColor),
             (.localized(resource: HelpStrings.supportedFormatsSection2Title),
              [.localized(resource: HelpStrings.supportedFormatsSection2Item1Text),
               .localized(resource: HelpStrings.supportedFormatsSection2Item2Text)],
-             UIImage(named: "nonSupportedFormatsIcon", in: giniCaptureBundle(), compatibleWith: nil),
+             UIImageNamedPreferred(named: "nonSupportedFormatsIcon"),
              GiniConfiguration.shared.nonSupportedFormatsIconColor)
         ]
         


### PR DESCRIPTION
- Allow customizing the support/nonsupport icons on the supported formats screen.
