### PR TITLE
PIA-2781 pay button

### DIFF
--- a/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/ReturnAssistant/DigitalInvoiceViewController.swift
+++ b/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/ReturnAssistant/DigitalInvoiceViewController.swift
@@ -70,7 +70,8 @@ public class DigitalInvoiceViewController: UIViewController {
     private var didShowOnboardInCurrentSession = false
     private var didShowInfoViewInCurrentSession = false
     private var toggleUIUpdates = false
-    
+    private let vm = DigitalInvoiceViewModel()
+
     fileprivate func configureTableView() {
         tableView.delegate = self
         tableView.dataSource = self
@@ -141,21 +142,6 @@ public class DigitalInvoiceViewController: UIViewController {
         
         guard let invoice = invoice else { return }
         delegate?.didFinish(viewController: self, invoice: invoice)
-    }
-    
-    private func payButtonTitle(
-        isEnabled: Bool = false,
-        numSelected: Int,
-        numTotal: Int
-    ) -> String {
-
-        if isEnabled {
-            return String.localizedStringWithFormat(
-                DigitalInvoiceStrings.payButtonTitle.localizedGiniBankFormat,
-                numSelected,
-                numTotal)
-        }
-        return .ginibankLocalized(resource: DigitalInvoiceStrings.noInvoicePayButtonTitle)
     }
     
     private func payButtonAccessibilityLabel() -> String {
@@ -356,9 +342,9 @@ extension DigitalInvoiceViewController: UITableViewDelegate, UITableViewDataSour
             cell.payButton.addTarget(self, action: #selector(payButtonTapped), for: .touchUpInside)
             if let invoice = invoice {
                 let total = invoice.total?.value ?? 0
-                let shouldEnablePayButton = total > 0
+                let shouldEnablePayButton = vm.isPayButtonEnabled(total: total)
                 cell.enableButtons(shouldEnablePayButton)
-                let buttonTitle = payButtonTitle(
+                let buttonTitle = vm.payButtonTitle(
                     isEnabled: shouldEnablePayButton,
                     numSelected: invoice.numSelected,
                     numTotal: invoice.numTotal
@@ -370,7 +356,7 @@ extension DigitalInvoiceViewController: UITableViewDelegate, UITableViewDataSour
                 cell.skipButton.setTitle(skipButtonTitle(), for: .normal)
                 cell.skipButton.addTarget(self, action: #selector(skipButtonTapped), for: .touchUpInside)
             } else {
-                let buttonTitle = payButtonTitle(
+                let buttonTitle = vm.payButtonTitle(
                     isEnabled: false,
                     numSelected: 0,
                     numTotal: 0

--- a/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/ReturnAssistant/DigitalInvoiceViewController.swift
+++ b/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/ReturnAssistant/DigitalInvoiceViewController.swift
@@ -143,17 +143,19 @@ public class DigitalInvoiceViewController: UIViewController {
         delegate?.didFinish(viewController: self, invoice: invoice)
     }
     
-    private func payButtonTitle() -> String {
-        
-        guard let invoice = invoice else {
-            return .ginibankLocalized(resource: DigitalInvoiceStrings.noInvoicePayButtonTitle)
+    private func payButtonTitle(
+        isEnabled: Bool = false,
+        numSelected: Int,
+        numTotal: Int
+    ) -> String {
+
+        if isEnabled {
+            return String.localizedStringWithFormat(
+                DigitalInvoiceStrings.payButtonTitle.localizedGiniBankFormat,
+                numSelected,
+                numTotal)
         }
-        if invoice.numSelected == 0 {
-            return .ginibankLocalized(resource: DigitalInvoiceStrings.noInvoicePayButtonTitle)
-        }
-        return String.localizedStringWithFormat(DigitalInvoiceStrings.payButtonTitle.localizedGiniBankFormat,
-                                                invoice.numSelected,
-                                                invoice.numTotal)
+        return .ginibankLocalized(resource: DigitalInvoiceStrings.noInvoicePayButtonTitle)
     }
     
     private func payButtonAccessibilityLabel() -> String {
@@ -347,22 +349,33 @@ extension DigitalInvoiceViewController: UITableViewDelegate, UITableViewDataSour
             return cell
             
         case .footer:
-            
             let cell = tableView.dequeueReusableCell(withIdentifier: "DigitalInvoiceFooterCell",
                                                      for: indexPath) as! DigitalInvoiceFooterCell
-            
             cell.returnAssistantConfiguration = returnAssistantConfiguration
-
-            cell.payButton.setTitle(payButtonTitle(), for: .normal)
             cell.payButton.accessibilityLabel = payButtonAccessibilityLabel()
             cell.payButton.addTarget(self, action: #selector(payButtonTapped), for: .touchUpInside)
             if let invoice = invoice {
                 let total = invoice.total?.value ?? 0
-                let shouldEnablePayButton = invoice.numSelected > 0 || total > 0
+                let shouldEnablePayButton = total > 0
                 cell.enableButtons(shouldEnablePayButton)
+                let buttonTitle = payButtonTitle(
+                    isEnabled: shouldEnablePayButton,
+                    numSelected: invoice.numSelected,
+                    numTotal: invoice.numTotal
+                )
+                cell.payButton.setTitle(
+                    buttonTitle,
+                    for: .normal)
                 cell.shouldSetUIForInaccurateResults(invoice.inaccurateResults)
                 cell.skipButton.setTitle(skipButtonTitle(), for: .normal)
                 cell.skipButton.addTarget(self, action: #selector(skipButtonTapped), for: .touchUpInside)
+            } else {
+                let buttonTitle = payButtonTitle(
+                    isEnabled: false,
+                    numSelected: 0,
+                    numTotal: 0
+                )
+                cell.payButton.setTitle(buttonTitle, for: .normal)
             }
             return cell
             

--- a/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/ReturnAssistant/DigitalInvoiceViewModel.swift
+++ b/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/ReturnAssistant/DigitalInvoiceViewModel.swift
@@ -18,7 +18,7 @@ final class DigitalInvoiceViewModel {
         numTotal: Int
     ) -> String {
 
-        if isEnabled {
+        if isEnabled && numSelected != 0 {
             return String.localizedStringWithFormat(
                 DigitalInvoiceStrings.payButtonTitle.localizedGiniBankFormat,
                 numSelected,

--- a/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/ReturnAssistant/DigitalInvoiceViewModel.swift
+++ b/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/ReturnAssistant/DigitalInvoiceViewModel.swift
@@ -1,0 +1,29 @@
+//
+//  DigitalInvoiceViewModel.swift
+//  GiniBank
+//
+//  Created by Krzysztof Kryniecki on 18/07/2022.
+//
+
+import Foundation
+
+final class DigitalInvoiceViewModel {
+    func isPayButtonEnabled(total: Decimal) -> Bool {
+        return total > 0
+    }
+    
+    func payButtonTitle(
+        isEnabled: Bool = false,
+        numSelected: Int,
+        numTotal: Int
+    ) -> String {
+
+        if isEnabled {
+            return String.localizedStringWithFormat(
+                DigitalInvoiceStrings.payButtonTitle.localizedGiniBankFormat,
+                numSelected,
+                numTotal)
+        }
+        return .ginibankLocalized(resource: DigitalInvoiceStrings.noInvoicePayButtonTitle)
+    }
+}

--- a/BankSDK/GiniBankSDK/Tests/GiniBankSDKTests/String+UtilsTests.swift
+++ b/BankSDK/GiniBankSDK/Tests/GiniBankSDKTests/String+UtilsTests.swift
@@ -1,6 +1,6 @@
 //
 //  String+UtilsTests.swift
-//  
+//
 //
 //  Created by Nadya Karaban on 05.11.21.
 //
@@ -55,7 +55,7 @@ final class StringUtilsTests: XCTestCase {
         let amountToPay = "28.10:EUR"
         var giniBankError = GiniBankError.amountParsingError(amountString: "")
         do {
-            try String.parseAmountStringToBackendFormat(string: amountToPay)
+            _ = try String.parseAmountStringToBackendFormat(string: amountToPay)
         } catch let error {
             giniBankError = error as! GiniBankError
         }
@@ -83,5 +83,51 @@ final class StringUtilsTests: XCTestCase {
             let formatStr = Price.formatAmountString(newText: "24007.31")
             XCTAssertEqual(formatStr, "24,007.31")
         }
+    }
+    
+    func testEnablingPayButtonWithoutAmount() {
+        let vm = DigitalInvoiceViewModel()
+        let totalAmount: Decimal = 0
+        let isEnabled = vm.isPayButtonEnabled(total: totalAmount)
+        XCTAssertEqual(isEnabled, false)
+    }
+    
+    func testEnablingPayButtonWithAmount() {
+        let vm = DigitalInvoiceViewModel()
+        let totalAmount: Decimal = 123
+        let isEnabled = vm.isPayButtonEnabled(total: totalAmount)
+        XCTAssertEqual(isEnabled, true)
+    }
+    
+    func testPayButtonDisabledTitle() {
+        let vm = DigitalInvoiceViewModel()
+        let totalItems = 3
+        let isEnabled = false
+        let title = vm.payButtonTitle(isEnabled: isEnabled, numSelected: 0, numTotal: totalItems)
+        XCTAssertEqual(title, "Pay")
+    }
+    
+    func testPayButtonEnabledItemsZeroTotalTitle() {
+        let vm = DigitalInvoiceViewModel()
+        let totalItems = 3
+        let isEnabled = false
+        let title = vm.payButtonTitle(isEnabled: isEnabled, numSelected: 3, numTotal: totalItems)
+        XCTAssertEqual(title, "Pay")
+    }
+    
+    func testPayButtonEnabled2ItemsTotalPositiveTitle() {
+        let vm = DigitalInvoiceViewModel()
+        let totalItems = 3
+        let isEnabled = true
+        let title = vm.payButtonTitle(isEnabled: isEnabled, numSelected: 3, numTotal: totalItems)
+        XCTAssertEqual(title, "Pay 3/3")
+    }
+    
+    func testPayButtonEnabled0ItemsTotalPositiveTitle() {
+        let vm = DigitalInvoiceViewModel()
+        let totalItems = 3
+        let isEnabled = true
+        let title = vm.payButtonTitle(isEnabled: isEnabled, numSelected: 0, numTotal: totalItems)
+        XCTAssertEqual(title, "Pay")
     }
 }


### PR DESCRIPTION
- Pay button is disabled when total amount is 0, irrelevant of how many items are selected.
- When button is disabled the label should be just “Pay”.
- the pay button is just 'Pay' when 0 items selected and there is a amount greater than 0