### PR TITLE
Pia 3260 skip review screen for images received from another app via open with

### DIFF
--- a/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/GiniBankNetworkingScreenApiCoordinator.swift
+++ b/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/GiniBankNetworkingScreenApiCoordinator.swift
@@ -39,13 +39,13 @@ open class GiniBankNetworkingScreenApiCoordinator: GiniScreenAPICoordinator, Gin
         // When an non reviewable document or an image in multipage mode is captured,
         // it has to be uploaded right away.
         if giniConfiguration.multipageEnabled || !document.isReviewable {
-            if document.isImported {
+
+            if (document as? GiniImageDocument)?.isFromOtherApp ?? false {
                 uploadAndStartAnalysisWithReturnAssistant(document: document, networkDelegate: networkDelegate, uploadDidFail: {
                     self.didCapture(document: document, networkDelegate: networkDelegate)
                 })
                 return
             }
-
             if !document.isReviewable {
                 uploadAndStartAnalysisWithReturnAssistant(document: document, networkDelegate: networkDelegate, uploadDidFail: {
                     self.didCapture(document: document, networkDelegate: networkDelegate)

--- a/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/GiniBankNetworkingScreenApiCoordinator.swift
+++ b/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/GiniBankNetworkingScreenApiCoordinator.swift
@@ -51,7 +51,7 @@ open class GiniBankNetworkingScreenApiCoordinator: GiniScreenAPICoordinator, Gin
                     self.didCapture(document: document, networkDelegate: networkDelegate)
                 })
             } else if giniConfiguration.multipageEnabled {
-                // When multipage is enabled the document updload result should be communicated to the network delegate
+                // When multipage is enabled the document upload result should be communicated to the network delegate
                 uploadWithReturnAssistant(document: document,
                                           didComplete: networkDelegate.uploadDidComplete,
                                           didFail: networkDelegate.uploadDidFail)

--- a/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/GiniBankNetworkingScreenApiCoordinator.swift
+++ b/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/GiniBankNetworkingScreenApiCoordinator.swift
@@ -39,6 +39,13 @@ open class GiniBankNetworkingScreenApiCoordinator: GiniScreenAPICoordinator, Gin
         // When an non reviewable document or an image in multipage mode is captured,
         // it has to be uploaded right away.
         if giniConfiguration.multipageEnabled || !document.isReviewable {
+            if document.isImported {
+                uploadAndStartAnalysisWithReturnAssistant(document: document, networkDelegate: networkDelegate, uploadDidFail: {
+                    self.didCapture(document: document, networkDelegate: networkDelegate)
+                })
+                return
+            }
+
             if !document.isReviewable {
                 uploadAndStartAnalysisWithReturnAssistant(document: document, networkDelegate: networkDelegate, uploadDidFail: {
                     self.didCapture(document: document, networkDelegate: networkDelegate)

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Models/GiniImageDocument.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Models/GiniImageDocument.swift
@@ -26,6 +26,7 @@ final public class GiniImageDocument: NSObject, GiniCaptureDocument {
         return self.metaInformationManager.imageRotationDeltaDegrees()
     }
 
+    // A boolean to determine if the document is opened from another app or from the SDK
     public var isFromOtherApp: Bool
     fileprivate let metaInformationManager: ImageMetaInformationManager
     
@@ -47,8 +48,10 @@ final public class GiniImageDocument: NSObject, GiniCaptureDocument {
         self.id = UUID().uuidString
 
         switch imageSource {
-        case .appName(name: _) : isFromOtherApp = true
-        default: isFromOtherApp = false
+        case .appName(name: _) :
+            isFromOtherApp = true
+        default:
+            isFromOtherApp = false
         }
 
         self.isImported = imageSource != DocumentSource.camera

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Models/GiniImageDocument.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Models/GiniImageDocument.swift
@@ -26,7 +26,7 @@ final public class GiniImageDocument: NSObject, GiniCaptureDocument {
         return self.metaInformationManager.imageRotationDeltaDegrees()
     }
 
-    // A boolean to determine if the document is opened from another app or from the SDK
+    // A flag to determine if the document is opened from another app or from the SDK
     public var isFromOtherApp: Bool
     fileprivate let metaInformationManager: ImageMetaInformationManager
     

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Models/GiniImageDocument.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Models/GiniImageDocument.swift
@@ -25,7 +25,8 @@ final public class GiniImageDocument: NSObject, GiniCaptureDocument {
     public var rotationDelta: Int { // Should be normalized to be in [0, 360)
         return self.metaInformationManager.imageRotationDeltaDegrees()
     }
-    
+
+    public var isFromOtherApp: Bool
     fileprivate let metaInformationManager: ImageMetaInformationManager
     
     /**
@@ -44,6 +45,12 @@ final public class GiniImageDocument: NSObject, GiniCaptureDocument {
         self.previewImage = UIImage(data: data)
         self.isReviewable = true
         self.id = UUID().uuidString
+
+        switch imageSource {
+        case .appName(name: _) : isFromOtherApp = true
+        default: isFromOtherApp = false
+        }
+
         self.isImported = imageSource != DocumentSource.camera
         self.metaInformationManager = ImageMetaInformationManager(imageData: data,
                                                                   deviceOrientation: deviceOrientation,

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Screen API Coordinator/GiniScreenAPICoordinator+Analysis.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Screen API Coordinator/GiniScreenAPICoordinator+Analysis.swift
@@ -64,7 +64,7 @@ extension GiniScreenAPICoordinator {
                             self?.screenAPINavigationController.dismiss(animated: true)
                         }
                     }, cancelPressed: { [weak self] in
-                    self?.backToCamera()
+                        self?.screenAPINavigationController.dismiss(animated: true)
                 })
             }
         default:

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Screen API Coordinator/GiniScreenAPICoordinator+Camera.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Screen API Coordinator/GiniScreenAPICoordinator+Camera.swift
@@ -188,7 +188,14 @@ extension GiniScreenAPICoordinator: CameraViewControllerDelegate {
         if visionDocuments.compactMap({ $0 as? GiniImageDocument }).filter({ $0.isFromOtherApp }).isNotEmpty {
             showAnalysisScreen()
         } else {
-            showReview()
+            if let documentsType = visionDocuments.type {
+                switch documentsType {
+                case .image:
+                    showReview()
+                case .qrcode, .pdf:
+                    showAnalysisScreen()
+                }
+            }
         }
     }
 }

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Screen API Coordinator/GiniScreenAPICoordinator+Camera.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Screen API Coordinator/GiniScreenAPICoordinator+Camera.swift
@@ -183,13 +183,11 @@ extension GiniScreenAPICoordinator: CameraViewControllerDelegate {
 
     func showNextScreenAfterPicking(pages: [GiniCapturePage]) {
         let visionDocuments = pages.map { $0.document }
-        if let documentsType = visionDocuments.type {
-            switch documentsType {
-            case .image:
-                showReview()
-            case .qrcode, .pdf:
-                showAnalysisScreen()
-            }
+
+        if visionDocuments.filter({ $0.isImported }).isNotEmpty {
+            showAnalysisScreen()
+        } else {
+            showReview()
         }
     }
 }

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Screen API Coordinator/GiniScreenAPICoordinator+Camera.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Screen API Coordinator/GiniScreenAPICoordinator+Camera.swift
@@ -184,7 +184,8 @@ extension GiniScreenAPICoordinator: CameraViewControllerDelegate {
     func showNextScreenAfterPicking(pages: [GiniCapturePage]) {
         let visionDocuments = pages.map { $0.document }
 
-        if visionDocuments.filter({ $0.isImported }).isNotEmpty {
+        // Creating an array of GiniImageDocuments and filtering it for 'isFromOtherApp'
+        if visionDocuments.compactMap({ $0 as? GiniImageDocument }).filter({ $0.isFromOtherApp }).isNotEmpty {
             showAnalysisScreen()
         } else {
             showReview()

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Screen API Coordinator/GiniScreenAPICoordinator.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Screen API Coordinator/GiniScreenAPICoordinator.swift
@@ -166,6 +166,11 @@ open class GiniScreenAPICoordinator: NSObject, Coordinator {
     }
 
     private func initialViewControllers(with pages: [GiniCapturePage]) -> [UIViewController] {
+        if pages.filter({ $0.document.isImported }).isNotEmpty {
+            self.analysisViewController = createAnalysisScreen(withDocument: pages[0].document)
+            return [self.analysisViewController!]
+        }
+
         if pages.type == .image {
             reviewViewController =
                 createReviewScreenContainer(with: pages)

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Screen API Coordinator/GiniScreenAPICoordinator.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Screen API Coordinator/GiniScreenAPICoordinator.swift
@@ -166,7 +166,8 @@ open class GiniScreenAPICoordinator: NSObject, Coordinator {
     }
 
     private func initialViewControllers(with pages: [GiniCapturePage]) -> [UIViewController] {
-        if pages.filter({ $0.document.isImported }).isNotEmpty {
+        // Creating an array of GiniImageDocuments and filtering it for 'isFromOtherApp'
+        if pages.compactMap({ $0.document as? GiniImageDocument }).filter({ $0.isFromOtherApp }).isNotEmpty {
             self.analysisViewController = createAnalysisScreen(withDocument: pages[0].document)
             return [self.analysisViewController!]
         }

--- a/CaptureSDK/GiniCaptureSDK/Tests/GiniCaptureSDKTests/GiniScreenAPICoordinatorTests.swift
+++ b/CaptureSDK/GiniCaptureSDK/Tests/GiniCaptureSDKTests/GiniScreenAPICoordinatorTests.swift
@@ -49,8 +49,11 @@ final class GiniScreenAPICoordinatorTests: XCTestCase {
     }
     
     func testNavControllerTypesAfterStartWithImages() {
-        let capturedImages = [GiniCaptureTestsHelper.loadImageDocument(named: "invoice"),
-                              GiniCaptureTestsHelper.loadImageDocument(named: "invoice2")]
+        let document1 = GiniCaptureTestsHelper.loadImageDocument(named: "invoice")
+        document1.isImported = false
+        let document2 = GiniCaptureTestsHelper.loadImageDocument(named: "invoice2")
+        document2.isImported = false
+        let capturedImages = [document1, document2]
 
         let rootViewController = coordinator.start(withDocuments: capturedImages)
         _ = rootViewController.view
@@ -86,7 +89,9 @@ final class GiniScreenAPICoordinatorTests: XCTestCase {
     
     func testNavControllerTypesAfterStartWithImageAndMultipageDisabled() {
         giniConfiguration.multipageEnabled = false
-        let capturedImages = [GiniCaptureTestsHelper.loadImageDocument(named: "invoice")]
+        let document = GiniCaptureTestsHelper.loadImageDocument(named: "invoice")
+        document.isImported = false
+        let capturedImages = [document]
 
         let rootViewController = coordinator.start(withDocuments: capturedImages)
         _ = rootViewController.view


### PR DESCRIPTION
When opening an image from another app(Files for ex.) the Review screen should be skipped and if an error occurs on analysis, the No results screen's cancel button should close the flow, not go back to the review.