### PR TITLE
Merge pull request #111 from gini/PIA-2781_pay_button

### DIFF
--- a/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/ReturnAssistant/DigitalInvoiceViewController.swift
+++ b/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/ReturnAssistant/DigitalInvoiceViewController.swift
@@ -70,7 +70,8 @@ public class DigitalInvoiceViewController: UIViewController {
     private var didShowOnboardInCurrentSession = false
     private var didShowInfoViewInCurrentSession = false
     private var toggleUIUpdates = false
-    
+    private let vm = DigitalInvoiceViewModel()
+
     fileprivate func configureTableView() {
         tableView.delegate = self
         tableView.dataSource = self
@@ -345,22 +346,33 @@ extension DigitalInvoiceViewController: UITableViewDelegate, UITableViewDataSour
             return cell
             
         case .footer:
-            
             let cell = tableView.dequeueReusableCell(withIdentifier: "DigitalInvoiceFooterCell",
                                                      for: indexPath) as! DigitalInvoiceFooterCell
-            
             cell.returnAssistantConfiguration = returnAssistantConfiguration
-
-            cell.payButton.setTitle(payButtonTitle(), for: .normal)
             cell.payButton.accessibilityLabel = payButtonAccessibilityLabel()
             cell.payButton.addTarget(self, action: #selector(payButtonTapped), for: .touchUpInside)
             if let invoice = invoice {
                 let total = invoice.total?.value ?? 0
-                let shouldEnablePayButton = invoice.numSelected > 0 || total > 0
+                let shouldEnablePayButton = vm.isPayButtonEnabled(total: total)
                 cell.enableButtons(shouldEnablePayButton)
+                let buttonTitle = vm.payButtonTitle(
+                    isEnabled: shouldEnablePayButton,
+                    numSelected: invoice.numSelected,
+                    numTotal: invoice.numTotal
+                )
+                cell.payButton.setTitle(
+                    buttonTitle,
+                    for: .normal)
                 cell.shouldSetUIForInaccurateResults(invoice.inaccurateResults)
                 cell.skipButton.setTitle(skipButtonTitle(), for: .normal)
                 cell.skipButton.addTarget(self, action: #selector(skipButtonTapped), for: .touchUpInside)
+            } else {
+                let buttonTitle = vm.payButtonTitle(
+                    isEnabled: false,
+                    numSelected: 0,
+                    numTotal: 0
+                )
+                cell.payButton.setTitle(buttonTitle, for: .normal)
             }
             return cell
             

--- a/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/ReturnAssistant/DigitalInvoiceViewModel.swift
+++ b/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/ReturnAssistant/DigitalInvoiceViewModel.swift
@@ -1,0 +1,32 @@
+//
+//  DigitalInvoiceViewModel.swift
+//  GiniBank
+//
+//  Created by Krzysztof Kryniecki on 18/07/2022.
+//
+
+import Foundation
+
+final class DigitalInvoiceViewModel {
+    func isPayButtonEnabled(total: Decimal) -> Bool {
+        return total > 0
+    }
+    
+    func payButtonTitle(
+        isEnabled: Bool = false,
+        numSelected: Int,
+        numTotal: Int
+    ) -> String {
+
+        if isEnabled && numSelected != 0 {
+            return String.localizedStringWithFormat(
+                DigitalInvoiceStrings.payButtonTitle.localizedGiniBankFormat,
+                numSelected,
+                numTotal)
+        }
+        if numSelected == 0 {
+            return .ginibankLocalized(resource: DigitalInvoiceStrings.payButtonOtherCharges)
+        }
+        return .ginibankLocalized(resource: DigitalInvoiceStrings.disabledPayButtonTitle)
+    }
+}

--- a/BankSDK/GiniBankSDK/Tests/GiniBankSDKTests/String+UtilsTests.swift
+++ b/BankSDK/GiniBankSDK/Tests/GiniBankSDKTests/String+UtilsTests.swift
@@ -1,6 +1,6 @@
 //
 //  String+UtilsTests.swift
-//  
+//
 //
 //  Created by Nadya Karaban on 05.11.21.
 //
@@ -55,7 +55,7 @@ final class StringUtilsTests: XCTestCase {
         let amountToPay = "28.10:EUR"
         var giniBankError = GiniBankError.amountParsingError(amountString: "")
         do {
-            try String.parseAmountStringToBackendFormat(string: amountToPay)
+            _ = try String.parseAmountStringToBackendFormat(string: amountToPay)
         } catch let error {
             giniBankError = error as! GiniBankError
         }
@@ -83,5 +83,57 @@ final class StringUtilsTests: XCTestCase {
             let formatStr = Price.formatAmountString(newText: "24007.31")
             XCTAssertEqual(formatStr, "24,007.31")
         }
+    }
+    
+    func testEnablingPayButtonWithoutAmount() {
+        let vm = DigitalInvoiceViewModel()
+        let totalAmount: Decimal = 0
+        let isEnabled = vm.isPayButtonEnabled(total: totalAmount)
+        XCTAssertEqual(isEnabled, false)
+    }
+    
+    func testEnablingPayButtonWithAmount() {
+        let vm = DigitalInvoiceViewModel()
+        let totalAmount: Decimal = 123
+        let isEnabled = vm.isPayButtonEnabled(total: totalAmount)
+        XCTAssertEqual(isEnabled, true)
+    }
+    
+    func testPayButtonDisabledTitle() {
+        let vm = DigitalInvoiceViewModel()
+        let totalItems = 3
+        let isEnabled = false
+        let title = vm.payButtonTitle(isEnabled: isEnabled, numSelected: 0, numTotal: totalItems)
+        XCTAssertEqual(title,  .ginibankLocalized(resource: DigitalInvoiceStrings.disabledPayButtonTitle)
+)
+    }
+    
+    func testPayButtonEnabledItemsZeroTotalTitle() {
+        let vm = DigitalInvoiceViewModel()
+        let totalItems = 3
+        let isEnabled = false
+        let title = vm.payButtonTitle(isEnabled: isEnabled, numSelected: 3, numTotal: totalItems)
+        XCTAssertEqual(title, .ginibankLocalized(resource: DigitalInvoiceStrings.disabledPayButtonTitle))
+    }
+    
+    func testPayButtonEnabled2ItemsTotalPositiveTitle() {
+        let vm = DigitalInvoiceViewModel()
+        let totalItems = 3
+        let isEnabled = true
+        let title = vm.payButtonTitle(isEnabled: isEnabled, numSelected: 3, numTotal: totalItems)
+        XCTAssertEqual(
+            title,
+            String.localizedStringWithFormat(
+                DigitalInvoiceStrings.payButtonTitle.localizedGiniBankFormat,
+                3,
+                3))
+    }
+    
+    func testPayButtonEnabled0ItemsTotalPositiveTitle() {
+        let vm = DigitalInvoiceViewModel()
+        let totalItems = 3
+        let isEnabled = vm.isPayButtonEnabled(total: 23.03)
+        let title = vm.payButtonTitle(isEnabled: isEnabled, numSelected: 0, numTotal: totalItems)
+        XCTAssertEqual(title, .ginibankLocalized(resource: DigitalInvoiceStrings.payButtonOtherCharges))
     }
 }

--- a/BankSDK/GiniBankSDKExample/GiniBankSDKExample/Credentials.plist
+++ b/BankSDK/GiniBankSDKExample/GiniBankSDKExample/Credentials.plist
@@ -5,8 +5,8 @@
 	<key>client_domain</key>
 	<string>gini.net</string>
 	<key>client_password</key>
-	<string>***</string>
+    <string>***</string>
 	<key>client_id</key>
-	<string>***</string>
+    <string>***</string>
 </dict>
 </plist>


### PR DESCRIPTION
Pay button is disabled when total amount is 0, irrelevant of how many items are selected.
When button is disabled the label should be just “Pay”.
the pay button is just 'Pay' when 0 items selected and there is a amount greater than 0