### PR TITLE
Add localisation fixes 

### DIFF
--- a/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/GiniBankNetworkingScreenApiCoordinator.swift
+++ b/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/GiniBankNetworkingScreenApiCoordinator.swift
@@ -282,7 +282,7 @@ extension GiniBankNetworkingScreenApiCoordinator {
 
                 guard error != .requestCancelled else { return }
 
-                networkDelegate.displayError(withMessage: .ginibankLocalized(resource: AnalysisStrings.analysisErrorMessage),
+                networkDelegate.displayError(withMessage: .localized(resource: AnalysisStrings.analysisErrorMessage),
                                              andAction: {
                                                  self.startAnalysisWithReturnAssistant(networkDelegate: networkDelegate)
                                              })

--- a/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Resources/de.lproj/Localizable.strings
+++ b/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Resources/de.lproj/Localizable.strings
@@ -1,9 +1,9 @@
-/* 
+/*
   Localizable.strings
   GiniBank
 
-  Created by Peter Pult on 08/06/16.
-  Copyright © 2016 Gini. All rights reserved.
+  Created by Nadzeya Karaban on 04/11/21.
+  Copyright © 2021 Gini. All rights reserved.
 */
 
 "ginibank.help.menu.title" = "Hilfe";

--- a/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Resources/de.lproj/Localizable.strings
+++ b/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Resources/de.lproj/Localizable.strings
@@ -68,4 +68,3 @@
 Bezahle nur, was du behälst.";
 "ginibank.digitalinvoice.onboarding.donebutton" = "Weiter";
 "ginibank.digitalinvoice.onboarding.hidebutton" = "Bitte nicht mehr anzeigen";
-"ginibank.analysis.error.analysis" = "Beim Analysieren des Dokuments ist ein Fehler aufgetreten.";

--- a/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Resources/de.lproj/Localizable.strings
+++ b/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Resources/de.lproj/Localizable.strings
@@ -6,10 +6,6 @@
   Copyright © 2021 Gini. All rights reserved.
 */
 
-"ginibank.help.menu.title" = "Hilfe";
-"ginibank.help.menu.firstItem" = "Tipps für beste Ergebnisse aus Fotos";
-"ginibank.help.menu.secondItem" = "Dokumente aus anderen Apps öffnen";
-"ginibank.help.menu.thirdItem" = "Unterstützte Formate";
 "ginibank.help.menu.fourthItem" = "Der neue Retourenassistent";
 
 "ginibank.help.menu.returnAssistant.title" = "Retourenassistent";

--- a/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Resources/de.lproj/Localizable.strings
+++ b/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Resources/de.lproj/Localizable.strings
@@ -72,3 +72,4 @@
 Bezahle nur, was du behälst.";
 "ginibank.digitalinvoice.onboarding.donebutton" = "Weiter";
 "ginibank.digitalinvoice.onboarding.hidebutton" = "Bitte nicht mehr anzeigen";
+"ginibank.analysis.error.analysis" = "Beim Analysieren des Dokuments ist ein Fehler aufgetreten.";

--- a/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Resources/en.lproj/Localizable.strings
+++ b/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Resources/en.lproj/Localizable.strings
@@ -95,3 +95,4 @@
 "ginibank.digitalinvoice.onboarding.text2" = "Deselect article that you want to return and pay only for what you keep!";
 "ginibank.digitalinvoice.onboarding.donebutton" = "Next";
 "ginibank.digitalinvoice.onboarding.hidebutton" = "Don’t show anymore";
+"ginibank.analysis.error.analysis" = "An error occurred while parsing the document.";

--- a/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Resources/en.lproj/Localizable.strings
+++ b/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Resources/en.lproj/Localizable.strings
@@ -23,18 +23,6 @@
 "ginibank.help.menu.returnAssistant.section3.body" = "If the price has not been read out perfectly, you can simply correct it manually. The total price is updated automatically.";
 "ginibank.help.menu.returnAssistant.backButton.title" = "Back";
 
-"ginibank.albums.title" = "Albums";
-"ginibank.imagepicker.openbutton" = "Open";
-
-"ginibank.multipagereview.reorderContainerTooltipMessage" = "The pages must be in the right order. You can sort them here.";
-"ginibank.multipagereview.dragAndDropTip" = "Drag & Drop to sort";
-"ginibank.multipagereview.error.retakeAction" = "Retake";
-"ginibank.multipagereview.error.retryAction" = "Retry";
-
-"ginibank.images.openWithTutorialStep1" = "openWithTutorialStep1_en";
-"ginibank.images.openWithTutorialStep2" = "openWithTutorialStep2_en";
-"ginibank.images.openWithTutorialStep3" = "openWithTutorialStep3_en";
-
 "ginibank.digitalinvoice.screentitle" = "Digital Invoice";
 "ginibank.digitalinvoice.paybuttontitle.noinvoice" = "Pay";
 "ginibank.digitalinvoice.paybuttontitle" = "Pay %d/%d";

--- a/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Resources/en.lproj/Localizable.strings
+++ b/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Resources/en.lproj/Localizable.strings
@@ -1,9 +1,9 @@
 /* 
   Localizable.strings
-  GiniVision
+  GiniBank
 
-  Created by Peter Pult on 08/06/16.
-  Copyright © 2016 Gini. All rights reserved.
+  Created by Nadzeya Karaban on 04/11/21.
+  Copyright © 2021 Gini. All rights reserved.
 */
 "ginibank.help.menu.title" = "Help";
 "ginibank.help.menu.firstItem" = "Tips for best results from photos";
@@ -27,9 +27,7 @@
 "ginibank.imagepicker.openbutton" = "Open";
 
 "ginibank.multipagereview.reorderContainerTooltipMessage" = "The pages must be in the right order. You can sort them here.";
-"ginibank.multipagereview.addButtonLabel" = "Add a page";
 "ginibank.multipagereview.dragAndDropTip" = "Drag & Drop to sort";
-"ginibank.multipagereview.title" = "%d of %d";
 "ginibank.multipagereview.error.retakeAction" = "Retake";
 "ginibank.multipagereview.error.retryAction" = "Retry";
 

--- a/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Resources/en.lproj/Localizable.strings
+++ b/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Resources/en.lproj/Localizable.strings
@@ -78,4 +78,3 @@
 "ginibank.digitalinvoice.onboarding.text2" = "Deselect article that you want to return and pay only for what you keep!";
 "ginibank.digitalinvoice.onboarding.donebutton" = "Next";
 "ginibank.digitalinvoice.onboarding.hidebutton" = "Don’t show anymore";
-"ginibank.analysis.error.analysis" = "An error occurred while parsing the document.";

--- a/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Resources/en.lproj/Localizable.strings
+++ b/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Resources/en.lproj/Localizable.strings
@@ -5,10 +5,7 @@
   Created by Nadzeya Karaban on 04/11/21.
   Copyright © 2021 Gini. All rights reserved.
 */
-"ginibank.help.menu.title" = "Help";
-"ginibank.help.menu.firstItem" = "Tips for best results from photos";
-"ginibank.help.menu.secondItem" = "Open document from other apps";
-"ginibank.help.menu.thirdItem" = "Supported formats";
+
 "ginibank.help.menu.fourthItem" = "The new return assistant";
 
 "ginibank.help.menu.returnAssistant.title" = "Return Assistant";

--- a/BankSDK/GiniBankSDKExample/GiniBankSDKExample.xcodeproj/project.pbxproj
+++ b/BankSDK/GiniBankSDKExample/GiniBankSDKExample.xcodeproj/project.pbxproj
@@ -85,7 +85,6 @@
 		F4083ED82735B0CB004DDD3B /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/LocalizableCustomName.strings; sourceTree = "<group>"; };
 		F4083EDA2735B0CD004DDD3B /* de */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = de; path = de.lproj/LocalizableCustomName.strings; sourceTree = "<group>"; };
 		F40E1435273C06AA00734A0E /* PartialDocument.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = PartialDocument.swift; path = GiniBankSDKExample/PartialDocument.swift; sourceTree = SOURCE_ROOT; };
-		F40E1437273C08D200734A0E /* testPDF.pdf */ = {isa = PBXFileReference; lastKnownFileType = image.pdf; name = testPDF.pdf; path = GiniBankSDKExample/testPDF.pdf; sourceTree = SOURCE_ROOT; };
 		F414A56225EBB87F00D04A80 /* DocumentAnalysisHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DocumentAnalysisHelper.swift; sourceTree = "<group>"; };
 		F439C21827355C0C0010D77D /* GiniBankSDK */ = {isa = PBXFileReference; lastKnownFileType = folder; name = GiniBankSDK; path = ../GiniBankSDK; sourceTree = "<group>"; };
 		F441DCA625E55D5800AAB09A /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
