### PR TITLE
Pia 3162 expose extraction candidates

### DIFF
--- a/BankAPILibrary/GiniBankAPILibrary/Sources/GiniBankAPILibrary/Documents/ExtractionResult.swift
+++ b/BankAPILibrary/GiniBankAPILibrary/Sources/GiniBankAPILibrary/Documents/ExtractionResult.swift
@@ -21,10 +21,17 @@ import Foundation
     // Return reasons from which users can pick one when deselecting line items.
     public var returnReasons: [ReturnReason]?
     
-    public init(extractions: [Extraction], lineItems: [[Extraction]]?, returnReasons: [ReturnReason]?) {
+    /// The extraction candidates.
+    public let candidates: [String: [Extraction.Candidate]]
+    
+    public init(extractions: [Extraction],
+                lineItems: [[Extraction]]?,
+                returnReasons: [ReturnReason]?,
+                candidates: [String: [Extraction.Candidate]]) {
         self.extractions = extractions
         self.lineItems = lineItems
         self.returnReasons = returnReasons
+        self.candidates = candidates
         
         super.init()
     }
@@ -33,6 +40,7 @@ import Foundation
         
         self.init(extractions: extractionsContainer.extractions,
                   lineItems: extractionsContainer.compoundExtractions?["lineItems"],
-                  returnReasons: extractionsContainer.returnReasons)
+                  returnReasons: extractionsContainer.returnReasons,
+                  candidates: extractionsContainer.candidates)
     }
 }

--- a/BankAPILibrary/GiniBankAPILibrary/Sources/GiniBankAPILibrary/Documents/ExtractionsContainer.swift
+++ b/BankAPILibrary/GiniBankAPILibrary/Sources/GiniBankAPILibrary/Documents/ExtractionsContainer.swift
@@ -10,7 +10,7 @@ import Foundation
 struct ExtractionsContainer {
     let extractions: [Extraction]
     let compoundExtractions: [String : [[Extraction]]]?
-    let candidates: [Extraction.Candidate]
+    let candidates: [String: [Extraction.Candidate]]
     let returnReasons: [ReturnReason]?
     
     enum CodingKeys: String, CodingKey {
@@ -32,8 +32,10 @@ extension ExtractionsContainer: Decodable {
                                                forKey: .extractions)
         let decodedCompoundExtractions = try container.decodeIfPresent([String : [[String : Extraction]]].self,
                                                                 forKey: .compoundExtractions)
-        let decodedCandidates = try container.decodeIfPresent([String : [Extraction.Candidate]].self,
+        
+        self.candidates = try container.decodeIfPresent([String: [Extraction.Candidate]].self,
                                                        forKey: .candidates) ?? [:]
+
         
         extractions = decodedExtractions.map { (key, value) in
             let extraction = value
@@ -53,8 +55,6 @@ extension ExtractionsContainer: Decodable {
                 }
             }
         }
-        
-        candidates = decodedCandidates.flatMap { $0.value }
         
         returnReasons = try container.decodeIfPresent([ReturnReason].self, forKey: .returnReasons)
     }

--- a/BankAPILibrary/GiniBankAPILibrary/Tests/GiniBankAPILibraryTests/ExtractionsContainerTest.swift
+++ b/BankAPILibrary/GiniBankAPILibrary/Tests/GiniBankAPILibraryTests/ExtractionsContainerTest.swift
@@ -65,7 +65,7 @@ final class ExtractionsContainerTest: XCTestCase {
                                              value: "123.93:EUR")
         
         XCTAssertEqual(container.candidates.count, 2)
-        XCTAssertTrue(container.candidates.contains(candidate))
+        XCTAssertEqual(container.candidates["amounts"]!.first, candidate)
         
         let returnReason = ReturnReason(id: "r1", localizedLabels: ["de" : "Anderes Aussehen als angeboten"])
         

--- a/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/GiniBankNetworkingScreenApiCoordinator.swift
+++ b/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/GiniBankNetworkingScreenApiCoordinator.swift
@@ -30,7 +30,7 @@ open class GiniBankNetworkingScreenApiCoordinator: GiniScreenAPICoordinator, Gin
                            value: $0.value,
                            name: QRCodesExtractor.epsCodeUrlKey)
             }
-            let extractionResult = ExtractionResult(extractions: extractions, lineItems: [], returnReasons: [])
+            let extractionResult = ExtractionResult(extractions: extractions, lineItems: [], returnReasons: [], candidates: [:])
 
             deliver(result: extractionResult, analysisDelegate: networkDelegate)
             return
@@ -181,7 +181,7 @@ open class GiniBankNetworkingScreenApiCoordinator: GiniScreenAPICoordinator, Gin
                     return (name, $0)
                 })
 
-                let result = AnalysisResult(extractions: extractions, lineItems: result.lineItems, images: images)
+                let result = AnalysisResult(extractions: extractions, lineItems: result.lineItems, images: images, candidates: result.candidates)
 
                 let documentService = self.documentService
 
