### PR TITLE
PIA-2903 pr

### DIFF
--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Camera/Camera.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Camera/Camera.swift
@@ -303,25 +303,6 @@ extension Camera: AVCaptureMetadataOutputObjectsDelegate {
 // MARK: - AVCapturePhotoCaptureDelegate
 
 extension Camera: AVCapturePhotoCaptureDelegate {
-    //swiftlint:disable function_parameter_count
-    func photoOutput(_ output: AVCapturePhotoOutput,
-                     didFinishProcessingPhoto photoSampleBuffer: CMSampleBuffer?,
-                     previewPhoto previewPhotoSampleBuffer: CMSampleBuffer?,
-                     resolvedSettings: AVCaptureResolvedPhotoSettings,
-                     bracketSettings: AVCaptureBracketedStillImageSettings?,
-                     error: Error?) {
-        guard let buffer = photoSampleBuffer,
-            let imageData = AVCapturePhotoOutput
-                .jpegPhotoDataRepresentation(forJPEGSampleBuffer: buffer,
-                                             previewPhotoSampleBuffer: previewPhotoSampleBuffer),
-            error == nil else {
-                didCaptureImageHandler?(nil, .captureFailed)
-                return
-        }
-        
-        didCaptureImageHandler?(imageData, nil)
-    }
-    
     func photoOutput(_ output: AVCapturePhotoOutput, didFinishProcessingPhoto photo: AVCapturePhoto, error: Error?){
         if error != nil {
             didCaptureImageHandler?(nil, .captureFailed)


### PR DESCRIPTION
CameraViewController - Remove deprecated delegate function

The function I deleted is deprecated and not used according to the [Apple documentation](https://developer.apple.com/documentation/avfoundation/avcapturephotocapturedelegate/1778647-photooutput)

