### PR TITLE
fix(GiniBankSDK): Add tint color for action sheet

### DIFF
--- a/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/ReturnAssistant/DeselectLineItemActionSheet.swift
+++ b/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/ReturnAssistant/DeselectLineItemActionSheet.swift
@@ -16,6 +16,7 @@ class DeselectLineItemActionSheet {
         let actionSheet = UIAlertController(title: nil,
                                             message: NSLocalizedStringPreferredGiniBankFormat("ginibank.digitalinvoice.deselectreasonactionsheet.message", comment: "Info message when deselect a return reason"),
                                             preferredStyle: .actionSheet)
+        actionSheet.view.tintColor = .GiniBank.accent1
 
         for reason in returnReasons {
             actionSheet.addAction(UIAlertAction(title: reason.labelInLocalLanguageOrGerman,


### PR DESCRIPTION
When you change the tint color to red:

![Simulator Screen Shot - iPad Pro (11-inch) (4th generation) - 2023-03-02 at 10 41 05](https://user-images.githubusercontent.com/19169669/222376816-d2bce0dd-2804-4cf1-9bc3-fecbb8fa260b.png)
