### PR TITLE
fix(GiniBankSDK): Allows change warning icon color on the No Results …

### DIFF
--- a/BankSDK/GiniBankSDKExample/GiniBankSDKExample/AppCoordinator.swift
+++ b/BankSDK/GiniBankSDKExample/GiniBankSDKExample/AppCoordinator.swift
@@ -48,6 +48,7 @@ final class AppCoordinator: Coordinator {
             }
             return CustomDocumentValidationResult.success()
         }
+//        configuration.noResultsWarningContainerIconColor = .cyan
 //        let customMenuItem = HelpMenuViewController.Item.custom("Custom menu item", CustomMenuItemViewController())
 //        configuration.customMenuItems = [customMenuItem]
 //        configuration.albumsScreenSelectMorePhotosTextColor = GiniColor(lightModeColor: .systemBlue, darkModeColor: .systemBlue)

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Help/No results/ImageAnalysisNoResultsViewController.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Help/No results/ImageAnalysisNoResultsViewController.swift
@@ -97,7 +97,9 @@ public final class ImageAnalysisNoResultsViewController: UIViewController {
         self.title = title
         self.subHeaderTitle = subHeaderText
         self.topViewText = topViewText
-        self.topViewIcon = topViewIcon
+        if let topViewIcon = topViewIcon {
+            self.topViewIcon = topViewIcon.tintedImageWithColor(giniConfiguration.noResultsWarningContainerIconColor)
+        }
         self.bottomButtonText = bottomButtonText
         self.bottomButtonIconImage = bottomButtonIcon
     }


### PR DESCRIPTION
 - Allows change warning icon color on the No Results screen.

 - Update example.

[PIA-3075](https://ginis.atlassian.net/browse/PIA-3075)