@@ -205,7 +204,6 @@
 		F441DC3725E5283300AAB09A /* Supporting Files */ = {
 			isa = PBXGroup;
 			children = (
-				F40E1437273C08D200734A0E /* testPDF.pdf */,
 				F4AD00F725DFDF4400C34E15 /* Images.xcassets */,
 			);
 			path = "Supporting Files";

--- a/BankSDK/GiniBankSDKExample/GiniBankSDKExample/de.lproj/LocalizableCustomName.strings
+++ b/BankSDK/GiniBankSDKExample/GiniBankSDKExample/de.lproj/LocalizableCustomName.strings
@@ -20,11 +20,6 @@
  or on [Github](https://github.com/gini/gini-capture-sdk-ios/blob/master/GiniCapture/Assets/Localizable.strings).
 */
 
-"next" = "Weiter";
-"close" = "Close";
-"newDocument" = "New document";
-"help" = "Help";
-"analysisFailedErrorMessage" = "Dokumentanalyse fehlgeschlagen. Möchten Sie es erneut versuchen?";
 //"ginicapture.analysis.error.analysis" = "CM Beim Analysieren des Dokuments ist ein Fehler aufgetreten.";
 //"ginicapture.camera.popupTitleImportPDF" = "CM PDF importieren";
 //"ginicapture.camera.popupOptionPhotos" = "CM Fotos";

--- a/BankSDK/GiniBankSDKExample/GiniBankSDKExample/de.lproj/LocalizableCustomName.strings
+++ b/BankSDK/GiniBankSDKExample/GiniBankSDKExample/de.lproj/LocalizableCustomName.strings
@@ -25,3 +25,9 @@
 "newDocument" = "New document";
 "help" = "Help";
 "analysisFailedErrorMessage" = "Dokumentanalyse fehlgeschlagen. Möchten Sie es erneut versuchen?";
+//"ginicapture.camera.popupTitleImportPDF" = "CM PDF importieren";
+//"ginicapture.camera.popupOptionPhotos" = "CM Fotos";
+//"ginicapture.camera.popupOptionFiles" = "CM Dokumente";
+//"ginicapture.camera.popupTitleImportPDForPhotos" = "CM Fotos oder PDF importieren";
+//"ginicapture.camera.popupCancel" = "CM Abbrechen";
+//"ginicapture.camera.capturedImagesStackLabel" = "CM Erfasste Dokumente";

--- a/BankSDK/GiniBankSDKExample/GiniBankSDKExample/de.lproj/LocalizableCustomName.strings
+++ b/BankSDK/GiniBankSDKExample/GiniBankSDKExample/de.lproj/LocalizableCustomName.strings
@@ -65,3 +65,4 @@
 //"ginicapture.help.menu.thirdItem" = "CM Unterstützte Formate";
 //
 //"ginicapture.help.openWithTutorial.title" = "CM Dokumente aus anderen Apps öffnen";
+"close" = "Schließen";

--- a/BankSDK/GiniBankSDKExample/GiniBankSDKExample/de.lproj/LocalizableCustomName.strings
+++ b/BankSDK/GiniBankSDKExample/GiniBankSDKExample/de.lproj/LocalizableCustomName.strings
@@ -25,6 +25,7 @@
 "newDocument" = "New document";
 "help" = "Help";
 "analysisFailedErrorMessage" = "Dokumentanalyse fehlgeschlagen. Möchten Sie es erneut versuchen?";
+//"ginicapture.analysis.error.analysis" = "CM Beim Analysieren des Dokuments ist ein Fehler aufgetreten.";
 //"ginicapture.camera.popupTitleImportPDF" = "CM PDF importieren";
 //"ginicapture.camera.popupOptionPhotos" = "CM Fotos";
 //"ginicapture.camera.popupOptionFiles" = "CM Dokumente";

--- a/BankSDK/GiniBankSDKExample/GiniBankSDKExample/de.lproj/LocalizableCustomName.strings
+++ b/BankSDK/GiniBankSDKExample/GiniBankSDKExample/de.lproj/LocalizableCustomName.strings
@@ -1,16 +1,16 @@
 /* 
   Localizable.strings
-  GiniCapture
+  GiniBankExample
 
-  Created by Peter Pult on 16/06/16.
-  Copyright © 2016 Gini. All rights reserved.
+  Created by Nadzeya Karaban on 02/11/21.
+  Copyright © 2021 Gini. All rights reserved.
 */
 
 /*
- Gini Capture SDK
+ Gini Bank SDK
  ===================
  
- To easily customize texts in the Gini Capture SDK overwrite keys by your own definitions.
+ To easily customize texts in the Gini Bank SDK overwrite keys by your own definitions.
  For example to change the title of the camera add:
  ```
  "ginicapture.navigationbar.camera.title" = "Fotoüberweisung";

--- a/BankSDK/GiniBankSDKExample/GiniBankSDKExample/de.lproj/LocalizableCustomName.strings
+++ b/BankSDK/GiniBankSDKExample/GiniBankSDKExample/de.lproj/LocalizableCustomName.strings
@@ -52,3 +52,20 @@
 //"ginicapture.noresults.gotocamera" = "CM Zur Kamera";
 //"ginicapture.noresults.title" = "CM Tipps für Fotos";
 //"ginicapture.noresults.warningHelpMenu" = "CM Zur Erkennung aller Daten bitte folgende Tipps beim Abfotografieren beachten:";
+
+//"ginicapture.help.supportedFormats.title" = "CM Unterstützte Formate";
+//"ginicapture.help.supportedFormats.section.1.title" = "CM Folgende Formate werden unterstützt:";
+//"ginicapture.help.supportedFormats.section.1.item.1" = "CM Computer-erstellte Überweisungsträger und Rechnungen";
+//"ginicapture.help.supportedFormats.section.1.item.2" = "CM Einseitige Bilder im jpg, png, gif oder tiff Format";
+//"ginicapture.help.supportedFormats.section.1.item.3" = "CM PDF Dokumente von bis zu 10 Seiten";
+//"ginicapture.help.supportedFormats.section.1.item.4" = "CM QR Codes";
+//"ginicapture.help.supportedFormats.section.2.title" = "CM Was nicht analysiert wird:";
+//"ginicapture.help.supportedFormats.section.2.item.1" = "CM Handschrift";
+//"ginicapture.help.supportedFormats.section.2.item.2" = "CM Fotos von Bildschirmen";
+//
+//"ginicapture.help.menu.title" = "CM Hilfe";
+//"ginicapture.help.menu.firstItem" = "CM Tipps für beste Ergebnisse aus Fotos";
+//"ginicapture.help.menu.secondItem" = "CM Dokumente aus anderen Apps öffnen";
+//"ginicapture.help.menu.thirdItem" = "CM Unterstützte Formate";
+//
+//"ginicapture.help.openWithTutorial.title" = "CM Dokumente aus anderen Apps öffnen";

--- a/BankSDK/GiniBankSDKExample/GiniBankSDKExample/de.lproj/LocalizableCustomName.strings
+++ b/BankSDK/GiniBankSDKExample/GiniBankSDKExample/de.lproj/LocalizableCustomName.strings
@@ -33,3 +33,6 @@
 //"ginicapture.camera.capturedImagesStackLabel" = "CM Erfasste Dokumente";
 
 //"ginicapture.imagepicker.openbutton" = "CM Öffnen";
+
+//"ginicapture.multipagereview.addButtonLabel" = "CM Seiten hinzufügen";
+//"ginicapture.multipagereview.title" = "CM %d von %d";

--- a/BankSDK/GiniBankSDKExample/GiniBankSDKExample/de.lproj/LocalizableCustomName.strings
+++ b/BankSDK/GiniBankSDKExample/GiniBankSDKExample/de.lproj/LocalizableCustomName.strings
@@ -31,3 +31,5 @@
 //"ginicapture.camera.popupTitleImportPDForPhotos" = "CM Fotos oder PDF importieren";
 //"ginicapture.camera.popupCancel" = "CM Abbrechen";
 //"ginicapture.camera.capturedImagesStackLabel" = "CM Erfasste Dokumente";
+
+//"ginicapture.imagepicker.openbutton" = "CM Öffnen";

--- a/BankSDK/GiniBankSDKExample/GiniBankSDKExample/de.lproj/LocalizableCustomName.strings
+++ b/BankSDK/GiniBankSDKExample/GiniBankSDKExample/de.lproj/LocalizableCustomName.strings
@@ -46,3 +46,9 @@
 //"ginicapture.images.openWithTutorialStep3" = "openWithTutorialStep3";
 //
 //"ginicapture.albums.title" = "CM Alben";
+
+//"ginicapture.noresults.collection.header" = "CM Tipps für beste Ergebnisse:";
+//"ginicapture.noresults.warning" = "CM Es konnten keine Daten ausgelesen werden. Bitte Aufnahme wiederholen.";
+//"ginicapture.noresults.gotocamera" = "CM Zur Kamera";
+//"ginicapture.noresults.title" = "CM Tipps für Fotos";
+//"ginicapture.noresults.warningHelpMenu" = "CM Zur Erkennung aller Daten bitte folgende Tipps beim Abfotografieren beachten:";

--- a/BankSDK/GiniBankSDKExample/GiniBankSDKExample/de.lproj/LocalizableCustomName.strings
+++ b/BankSDK/GiniBankSDKExample/GiniBankSDKExample/de.lproj/LocalizableCustomName.strings
@@ -36,3 +36,13 @@
 
 //"ginicapture.multipagereview.addButtonLabel" = "CM Seiten hinzufügen";
 //"ginicapture.multipagereview.title" = "CM %d von %d";
+//"ginicapture.multipagereview.reorderContainerTooltipMessage" = "CM Die Seiten müssen in der richtigen Reihenfolge sein. Hier können Sie sie sortieren.";
+//"ginicapture.multipagereview.dragAndDropTip" = "CM Drag & Drop zum Sortieren";
+//"ginicapture.multipagereview.error.retakeAction" = "CM Wiederholung";
+//"ginicapture.multipagereview.error.retryAction" = "CM Wiederholen";
+//
+//"ginicapture.images.openWithTutorialStep1" = "openWithTutorialStep1";
+//"ginicapture.images.openWithTutorialStep2" = "openWithTutorialStep2";
+//"ginicapture.images.openWithTutorialStep3" = "openWithTutorialStep3";
+//
+//"ginicapture.albums.title" = "CM Alben";

--- a/BankSDK/GiniBankSDKExample/GiniBankSDKExample/en.lproj/LocalizableCustomName.strings
+++ b/BankSDK/GiniBankSDKExample/GiniBankSDKExample/en.lproj/LocalizableCustomName.strings
@@ -57,3 +57,20 @@
 //"ginicapture.noresults.gotocamera" = "CM Back to the camera";
 //"ginicapture.noresults.title" = "CM Tips for photos";
 //"ginicapture.noresults.warningHelpMenu" = "CM For best extraction results, please apply the following tips for photos:";
+
+//"ginicapture.help.supportedFormats.title" = "CM Supported formats";
+//"ginicapture.help.supportedFormats.section.1.title" = "CM The following formats are supported:";
+//"ginicapture.help.supportedFormats.section.1.item.1" = "CM Computer-generated invoices and remittance slips";
+//"ginicapture.help.supportedFormats.section.1.item.2" = "CM 1-sided photos of format jpeg, png or gif";
+//"ginicapture.help.supportedFormats.section.1.item.3" = "CM PDF documents of up to 10 pages";
+//"ginicapture.help.supportedFormats.section.1.item.4" = "CM QR Codes";
+//"ginicapture.help.supportedFormats.section.2.title" = "CM What is not supported:";
+//"ginicapture.help.supportedFormats.section.2.item.1" = "CM Handwriting";
+//"ginicapture.help.supportedFormats.section.2.item.2" = "CM Photos of monitors or screens";
+//
+//"ginicapture.help.menu.title" = "CM Help";
+//"ginicapture.help.menu.firstItem" = "CM Tips for best results from photos";
+//"ginicapture.help.menu.secondItem" = "CM Open document from other apps";
+//"ginicapture.help.menu.thirdItem" = "CM Supported formats";
+//
+//"ginicapture.help.openWithTutorial.title" = "CM Open documents from other apps";

--- a/BankSDK/GiniBankSDKExample/GiniBankSDKExample/en.lproj/LocalizableCustomName.strings
+++ b/BankSDK/GiniBankSDKExample/GiniBankSDKExample/en.lproj/LocalizableCustomName.strings
@@ -65,3 +65,4 @@
 //"ginicapture.help.menu.thirdItem" = "CM Supported formats";
 //
 //"ginicapture.help.openWithTutorial.title" = "CM Open documents from other apps";
+"close" = "Close";

--- a/BankSDK/GiniBankSDKExample/GiniBankSDKExample/en.lproj/LocalizableCustomName.strings
+++ b/BankSDK/GiniBankSDKExample/GiniBankSDKExample/en.lproj/LocalizableCustomName.strings
@@ -53,3 +53,9 @@
 //"ginicapture.images.openWithTutorialStep3" = "openWithTutorialStep3_en";
 //
 //"ginicapture.albums.title" = "CM Albums";
+
+//"ginicapture.noresults.collection.header" = " CM Tips for best results:";
+//"ginicapture.noresults.warning" = "CM No information could be extracted. Please take a new photo.";
+//"ginicapture.noresults.gotocamera" = "CM Back to the camera";
+//"ginicapture.noresults.title" = "CM Tips for photos";
+//"ginicapture.noresults.warningHelpMenu" = "CM For best extraction results, please apply the following tips for photos:";

--- a/BankSDK/GiniBankSDKExample/GiniBankSDKExample/en.lproj/LocalizableCustomName.strings
+++ b/BankSDK/GiniBankSDKExample/GiniBankSDKExample/en.lproj/LocalizableCustomName.strings
@@ -38,3 +38,5 @@
 //"ginicapture.camera.popupTitleImportPDForPhotos" = "CM Import Photos or PDF files";
 //"ginicapture.camera.popupCancel" = "CM Cancel";
 //"ginicapture.camera.capturedImagesStackLabel" = "CM Captured documents";
+
+//"ginicapture.imagepicker.openbutton" = "CM Open";

--- a/BankSDK/GiniBankSDKExample/GiniBankSDKExample/en.lproj/LocalizableCustomName.strings
+++ b/BankSDK/GiniBankSDKExample/GiniBankSDKExample/en.lproj/LocalizableCustomName.strings
@@ -32,3 +32,9 @@
 "ginibank.digitalinvoice.deselectreasonactionsheet.action.cancel" = "Yes, deselect it.";
 "ginicapture.review.documentImageTitle" = "Docs";
 "ginicapture.review.rotateButton" = "Rotate in 90 degrees";
+//"ginicapture.camera.popupTitleImportPDF" = "CM Import PDF";
+//"ginicapture.camera.popupOptionPhotos" = "CM Gallery";
+//"ginicapture.camera.popupOptionFiles" = "CM Documents";
+//"ginicapture.camera.popupTitleImportPDForPhotos" = "CM Import Photos or PDF files";
+//"ginicapture.camera.popupCancel" = "CM Cancel";
+//"ginicapture.camera.capturedImagesStackLabel" = "CM Captured documents";

--- a/BankSDK/GiniBankSDKExample/GiniBankSDKExample/en.lproj/LocalizableCustomName.strings
+++ b/BankSDK/GiniBankSDKExample/GiniBankSDKExample/en.lproj/LocalizableCustomName.strings
@@ -40,3 +40,6 @@
 //"ginicapture.camera.capturedImagesStackLabel" = "CM Captured documents";
 
 //"ginicapture.imagepicker.openbutton" = "CM Open";
+
+//"ginicapture.multipagereview.addButtonLabel" = "CM Add a page";
+//"ginicapture.multipagereview.title" = "CM %d of %d";

--- a/BankSDK/GiniBankSDKExample/GiniBankSDKExample/en.lproj/LocalizableCustomName.strings
+++ b/BankSDK/GiniBankSDKExample/GiniBankSDKExample/en.lproj/LocalizableCustomName.strings
@@ -1,16 +1,16 @@
-/* 
+/*
   Localizable.strings
-  GiniCapture
+  GiniBankExample
 
-  Created by Peter Pult on 16/06/16.
-  Copyright © 2016 Gini. All rights reserved.
+  Created by Nadzeya Karaban on 02/11/21.
+  Copyright © 2021 Gini. All rights reserved.
 */
 
 /*
- Gini Capture SDK
+ Gini Bank SDK
  ===================
  
- To easily customize texts in the Gini Capture SDK overwrite keys by your own definitions.
+ To easily customize texts in the Gini Bank SDK overwrite keys by your own definitions.
  For example to change the title of the camera add:
  ```
  "ginicapture.navigationbar.camera.title" = "Fotoüberweisung";
@@ -19,7 +19,6 @@
  All keys can be found in the `Localizable.strings` file in the Gini Capture SDK bundle
  or on [Github](https://github.com/gini/gini-capture-sdk-ios/blob/master/GiniCapture/Assets/Localizable.strings).
 */
-
 
 //"ginicapture.analysis.error.analysis" = "CM An error occurred while parsing the document.";
 //"ginicapture.camera.popupTitleImportPDF" = "CM Import PDF";

--- a/BankSDK/GiniBankSDKExample/GiniBankSDKExample/en.lproj/LocalizableCustomName.strings
+++ b/BankSDK/GiniBankSDKExample/GiniBankSDKExample/en.lproj/LocalizableCustomName.strings
@@ -20,16 +20,7 @@
  or on [Github](https://github.com/gini/gini-capture-sdk-ios/blob/master/GiniCapture/Assets/Localizable.strings).
 */
 
-"next" = "Weiter";
-"close" = "Close";
-"newDocument" = "New document";
-"help" = "Help";
-"analysisFailedErrorMessage" = "Dokumentanalyse fehlgeschlagen. Möchten Sie es erneut versuchen?";
-"ginicapture.navigationbar.camera.title"        = "Make a picture";
-"ginibank.digitalinvoice.deselectreasonactionsheet.message" = "Do you want to deselect?";
-"ginibank.digitalinvoice.deselectreasonactionsheet.action.cancel" = "Yes, deselect it.";
-"ginicapture.review.documentImageTitle" = "Docs";
-"ginicapture.review.rotateButton" = "Rotate in 90 degrees";
+
 //"ginicapture.analysis.error.analysis" = "CM An error occurred while parsing the document.";
 //"ginicapture.camera.popupTitleImportPDF" = "CM Import PDF";
 //"ginicapture.camera.popupOptionPhotos" = "CM Gallery";

--- a/BankSDK/GiniBankSDKExample/GiniBankSDKExample/en.lproj/LocalizableCustomName.strings
+++ b/BankSDK/GiniBankSDKExample/GiniBankSDKExample/en.lproj/LocalizableCustomName.strings
@@ -30,6 +30,7 @@
 "ginibank.digitalinvoice.deselectreasonactionsheet.action.cancel" = "Yes, deselect it.";
 "ginicapture.review.documentImageTitle" = "Docs";
 "ginicapture.review.rotateButton" = "Rotate in 90 degrees";
+//"ginicapture.analysis.error.analysis" = "CM An error occurred while parsing the document.";
 //"ginicapture.camera.popupTitleImportPDF" = "CM Import PDF";
 //"ginicapture.camera.popupOptionPhotos" = "CM Gallery";
 //"ginicapture.camera.popupOptionFiles" = "CM Documents";

--- a/BankSDK/GiniBankSDKExample/GiniBankSDKExample/en.lproj/LocalizableCustomName.strings
+++ b/BankSDK/GiniBankSDKExample/GiniBankSDKExample/en.lproj/LocalizableCustomName.strings
@@ -43,3 +43,13 @@
 
 //"ginicapture.multipagereview.addButtonLabel" = "CM Add a page";
 //"ginicapture.multipagereview.title" = "CM %d of %d";
+//"ginicapture.multipagereview.reorderContainerTooltipMessage" = "CM The pages must be in the right order. You can sort them here.";
+//"ginicapture.multipagereview.dragAndDropTip" = "CM Drag & Drop to sort";
+//"ginicapture.multipagereview.error.retakeAction" = "CM Retake";
+//"ginicapture.multipagereview.error.retryAction" = "CM Retry";
+//
+//"ginicapture.images.openWithTutorialStep1" = "openWithTutorialStep1_en";
+//"ginicapture.images.openWithTutorialStep2" = "openWithTutorialStep2_en";
+//"ginicapture.images.openWithTutorialStep3" = "openWithTutorialStep3_en";
+//
+//"ginicapture.albums.title" = "CM Albums";

--- a/BankSDK/GiniBankSDKExample/GiniBankSDKExample/en.lproj/LocalizableCustomName.strings
+++ b/BankSDK/GiniBankSDKExample/GiniBankSDKExample/en.lproj/LocalizableCustomName.strings
@@ -26,8 +26,6 @@
 "help" = "Help";
 "analysisFailedErrorMessage" = "Dokumentanalyse fehlgeschlagen. Möchten Sie es erneut versuchen?";
 "ginicapture.navigationbar.camera.title"        = "Make a picture";
-"ginicapture.noresults.warning" = "Warning";
-"ginicapture.noresults.collection.header" = "A new header";
 "ginibank.digitalinvoice.deselectreasonactionsheet.message" = "Do you want to deselect?";
 "ginibank.digitalinvoice.deselectreasonactionsheet.action.cancel" = "Yes, deselect it.";
 "ginicapture.review.documentImageTitle" = "Docs";

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Helpers/Localization/String Resources/AnalysisStrings.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Helpers/Localization/String Resources/AnalysisStrings.swift
@@ -47,16 +47,9 @@ public enum AnalysisStrings: LocalizableStringResource {
             return ("defaultPdfDokumentTitle", "Default PDF document title")
         }
     }
-    
+
     public var isCustomizable: Bool {
-        switch self {
-        case .cancelledMessage, .documentCreationErrorMessage, .loadingText, .pdfPages, .defaultPdfDokumentTitle,
-             .suggestion1Text, .suggestion2Text, .suggestion3Text, .suggestion4Text, .suggestion5Text,
-             .suggestionHeader:
-            return true
-        case .analysisErrorMessage:
-            return false
-        }
+        return true
     }
     
     public var fallbackTableEntry: String {

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Helpers/Localization/String Resources/CameraStrings.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Helpers/Localization/String Resources/CameraStrings.swift
@@ -98,18 +98,7 @@ enum CameraStrings: LocalizableStringResource {
     }
     
     var isCustomizable: Bool {
-        switch self {
-        case .captureButton, .captureFailedMessage, .errorPopupCancelButton,
-             .errorPopupGrantAccessButton, .errorPopupPickAnotherFileButton, .errorPopupReviewPagesButton,
-             .exceededFileSizeErrorMessage, .documentValidationGeneralErrorMessage,
-             .mixedArraysPopupCancelButton, .mixedArraysPopupUsePhotosButton, .mixedDocumentsErrorMessage,
-             .notAuthorizedButton, .notAuthorizedMessage, .photoLibraryAccessDeniedMessage, .qrCodeDetectedPopupMessage,
-             .qrCodeDetectedPopupButton, .tooManyPagesErrorMessage, .unknownErrorMessage, .wrongFormatErrorMessage, .unsupportedQrCodeDetectedPopupMessage, .fileImportTipLabel, .qrCodeTipLabel, .importFileButtonLabel, .failedToOpenDocumentErrorMessage:
-            return true
-        case .capturedImagesStackSubtitleLabel, .popupTitleImportPDF,
-             .popupTitleImportPDForPhotos, .popupOptionPhotos, .popupOptionFiles, .popupCancel:
-            return false
-        }
+        return true
     }
     
     var fallbackTableEntry: String {

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Helpers/Localization/String Resources/GalleryStrings.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Helpers/Localization/String Resources/GalleryStrings.swift
@@ -30,12 +30,7 @@ enum GalleryStrings: LocalizableStringResource {
     }
     
     var isCustomizable: Bool {
-        switch self {
-        case .albumsTitle:
-            return true
-        case .imagePickerOpenButton:
-            return false
-        }
+        return true
     }
     
     var fallbackTableEntry: String {

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Helpers/Localization/String Resources/HelpStrings.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Helpers/Localization/String Resources/HelpStrings.swift
@@ -68,17 +68,7 @@ enum HelpStrings: LocalizableStringResource {
     }
     
     var isCustomizable: Bool {
-        switch self {
-        case .openWithTutorialCollectionHeader, .openWithTutorialStep1Title, .openWithTutorialStep1Subtitle,
-             .openWithTutorialStep2Title, .openWithTutorialStep2Subtitle, .openWithTutorialStep3Title,
-             .openWithTutorialStep3Subtitle:
-            return true
-        case .menuTitle, .menuFirstItemText, .menuSecondItemText, .menuThirdItemText, .openWithTutorialTitle,
-             .supportedFormatsTitle, .supportedFormatsSection1Title, .supportedFormatsSection1Item1Text,
-             .supportedFormatsSection1Item2Text, .supportedFormatsSection1Item3Text, .supportedFormatsSection1Item4Text, .supportedFormatsSection2Title,
-             .supportedFormatsSection2Item1Text, .supportedFormatsSection2Item2Text:
-            return false
-        }
+        return true
     }
     
     var fallbackTableEntry: String {

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Helpers/Localization/String Resources/ImageAnalysisNoResultsStrings.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Helpers/Localization/String Resources/ImageAnalysisNoResultsStrings.swift
@@ -33,10 +33,7 @@ public enum ImageAnalysisNoResultsStrings: LocalizableStringResource {
     }
     
     public var isCustomizable: Bool {
-        switch self {
-        case .collectionHeaderText, .goToCameraButton, .titleText, .warningText, .warningHelpMenuText:
-            return false
-        }
+        return true
     }
     
     public var fallbackTableEntry: String {

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Helpers/Localization/String Resources/MultipageReviewStrings.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Helpers/Localization/String Resources/MultipageReviewStrings.swift
@@ -34,12 +34,7 @@ enum MultipageReviewStrings: LocalizableStringResource {
     }
     
     var isCustomizable: Bool {
-        switch self {
-        case .retakeActionButton, .retryActionButton, .reorderContainerTooltipMessage, .dragAndDropTipMessage:
-            return true
-        case .addButtonLabel, .titleMessage:
-            return false
-        }
+        return true
     }
     
     var fallbackTableEntry: String {

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Helpers/Localization/String Resources/NavigationBarStrings.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Helpers/Localization/String Resources/NavigationBarStrings.swift
@@ -29,10 +29,7 @@ enum NavigationBarStrings: LocalizableStringResource {
     }
     
     var isCustomizable: Bool {
-        switch self {
-        case .analysisTitle, .cameraTitle, .onboardingTitle, .reviewTitle:
-            return true
-        }
+        return true
     }
     
     var fallbackTableEntry: String {

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Helpers/Localization/String Resources/OnboardingStrings.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Helpers/Localization/String Resources/OnboardingStrings.swift
@@ -32,11 +32,7 @@ public enum OnboardingStrings: LocalizableStringResource {
     }
     
     public var isCustomizable: Bool {
-        switch self {
-        case .onboardingFirstPageText, .onboardingSecondPageText, .onboardingThirdPageText, .onboardingFourthPageText,
-             .onboardingFifthPageText:
-            return true
-        }
+        return true
     }
     
     public var fallbackTableEntry: String {

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Helpers/Localization/String Resources/ReviewStrings.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Helpers/Localization/String Resources/ReviewStrings.swift
@@ -35,10 +35,7 @@ enum ReviewStrings: LocalizableStringResource {
     }
     
     var isCustomizable: Bool {
-        switch self {
-        case .bottomText, .documentImageTitle, .rotateButton, .topText, .unknownErrorMessage:
-            return true
-        }
+        return true
     }
     
     var fallbackTableEntry: String {


### PR DESCRIPTION
- Allow text customising for capturedImagesStackSubtitleLabel, popupTitleImportPDF, popupTitleImportPDForPhotos, popupOptionPhotos, popupOptionFiles, popupCancel on the camera screen.
- Allow text customising for imagePickerOpenButton on the gallery screen.
- Allow text customising for addButtonLabel, navigation titleMessage on the multipage review screen.
- Allow text customising for collectionHeaderText, goToCameraButton, warningText
on the no results screen and warningHelpMenuText and titleText for the capturing tips screen.
- Allow text customisation for supported formats screen and title for the open with screen.
- Fix default analysis error text for the analysis screen.
- Remove duplicated text customization options for menu items.
- Remove duplicated customization options for reorderContainerTooltipMessage, dragAndDropTip, retakeAction and retryAction on the multipage review screen.
albums title on the albums screen and openButton title for image picker; images assets names for the onboarding screens.
- Remove duplicated customization options for addButtonLabel, navigation titleMessage on the multipage review screen.


