### PR TITLE
Pia 3182 add a loading indicator for the last added page on the analysis screen

### DIFF
--- a/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/GiniBankConfiguration.swift
+++ b/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/GiniBankConfiguration.swift
@@ -353,6 +353,11 @@ public final class GiniBankConfiguration: NSObject {
     public var onboardingNavigationBarBottomAdapter: OnboardingNavigationBarBottomAdapter?
 
     /**
+     * Set an adapter implementation to show a custom loading indicator on the buttons which support loading.
+     */
+    public var onButtonLoadingIndicator: OnButtonLoadingIndicatorAdapter?
+
+    /**
      Sets the back button text in the navigation bar on the review screen. Use this if you only want to show the title.
      
      - note: Screen API only.
@@ -1295,6 +1300,7 @@ public final class GiniBankConfiguration: NSObject {
         configuration.onboardingTextColor = self.onboardingTextColor
         configuration.onboardingScreenBackgroundColor = self.onboardingScreenBackgroundColor
         configuration.onboardingNavigationBarBottomAdapter = self.onboardingNavigationBarBottomAdapter
+        configuration.onButtonLoadingIndicator = self.onButtonLoadingIndicator
         
         configuration.navigationBarReviewTitleBackButton = self.navigationBarReviewTitleBackButton
         configuration.navigationBarReviewTitleCloseButton = self.navigationBarReviewTitleCloseButton

--- a/BankSDK/GiniBankSDKExample/GiniBankSDKExample/AppCoordinator.swift
+++ b/BankSDK/GiniBankSDKExample/GiniBankSDKExample/AppCoordinator.swift
@@ -84,9 +84,14 @@ final class AppCoordinator: Coordinator {
 //    configuration.primaryButtonShadowOpacity = 0.7
 //    configuration.primaryButtonCornerRadius = 10
 
-        // Custom loading indicator customization example
+//       //  Custom loading indicator customization example for the analysis screen
 //        let customLoadingIndicator = CustomLoadingIndicator()
 //        configuration.analysisScreenLoadingIndicator = customLoadingIndicator
+
+//      // Custom loading indicator customization example for the on button laoding indicator
+//        let customButtonLoadingIndicator = OnButtonLoading()
+//        configuration.onButtonLoadingIndicator = customButtonLoadingIndicator
+        
         // Custom navigation view controller
 //        let navigationViewController = UINavigationController()
 //        navigationViewController.navigationBar.backgroundColor = GiniColor(light: .purple, dark: .lightGray).uiColor()

--- a/BankSDK/GiniBankSDKExample/GiniBankSDKExample/CustomLoadingIndicator.swift
+++ b/BankSDK/GiniBankSDKExample/GiniBankSDKExample/CustomLoadingIndicator.swift
@@ -32,3 +32,27 @@ public final class CustomLoadingIndicator: UIActivityIndicatorView, AnalysisScre
 
     }
 }
+
+public final class OnButtonLoading: UIActivityIndicatorView, OnButtonLoadingIndicatorAdapter {
+    public func startAnimation() {
+        self.startAnimating()
+    }
+
+    public func stopAnimation() {
+        self.stopAnimating()
+    }
+
+    public func injectedView() -> UIView {
+        if #available(iOS 13.0, *) {
+            self.style = .large
+        }
+        self.color = .red
+        self.startAnimating()
+
+        return self
+    }
+
+    public func onDeinit() {
+
+    }
+}

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/GiniConfiguration.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/GiniConfiguration.swift
@@ -554,6 +554,11 @@ import UIKit
      * Set an adapter implementation to show a custom loading indicator on the document analysis screen.
      */
     public var analysisScreenLoadingIndicator: AnalysisScreenLoadingIndicatorAdapter?
+
+    /**
+     * Set an adapter implementation to show a custom loading indicator on the buttons which support loading.
+     */
+    public var onButtonLoadingIndicator: OnButtonLoadingIndicatorAdapter?
     
     /**
      Sets the back button text in the navigation bar on the review screen. Use this if you only want to show the title.

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Review/OnButtonLoadingIndicatorAdapter.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Review/OnButtonLoadingIndicatorAdapter.swift
@@ -1,0 +1,22 @@
+//
+//  OnButtonLoadingIndicatorAdapter.swift
+//  
+//
+//  Created by David Vizaknai on 19.10.2022.
+//
+
+import Foundation
+import UIKit
+/**
+*   Adapter for injecting a custom loading indicator on top of buttons.
+*/
+public protocol OnButtonLoadingIndicatorAdapter: InjectedViewAdapter {
+    /**
+     *  Called when the ther is loading in the background. You should start the loading indicator animation in this method.
+     */
+    func startAnimation()
+    /**
+     *  Called when the loading is finished. You should stop the loading indicator animation in this method.
+     */
+    func stopAnimation()
+}

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Review/ReviewViewController.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Review/ReviewViewController.swift
@@ -213,7 +213,6 @@ extension ReviewViewController {
         setupView()
         addConstraints()
         addLoadingView()
-        showAnimation()
     }
 
     public override func viewDidAppear(_ animated: Bool) {
@@ -314,19 +313,21 @@ extension ReviewViewController {
      */
 
     public func updateCollections(with pages: [GiniCapturePage], finishedUpload: Bool = true) {
-        if finishedUpload {
-            DispatchQueue.main.async {
-                self.processButton.alpha = 1
-                self.processButton.isEnabled = true
-                self.hideAnimation()
+        if giniConfiguration.multipageEnabled {
+            if finishedUpload {
+                DispatchQueue.main.async {
+                    self.processButton.alpha = 1
+                    self.processButton.isEnabled = true
+                    self.hideAnimation()
+                }
+                return
             }
-            return
-        }
 
-        DispatchQueue.main.async {
-            self.processButton.alpha = 0.3
-            self.processButton.isEnabled = false
-            self.showAnimation()
+            DispatchQueue.main.async {
+                self.processButton.alpha = 0.3
+                self.processButton.isEnabled = false
+                self.showAnimation()
+            }
         }
         self.pages = pages
         collectionView.reloadData()

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Review/ReviewViewController.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Review/ReviewViewController.swift
@@ -173,7 +173,8 @@ public final class ReviewViewController: UIViewController {
     private var loadingIndicatorView: UIActivityIndicatorView = {
         let indicatorView = UIActivityIndicatorView()
         indicatorView.hidesWhenStopped = true
-        indicatorView.style = .white
+        indicatorView.style = .whiteLarge
+        indicatorView.color = GiniColor(light: UIColor.GiniCapture.dark3, dark: UIColor.GiniCapture.light3).uiColor()
         return indicatorView
     }()
 
@@ -272,7 +273,7 @@ extension ReviewViewController {
     private func addLoadingView() {
         let loadingIndicator: UIView
 
-        if let customLoadingIndicator = giniConfiguration.analysisScreenLoadingIndicator?.injectedView() {
+        if let customLoadingIndicator = giniConfiguration.onButtonLoadingIndicator?.injectedView() {
             loadingIndicator = customLoadingIndicator
         } else {
             loadingIndicator = loadingIndicatorView
@@ -285,13 +286,13 @@ extension ReviewViewController {
         NSLayoutConstraint.activate([
             loadingIndicator.centerXAnchor.constraint(equalTo: processButton.centerXAnchor),
             loadingIndicator.centerYAnchor.constraint(equalTo: processButton.centerYAnchor),
-            loadingIndicator.widthAnchor.constraint(equalToConstant: 30),
-            loadingIndicator.heightAnchor.constraint(equalToConstant: 30)
+            loadingIndicator.widthAnchor.constraint(equalToConstant: 45),
+            loadingIndicator.heightAnchor.constraint(equalToConstant: 45)
         ])
     }
 
     private func showAnimation() {
-        if let loadingIndicator = giniConfiguration.analysisScreenLoadingIndicator {
+        if let loadingIndicator = giniConfiguration.onButtonLoadingIndicator {
             loadingIndicator.startAnimation()
         } else {
             loadingIndicatorView.startAnimating()
@@ -299,7 +300,7 @@ extension ReviewViewController {
     }
 
     private func hideAnimation() {
-        if let loadingIndicator = giniConfiguration.analysisScreenLoadingIndicator {
+        if let loadingIndicator = giniConfiguration.onButtonLoadingIndicator {
             loadingIndicator.stopAnimation()
         } else {
             loadingIndicatorView.stopAnimating()

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Review/ReviewViewController.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Review/ReviewViewController.swift
@@ -267,6 +267,18 @@ extension ReviewViewController {
         edgesForExtendedLayout = []
     }
 
+    private func updateButtonTitle() {
+        if pages.count > 1 {
+            processButton.setTitle(
+                NSLocalizedStringPreferredFormat("ginicapture.multipagereview.mainButtonTitle.plural",
+                                                 comment: "Process button title"), for: .normal)
+        } else {
+            processButton.setTitle(
+                NSLocalizedStringPreferredFormat("ginicapture.multipagereview.mainButtonTitle.singular",
+                                                 comment: "Process button title"), for: .normal)
+        }
+    }
+
     // MARK: - Loading indicator
 
     private func addLoadingView() {
@@ -313,22 +325,23 @@ extension ReviewViewController {
      */
 
     public func updateCollections(with pages: [GiniCapturePage], finishedUpload: Bool = true) {
-        if giniConfiguration.multipageEnabled {
-            if finishedUpload {
-                DispatchQueue.main.async {
+        DispatchQueue.main.async {
+            self.updateButtonTitle()
+
+            if self.giniConfiguration.multipageEnabled {
+                if finishedUpload {
                     self.processButton.alpha = 1
                     self.processButton.isEnabled = true
                     self.hideAnimation()
+                    return
                 }
-                return
-            }
 
-            DispatchQueue.main.async {
                 self.processButton.alpha = 0.3
                 self.processButton.isEnabled = false
                 self.showAnimation()
             }
         }
+
         self.pages = pages
         collectionView.reloadData()
 
@@ -449,6 +462,7 @@ extension ReviewViewController {
         let pageToDelete = pages[indexPath.row]
         pages.remove(at: indexPath.row)
         collectionView.deleteItems(at: [indexPath])
+        updateButtonTitle()
         delegate?.review(self, didDelete: pageToDelete)
     }
 }

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Screen API Coordinator/GiniScreenAPICoordinator.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Screen API Coordinator/GiniScreenAPICoordinator.swift
@@ -193,7 +193,7 @@ extension GiniScreenAPICoordinator {
         self.pages.append(contentsOf: pages)
 
         if pages.type == .image {
-            reviewViewController.updateCollections(with: self.pages)
+            reviewViewController.updateCollections(with: self.pages, finishedUpload: false)
         }
     }
 
@@ -214,7 +214,7 @@ extension GiniScreenAPICoordinator {
         }
 
         if giniConfiguration.multipageEnabled, pages.type == .image {
-            reviewViewController.updateCollections(with: pages)
+            reviewViewController.updateCollections(with: self.pages, finishedUpload: true)
         }
     }
 

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Screen API Coordinator/GiniScreenAPICoordinator.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Screen API Coordinator/GiniScreenAPICoordinator.swift
@@ -214,10 +214,7 @@ extension GiniScreenAPICoordinator {
         }
 
         if pages.type == .image {
-            DispatchQueue.main.asyncAfter(deadline: .now() + 2, execute: {
-                self.reviewViewController.updateCollections(with: self.pages, finishedUpload: true)
-            })
-
+            reviewViewController.updateCollections(with: self.pages, finishedUpload: true)
         }
     }
 

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Screen API Coordinator/GiniScreenAPICoordinator.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Screen API Coordinator/GiniScreenAPICoordinator.swift
@@ -213,8 +213,11 @@ extension GiniScreenAPICoordinator {
             pages[index].error = error
         }
 
-        if giniConfiguration.multipageEnabled, pages.type == .image {
-            reviewViewController.updateCollections(with: self.pages, finishedUpload: true)
+        if pages.type == .image {
+            DispatchQueue.main.asyncAfter(deadline: .now() + 2, execute: {
+                self.reviewViewController.updateCollections(with: self.pages, finishedUpload: true)
+            })
+
         }
     }
 

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Resources/de.lproj/Localizable.strings
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Resources/de.lproj/Localizable.strings
@@ -149,7 +149,8 @@ conveniently drag-and-drop PDFs from the iOS Files app to your Banking App to st
 
 "ginicapture.multipagereview.title" = "Übersicht";
 "ginicapture.multipagereview.description" = "Sind alle Zahlungsinformationen gut sichtbar?";
-"ginicapture.multipagereview.mainButtonTitle" = "Dokumente verarbeiten";
+"ginicapture.multipagereview.mainButtonTitle.singular" = "Dokument verarbeiten";
+"ginicapture.multipagereview.mainButtonTitle.plural" = "Dokumente verarbeiten";
 "ginicapture.multipagereview.secondaryButtonTitle" = "Seite";
 "ginicapture.multipagereview.error.retakeAction" = "Wiederholung";
 "ginicapture.multipagereview.error.retryAction" = "Wiederholen";

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Resources/en.lproj/Localizable.strings
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Resources/en.lproj/Localizable.strings
@@ -142,7 +142,8 @@ conveniently drag-and-drop PDFs from the iOS Files app to your Banking App to st
 
 "ginicapture.multipagereview.title" = "Review";
 "ginicapture.multipagereview.description" = "Make sure the payment details are visible";
-"ginicapture.multipagereview.mainButtonTitle" = "Process documents";
+"ginicapture.multipagereview.mainButtonTitle.singular" = "Process document";
+"ginicapture.multipagereview.mainButtonTitle.plural" = "Process documents";
 "ginicapture.multipagereview.secondaryButtonTitle" = "Pages";
 "ginicapture.multipagereview.error.retakeAction" = "Retake";
 "ginicapture.multipagereview.error.retryAction" = "Retry";


### PR DESCRIPTION
![simulator](https://user-images.githubusercontent.com/19169669/196692565-b85fe335-0f5f-4a32-8879-854b0e5f57a3.jpg)


Add custom loading indicator. 
Uncomment lines 92-92 in GiniBankSDKExample - Appcoordinator to test the custom loading