### PR TITLE
fix(GiniCaptureSDK): Fix layout with bottom navigation

### DIFF
--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Camera/CameraPreviewViewController.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Camera/CameraPreviewViewController.swift
@@ -326,9 +326,12 @@ extension CameraPreviewViewController {
         
         notAuthorizedView.translatesAutoresizingMaskIntoConstraints = false
 
+        let bottomPadding: CGFloat =
+            giniConfiguration.bottomNavigationBarEnabled ? Constants.bottomNavigationBarHeight : 0
+
         NSLayoutConstraint.activate([
             notAuthorizedView.centerXAnchor.constraint(equalTo: view.centerXAnchor),
-            notAuthorizedView.centerYAnchor.constraint(equalTo: view.centerYAnchor),
+            notAuthorizedView.bottomAnchor.constraint(equalTo: view.bottomAnchor, constant: -bottomPadding),
             notAuthorizedView.topAnchor.constraint(equalTo: view.topAnchor),
             notAuthorizedView.leadingAnchor.constraint(equalTo: view.leadingAnchor)])
 


### PR DESCRIPTION
On the smallest iPhone:
![Simulator Screen Shot - iPhone SE (1st generation) - 2022-12-12 at 16 00 34](https://user-images.githubusercontent.com/19169669/207064459-2a06de02-7ea9-4068-87d8-79b66bc9b587.png)
