### PR TITLE
ci(bank-sdk): Add podspecs and readmes on how to distribute XCFrameworks with CocoaPods

### DIFF
--- a/BankSDK/GiniBankSDK/Pod/GiniBankSDK.podspec
+++ b/BankSDK/GiniBankSDK/Pod/GiniBankSDK.podspec
@@ -1,0 +1,33 @@
+Pod::Spec.new do |spec|
+  spec.name               = "GiniBankSDK"
+  spec.version            = "1.13.0"
+  spec.summary            = "Gini Bank SDK for iOS"
+  spec.description        = "The Gini Bank SDK provides components for capturing, reviewing and analyzing photos of invoices and remittance slips."
+  spec.homepage           = "https://gini.net"
+  spec.documentation_url  = "https://developer.gini.net/gini-mobile-ios/GiniBankSDK/#{spec.version.to_s}/"
+  spec.author             = "Gini GmbH"
+  spec.license            = { :type => 'Private', :text => <<-LICENSE
+                                Copyright (c) 2021-2023, Gini GmbH
+
+                                All rights reserved.
+                                
+                                The projects in this repository, if not stated otherwise, are licensed through Gini GmbH ("Gini") and may not be
+                                used, altered or copied in any way without explicit permission by Gini. The
+                                terms of usage are defined in a separate usage agreement between Gini and the
+                                licensee, where the licensee can gain access to a non-exclusive,
+                                non-transferable usage right which is restricted for the time of a contractual
+                                relationship between Gini and the licensee.
+                                
+                                For license related inquiries contact Gini via the email address
+                                technical-support@gini.net.
+                              LICENSE
+                            }
+  spec.source             = { :http => "https://github.com/gini/gini-podspecs/raw/master/GiniBankSDK/#{spec.version.to_s}/GiniBankSDK-XCFrameworks.zip" }
+  spec.swift_version      = "5.3"
+
+  # Supported deployment targets
+  spec.ios.deployment_target  = "12.0"
+
+  # Published binaries
+  spec.vendored_frameworks = "GiniBankSDK.xcframework", "GiniCaptureSDK.xcframework", "GiniBankAPILibrary.xcframework"
+end

--- a/BankSDK/GiniBankSDK/Pod/README.md
+++ b/BankSDK/GiniBankSDK/Pod/README.md
@@ -1,0 +1,20 @@
+Distributing Gini Bank SDK XCFrameworks using CocoaPods
+======================================================
+
+How to release new versions
+---------------------------
+
+1. After the `.xcframeworks` have been created compress them into a zip named `GiniBankSDK-XCFrameworks.zip`.
+2. Update the version in the `GiniBankSDK.podspec`, for example `spec.version = 2.2.1`.
+3. Clone the `https://github.com/gini/gini-podspecs` repository.
+4. Go into the `gini-podspecs` repository folder and create a subfolder in `GiniBankSDK` which is named after the version, for example `GiniBankSDK/2.2.1`.
+5. Copy the `GiniBankSDK-XCFrameworks.zip` and the `GiniBankSDK.podspec` into the new folder.
+6. Commit and push the new folder and its contents.
+
+How to use the Gini Bank SDK pod
+--------------------------------
+
+1. Add the following to your `Podfile`:
+   1. `source 'https://github.com/gini/gini-podspecs.git'`
+   2. `pod GiniBankSDK`
+2. Run `pod update` to fetch the latest Gini Bank SDK pod version.

--- a/BankSDK/GiniBankSDKPinning/Pod/GiniBankSDKPinning.podspec
+++ b/BankSDK/GiniBankSDKPinning/Pod/GiniBankSDKPinning.podspec
@@ -1,0 +1,36 @@
+Pod::Spec.new do |spec|
+  spec.name               = "GiniBankSDKPinning"
+  spec.version            = "1.13.0"
+  spec.summary            = "Gini Bank SDK for iOS with certificate pinning"
+  spec.description        = "The Gini Bank SDK provides components for capturing, reviewing and analyzing photos of invoices and remittance slips."
+  spec.homepage           = "gini.net"
+  spec.documentation_url  = "https://developer.gini.net/gini-mobile-ios/GiniBankSDK/#{spec.version.to_s}/"
+  spec.author             = "Gini GmbH"
+  spec.license            = { :type => 'Private', :text => <<-LICENSE
+                                Copyright (c) 2021-2023, Gini GmbH
+
+                                All rights reserved.
+                                
+                                The projects in this repository, if not stated otherwise, are licensed through Gini GmbH ("Gini") and may not be
+                                used, altered or copied in any way without explicit permission by Gini. The
+                                terms of usage are defined in a separate usage agreement between Gini and the
+                                licensee, where the licensee can gain access to a non-exclusive,
+                                non-transferable usage right which is restricted for the time of a contractual
+                                relationship between Gini and the licensee.
+                                
+                                For license related inquiries contact Gini via the email address
+                                technical-support@gini.net.
+                              LICENSE
+                            }
+  spec.source             = { :http => "https://github.com/gini/gini-podspecs/raw/master/GiniBankSDKPinning/#{spec.version.to_s}/GiniBankSDKPinning-XCFrameworks.zip" }
+  spec.swift_version      = "5.3"
+
+  # Supported deployment targets
+  spec.ios.deployment_target  = "12.0"
+
+  # Published binaries
+  spec.vendored_frameworks = ["GiniBankSDK.xcframework", "GiniBankSDKPinning.xcframework",
+                              "GiniCaptureSDK.xcframework", "GiniCaptureSDKPinning.xcframework", 
+                              "GiniBankAPILibrary.xcframework", "GiniBankAPILibraryPinning.xcframework",
+                              "TrustKit.xcframework"]
+end

--- a/BankSDK/GiniBankSDKPinning/Pod/README.md
+++ b/BankSDK/GiniBankSDKPinning/Pod/README.md
@@ -1,0 +1,20 @@
+Distributing Gini Bank SDK Pinning XCFrameworks using CocoaPods
+======================================================
+
+How to release new versions
+---------------------------
+
+1. After the `.xcframeworks` have been created compress them into a zip named `GiniBankSDKPinning-XCFrameworks.zip`.
+2. Update the version in the `GiniBankSDKPinning.podspec`, for example `spec.version = 2.2.1`.
+3. Clone the `https://github.com/gini/gini-podspecs` repository.
+4. Go into the `gini-podspecs` repository folder and create a subfolder in `GiniBankSDKPinning` which is named after the version, for example `GiniBankSDKPinning/2.2.1`.
+5. Copy the `GiniBankSDK-XCFrameworks.zip` and the `GiniBankSDKPinning.podspec` into the new folder.
+6. Commit and push the new folder and its contents.
+
+How to use the GiniBankSDK pod
+------------------------------
+
+1. Add the following to your `Podfile`:
+   1. `source 'https://github.com/gini/gini-podspecs.git'`
+   2. `pod GiniBankSDKPinning`
+2. Run `pod update` to fetch the latest Gini Bank SDK pod version.


### PR DESCRIPTION
PIA-3939

Copy of `PIA-3835-cocoapod-for-xcframework`. Just the ticket id changed so that it's connected to the story ticket instead of the epic.