@@ -222,7 +222,8 @@ extension GiniBankNetworkingScreenApiCoordinator {
                 let result = AnalysisResult(extractions: extractions,
                                             lineItems: result.lineItems,
                                             images: images,
-                                            document: documentService.document)
+                                            document: documentService.document,
+                                            candidates: result.candidates)
 
                 self.resultsDelegate?
                     .giniCaptureAnalysisDidFinishWith(result: result) { updatedExtractions in

--- a/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/ReturnAssistant/DigitalInvoice.swift
+++ b/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/ReturnAssistant/DigitalInvoice.swift
@@ -156,7 +156,8 @@ extension DigitalInvoice {
             
             return ExtractionResult(extractions: _extractionResult.extractions,
                                     lineItems: lineItems.map { $0.extractions },
-                                    returnReasons: returnReasons)
+                                    returnReasons: returnReasons,
+                                    candidates: _extractionResult.candidates)
         }
         
         let modifiedExtractions = _extractionResult.extractions.map { extraction -> Extraction in
@@ -170,6 +171,7 @@ extension DigitalInvoice {
         
         return ExtractionResult(extractions: modifiedExtractions,
                                 lineItems: lineItems.map { $0.extractions },
-                                returnReasons: returnReasons)
+                                returnReasons: returnReasons,
+                                candidates: _extractionResult.candidates)
     }
 }

