### PR TITLE
Fix QR code scanning only if flag of QR reading is disabled

### DIFF
--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Camera/Camera2/Camera2ViewController.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Camera/Camera2/Camera2ViewController.swift
@@ -36,6 +36,10 @@ public final class Camera2ViewController: UIViewController, CameraScreen {
     private var validQRCodeProcessing: Bool = false
     public weak var delegate: CameraViewControllerDelegate?
 
+    private lazy var qrCodeScanningOnlyEnabled: Bool = {
+        return giniConfiguration.qrCodeScanningEnabled && giniConfiguration.onlyQRCodeScanningEnabled
+    }()
+
     @IBOutlet weak var cameraPane: CameraPane!
     private let cameraButtonsViewModel: CameraButtonsViewModel
     private var navigationBarBottomAdapter: CameraBottomNavigationBarAdapter?
@@ -115,7 +119,7 @@ public final class Camera2ViewController: UIViewController, CameraScreen {
         configureConstraints()
         configureTitle()
 
-        if giniConfiguration.onlyQRCodeScanningEnabled {
+        if qrCodeScanningOnlyEnabled {
             cameraPane.alpha = 0
             if giniConfiguration.bottomNavigationBarEnabled {
                 configureCustomTopNavigationBar(containsImage: false)
@@ -315,7 +319,7 @@ public final class Camera2ViewController: UIViewController, CameraScreen {
             cameraPreviewViewController.view.bottomAnchor.constraint(equalTo: view.bottomAnchor)
 
     private func configureConstraints() {
-        if giniConfiguration.onlyQRCodeScanningEnabled {
+        if qrCodeScanningOnlyEnabled {
             qrCodeOverLay.layoutViews(centeringBy: cameraPreviewViewController.qrCodeFrameView)
         } else {
             qrCodeOverLay.layoutViews(centeringBy: cameraPreviewViewController.cameraFrameView)
@@ -524,7 +528,7 @@ extension Camera2ViewController: CameraPreviewViewControllerDelegate {
 
     func cameraDidSetUp(_ viewController: CameraPreviewViewController,
                         camera: CameraProtocol) {
-        if !giniConfiguration.onlyQRCodeScanningEnabled {
+        if !qrCodeScanningOnlyEnabled {
             cameraPreviewViewController.cameraFrameView.isHidden = false
             cameraPane.toggleCaptureButtonActivation(state: true)
         }

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Camera/CameraPreviewViewController.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Camera/CameraPreviewViewController.swift
@@ -45,7 +45,7 @@ final class CameraPreviewViewController: UIViewController {
         let imageView = UIImageView()
         imageView.image = UIImageNamedPreferred(named: "cameraFocus")
         imageView.contentMode = .scaleAspectFit
-        imageView.isHidden = giniConfiguration.onlyQRCodeScanningEnabled
+        imageView.isHidden = qrCodeScanningOnlyEnabled
         return imageView
     }()
 
@@ -53,8 +53,12 @@ final class CameraPreviewViewController: UIViewController {
         let imageView = UIImageView()
         imageView.image = UIImageNamedPreferred(named: "qrCodeFocus")
         imageView.contentMode = .scaleAspectFit
-        imageView.isHidden = !giniConfiguration.onlyQRCodeScanningEnabled
+        imageView.isHidden = !qrCodeScanningOnlyEnabled
         return imageView
+    }()
+
+    private lazy var qrCodeScanningOnlyEnabled: Bool = {
+        return giniConfiguration.qrCodeScanningEnabled && giniConfiguration.onlyQRCodeScanningEnabled
     }()
 
     private var notAuthorizedView: UIView?


### PR DESCRIPTION
If you enable QRCode Scan ONLY but disable QR code scanning, nothing should happen. 