--- a/BankSDK/GiniBankSDKExample/GiniBankSDKExample/Screen API/ScreenAPICoordinator.swift
+++ b/BankSDK/GiniBankSDKExample/GiniBankSDKExample/Screen API/ScreenAPICoordinator.swift
@@ -178,7 +178,7 @@ extension ScreenAPICoordinator: GiniCaptureNetworkService {
         let extractionQuantity = Extraction.init(box: nil, candidates: "", entity: "numeric", value: "1", name: "quantity")
 
         let lineItem = [extractionQuantity, extractionsBaseGross, extractionDescription, extractionArtNumber]
-        let extractionResult = ExtractionResult.init(extractions: [extractionPaymentPurpose,extractionAmountToPay,extractionIban,extractionPaymentRecipient], lineItems: [lineItem, lineItem] , returnReasons: [])
+        let extractionResult = ExtractionResult.init(extractions: [extractionPaymentPurpose,extractionAmountToPay,extractionIban,extractionPaymentRecipient], lineItems: [lineItem, lineItem] , returnReasons: [], candidates: [:])
         if let doc = self.manuallyCreatedDocument {
             let result = (document: doc, extractionResult: extractionResult)
             completion(.success(result))

--- a/BankSDK/GiniBankSDKExample/Tests/ExtractionFeedbackIntegrationTest.swift
+++ b/BankSDK/GiniBankSDKExample/Tests/ExtractionFeedbackIntegrationTest.swift
@@ -160,7 +160,8 @@ class ExtractionFeedbackIntegrationTest: XCTestCase {
                         let analysisResult = AnalysisResult(extractions: extractions,
                                                             lineItems: extractionResult.lineItems,
                                                             images: [],
-                                                            document: self.giniCaptureSDKDocumentService?.document)
+                                                            document: self.giniCaptureSDKDocumentService?.document,
+                                                            candidates: extractionResult.candidates)
 
                         let sendFeedbackBlock: (([String: Extraction]) -> Void) = { [self] updatedExtractions in
                             let extractions = updatedExtractions.map {$0.1}

--- a/BankSDK/GiniBankSDKPinningExample/GiniBankSDKExample/Screen API/ScreenAPICoordinator.swift
+++ b/BankSDK/GiniBankSDKPinningExample/GiniBankSDKExample/Screen API/ScreenAPICoordinator.swift
@@ -202,7 +202,7 @@ extension ScreenAPICoordinator: GiniCaptureNetworkService {
         let extractionQuantity = Extraction.init(box: nil, candidates: "", entity: "numeric", value: "1", name: "quantity")
 
         let lineItem = [extractionQuantity, extractionsBaseGross, extractionDescription, extractionArtNumber]
-        let extractionResult = ExtractionResult.init(extractions: [extractionPaymentPurpose,extractionAmountToPay,extractionIban,extractionPaymentRecipient], lineItems: [lineItem, lineItem] , returnReasons: [])
+        let extractionResult = ExtractionResult.init(extractions: [extractionPaymentPurpose,extractionAmountToPay,extractionIban,extractionPaymentRecipient], lineItems: [lineItem, lineItem] , returnReasons: [], candidates: [:])
         if let doc = self.manuallyCreatedDocument {
             let result = (document: doc, extractionResult: extractionResult)
             completion(.success(result))

--- a/BankSDK/GiniBankSDKPinningExample/Tests/ExtractionFeedbackIntegrationTest.swift
+++ b/BankSDK/GiniBankSDKPinningExample/Tests/ExtractionFeedbackIntegrationTest.swift
@@ -181,7 +181,8 @@ class ExtractionFeedbackIntegrationTest: XCTestCase {
                         let analysisResult = AnalysisResult(extractions: extractions,
                                                             lineItems: extractionResult.lineItems,
                                                             images: [],
-                                                            document: self.giniCaptureSDKDocumentService?.document)
+                                                            document: self.giniCaptureSDKDocumentService?.document,
+                                                            candidates: extractionResult.candidates)
 
                         let sendFeedbackBlock: (([String: Extraction]) -> Void) = { [self] updatedExtractions in
                             let extractions = updatedExtractions.map {$0.1}

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Networking/AnalysisResult.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Networking/AnalysisResult.swift
@@ -22,7 +22,7 @@ import GiniBankAPILibrary
      *  it can also return the epsPaymentQRCodeUrl extraction, obtained from a EPS QR code.
      */
     public let extractions: [String: Extraction]
-
+    
     /**
      *  Line item compound extractions obtained in the analysis.
      */
@@ -36,10 +36,22 @@ import GiniBankAPILibrary
      */
     public let document: Document?
     
-    public init(extractions: [String: Extraction], lineItems: [[Extraction]]? = nil, images: [UIImage], document: Document? = nil) {
+    /*
+     *  Extraction candidates dictionary. To get the candidates for an extraction look for the
+     *  `Extraction.candidates` name in the dictionary. For example the IBAN extraction's `candidates` field
+     *  contains `"ibans"` and if you search for that in this dictionary, then you'll get all the IBAN candidates.
+     */
+    public let candidates: [String: [Extraction.Candidate]]
+    
+    public init(extractions: [String: Extraction],
+                lineItems: [[Extraction]]? = nil,
+                images: [UIImage],
+                document: Document? = nil,
+                candidates: [String: [Extraction.Candidate]]) {
         self.images = images
         self.extractions = extractions
         self.lineItems = lineItems
         self.document = document
+        self.candidates = candidates
     }
 }

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Networking/GiniNetworkingScreenAPICoordinator.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Networking/GiniNetworkingScreenAPICoordinator.swift
@@ -121,7 +121,7 @@ import GiniBankAPILibrary
                 })
                 
                 
-                let result = AnalysisResult(extractions: extractions, lineItems: result.lineItems, images: images, document: document)
+                let result = AnalysisResult(extractions: extractions, lineItems: result.lineItems, images: images, document: document, candidates: result.candidates)
                 
                 let documentService = self.documentService
                 
@@ -208,7 +208,7 @@ extension GiniNetworkingScreenAPICoordinator: GiniCaptureDelegate {
                            value: $0.value,
                            name: QRCodesExtractor.epsCodeUrlKey)
                 }
-            let extractionResult = ExtractionResult(extractions: extractions, lineItems: [], returnReasons: [])
+            let extractionResult = ExtractionResult(extractions: extractions, lineItems: [], returnReasons: [], candidates: [:])
             
             self.deliver(result: extractionResult, to: networkDelegate)
             return

--- a/CaptureSDK/GiniCaptureSDKExample/Tests/ExtractionFeedbackIntegrationTest.swift
+++ b/CaptureSDK/GiniCaptureSDKExample/Tests/ExtractionFeedbackIntegrationTest.swift
@@ -159,7 +159,8 @@ class ExtractionFeedbackIntegrationTest: XCTestCase {
                         let analysisResult = AnalysisResult(extractions: extractions,
                                                             lineItems: extractionResult.lineItems,
                                                             images: [],
-                                                            document: self.giniCaptureSDKDocumentService?.document)
+                                                            document: self.giniCaptureSDKDocumentService?.document,
+                                                            candidates: extractionResult.candidates)
                         
                         let sendFeedbackBlock: (([String: Extraction]) -> Void) = { [self] updatedExtractions in
                             let extractions = updatedExtractions.map {$0.1}

--- a/CaptureSDK/GiniCaptureSDKPinningExample/Tests/ExtractionFeedbackIntegrationTest.swift
+++ b/CaptureSDK/GiniCaptureSDKPinningExample/Tests/ExtractionFeedbackIntegrationTest.swift
@@ -180,7 +180,8 @@ class ExtractionFeedbackIntegrationTest: XCTestCase {
                         let analysisResult = AnalysisResult(extractions: extractions,
                                                             lineItems: extractionResult.lineItems,
                                                             images: [],
-                                                            document: self.giniCaptureSDKDocumentService?.document)
+                                                            document: self.giniCaptureSDKDocumentService?.document,
+                                                            candidates: extractionResult.candidates)
                         
                         let sendFeedbackBlock: (([String: Extraction]) -> Void) = { [self] updatedExtractions in
                             let extractions = updatedExtractions.map {$0.1}


### PR DESCRIPTION
I exposed a field through `AnalysisResult` to allow clients to get the extraction candidates.

Extraction candidates contain all identified extractions, for example if the invoice has three IBANs all of them will be added to the extraction candidates. One of them is picked as the main extraction, but clients may want to use one of the candidates instead.