### PR TITLE
Pia 3986 allow path in custom base url

### DIFF
--- a/.github/workflows/bank-api-library.build.docs.yml
+++ b/.github/workflows/bank-api-library.build.docs.yml
@@ -12,11 +12,11 @@ on:
   
 jobs:
   documentation:
-    runs-on: macOS-11    
+    runs-on: macOS-12
     steps:
     - uses: maxim-lobanov/setup-xcode@v1
       with:
-        xcode-version: '13.0'
+        xcode-version: '14.2'
 
     - name: Checkout
       uses: actions/checkout@v2

--- a/.github/workflows/bank-api-library.check.yml
+++ b/.github/workflows/bank-api-library.check.yml
@@ -15,15 +15,15 @@ on:
   
 jobs:
   check:
-    runs-on: macOS-11
+    runs-on: macOS-12
     strategy:
       matrix:
         target: [GiniBankAPILibrary, GiniBankAPILibraryPinning]
-        destination: ['platform=iOS Simulator,OS=15.0,name=iPhone 13', 'platform=iOS Simulator,OS=13.7,name=iPhone 11']
+        destination: ['platform=iOS Simulator,OS=16.2,name=iPhone 13', 'platform=iOS Simulator,OS=15.0,name=iPhone 11']
     steps:
     - uses: maxim-lobanov/setup-xcode@v1
       with:
-        xcode-version: '13.0'
+        xcode-version: '14.2'
 
     - name: Checkout
       uses: actions/checkout@v2
@@ -38,13 +38,13 @@ jobs:
            cd BankAPILibrary/GiniBankAPILibraryPinning
            swift package update
 
-    - name: Link to 13.7 Simulators
-      if: matrix.destination == 'platform=iOS Simulator,OS=13.7,name=iPhone 11'
+    - name: Link to 15.0 Simulators
+      if: matrix.destination == 'platform=iOS Simulator,OS=15.0,name=iPhone 11'
       run: |
         echo "Creating Runtimes folder if needed..."
         sudo mkdir -p /Library/Developer/CoreSimulator/Profiles/Runtimes
-        echo "Creating symlink of the iOS 13.7 runtime..."
-        sudo ln -s /Applications/Xcode_11.7.app/Contents/Developer/Platforms/iPhoneOS.platform/Library/Developer/CoreSimulator/Profiles/Runtimes/iOS.simruntime /Library/Developer/CoreSimulator/Profiles/Runtimes/iOS\ 13.7.simruntime
+        echo "Creating symlink of the iOS 15.0 runtime..."
+        sudo ln -s /Applications/Xcode_13.1.app/Contents/Developer/Platforms/iPhoneOS.platform/Library/Developer/CoreSimulator/Profiles/Runtimes/iOS.simruntime /Library/Developer/CoreSimulator/Profiles/Runtimes/iOS\ 15.0.simruntime
 
     - name: Build sdk targets
       run: |

--- a/.github/workflows/bank-api-library.publish.docs.yml
+++ b/.github/workflows/bank-api-library.publish.docs.yml
@@ -12,11 +12,11 @@ on:
   
 jobs:
   release-documentation:
-    runs-on: macOS-11    
+    runs-on: macOS-12    
     steps:
     - uses: maxim-lobanov/setup-xcode@v1
       with:
-        xcode-version: '13.0'
+        xcode-version: '14.2'
 
     - name: Checkout
       uses: actions/checkout@v2

--- a/.github/workflows/bank-api-library.release.yml
+++ b/.github/workflows/bank-api-library.release.yml
@@ -13,11 +13,11 @@ jobs:
 
   release:
     needs: check
-    runs-on: macOS-11    
+    runs-on: macOS-12    
     steps:
     - uses: maxim-lobanov/setup-xcode@v1
       with:
-        xcode-version: '13.0'
+        xcode-version: '14.2'
 
     - name: Checkout
       uses: actions/checkout@v2

--- a/BankAPILibrary/GiniBankAPILibrary/Sources/GiniBankAPILibrary/Documents/APIResource.swift
+++ b/BankAPILibrary/GiniBankAPILibrary/Sources/GiniBankAPILibrary/Documents/APIResource.swift
@@ -12,15 +12,23 @@ public enum APIDomain {
     case `default`
     /// The GYM API, which points to https://gym.gini.net/
     case gym(tokenSource: AlternativeTokenSource)
-    /// A custom domain with optional custom token source
-    case custom(domain: String, tokenSource: AlternativeTokenSource?)
+    /// A custom domain with optional path and custom token source
+    case custom(domain: String, path: String? = nil, tokenSource: AlternativeTokenSource?)
     
     var domainString: String {
         
         switch self {
         case .default: return "pay-api.gini.net"
         case .gym: return "gym.gini.net"
-        case .custom(let domain, _): return domain
+        case .custom(let domain, _, _): return domain
+        }
+    }
+    
+    var path: String {
+        switch self {
+        case .default: return ""
+        case .gym: return ""
+        case .custom(_, let path, _): return path ?? ""
         }
     }
 }
@@ -70,6 +78,10 @@ struct APIResource<T: Decodable>: Resource {
     }
     
     var path: String {
+        return "\(domain.path)\(methodPath)"
+    }
+    
+    private var methodPath: String {
         switch method {
         case .composite:
             return "/documents/composite"

--- a/BankAPILibrary/GiniBankAPILibrary/Sources/GiniBankAPILibrary/Documents/Core/Auth/UserResource.swift
+++ b/BankAPILibrary/GiniBankAPILibrary/Sources/GiniBankAPILibrary/Documents/Core/Auth/UserResource.swift
@@ -10,14 +10,21 @@ import Foundation
 public enum UserDomain {
     /// The default one, which points to https://user.gini.net
     case `default`
-    /// A custom domain
-    case custom(domain: String)
+    /// A custom domain with optional path
+    case custom(domain: String, path: String? = nil)
     
     var domainString: String {
         
         switch self {
         case .default: return "user.gini.net"
-        case .custom(let domain): return domain
+        case .custom(let domain, _): return domain
+        }
+    }
+    
+    var path: String {
+        switch self {
+        case .default: return ""
+        case .custom(_, let path): return path ?? ""
         }
     }
 }
@@ -37,6 +44,10 @@ struct UserResource<T: Decodable>: Resource {
     }
     
     var path: String {
+        return "\(domain.path)\(methodPath)"
+    }
+    
+    private var methodPath: String {
         switch method {
         case .token:
             return "/oauth/token"

--- a/BankAPILibrary/GiniBankAPILibrary/Sources/GiniBankAPILibrary/Documents/Core/GiniBankAPI.swift
+++ b/BankAPILibrary/GiniBankAPILibrary/Sources/GiniBankAPILibrary/Documents/Core/GiniBankAPI.swift
@@ -107,7 +107,7 @@ extension GiniBankAPI {
             case .default:
                 let sessionManager = SessionManager(userDomain: userApi, sessionDelegate: self.sessionDelegate)
                 return GiniBankAPI(documentService: DefaultDocumentService(sessionManager: sessionManager), paymentService: PaymentService(sessionManager: sessionManager, apiDomain: .default))
-            case .custom(_, let tokenSource):
+            case .custom(_, _, let tokenSource):
                 var sessionManager : SessionManager
                 if let tokenSource = tokenSource {
                      sessionManager = SessionManager(alternativeTokenSource: tokenSource, sessionDelegate: self.sessionDelegate)

--- a/BankAPILibrary/GiniBankAPILibrary/Tests/GiniBankAPILibraryTests/APIResourceTests.swift
+++ b/BankAPILibrary/GiniBankAPILibrary/Tests/GiniBankAPILibraryTests/APIResourceTests.swift
@@ -250,4 +250,13 @@ final class APIResourceTests: XCTestCase {
         XCTAssertEqual(urlString, "https://custom.domain.com/documents/", "path should match")
     }
     
+    func testCustomApiDomainWithPath() {
+        let resource = APIResource<[Document]>(method: .documents(limit: nil, offset: nil),
+                                               apiDomain: .custom(domain: "custom.domain.com", path:"/custom/path", tokenSource: nil),
+                                               httpMethod: .get)
+        
+        let urlString = resource.url.absoluteString
+        XCTAssertEqual(urlString, "https://custom.domain.com/custom/path/documents/", "path should match")
+    }
+    
 }

--- a/BankAPILibrary/GiniBankAPILibrary/Tests/GiniBankAPILibraryTests/UserResourceTests.swift
+++ b/BankAPILibrary/GiniBankAPILibrary/Tests/GiniBankAPILibraryTests/UserResourceTests.swift
@@ -47,4 +47,12 @@ class UserResourceTests: XCTestCase {
         XCTAssertEqual(urlString, "https://custom.domain.com/api/users")
     }
     
+    func testCustomUserDomainWithPath() {
+        let resource = UserResource<Token>(method: .users,
+                                           userDomain: .custom(domain: "custom.domain.com", path:"/custom/path"),
+                                           httpMethod: .post)
+        let urlString = resource.url.absoluteString
+        XCTAssertEqual(urlString, "https://custom.domain.com/custom/path/api/users")
+    }
+    
 }

--- a/BankSDK/GiniBankSDKExample/GiniBankSDKExample.xcodeproj/project.pbxproj
+++ b/BankSDK/GiniBankSDKExample/GiniBankSDKExample.xcodeproj/project.pbxproj
@@ -800,14 +800,14 @@
 				CODE_SIGN_ENTITLEMENTS = "GiniBankSDKExample/Example Swift.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = BQY9KX4V88;
+				DEVELOPMENT_TEAM = JA825X8F7Z;
 				INFOPLIST_FILE = GiniBankSDKExample/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = "net.gini.ginipaybank.Example-Swift";
+				PRODUCT_BUNDLE_IDENTIFIER = net.gini.banksdk.example;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_VERSION = 5.0;
@@ -823,14 +823,14 @@
 				CODE_SIGN_ENTITLEMENTS = "GiniBankSDKExample/Example Swift.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = BQY9KX4V88;
+				DEVELOPMENT_TEAM = JA825X8F7Z;
 				INFOPLIST_FILE = GiniBankSDKExample/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = "net.gini.ginipaybank.Example-Swift";
+				PRODUCT_BUNDLE_IDENTIFIER = net.gini.banksdk.example;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_VERSION = 5.0;


### PR DESCRIPTION
Changes for version 1.x.

Example of how to set the path when using the Bank SDK:
```swift
    let viewController = GiniBank.viewController(withClient: client,
                                                 configuration: configuration,
                                                 resultsDelegate: self,
                                                 api: .custom(domain: "scan2bank-service-v1-scan2bank-itu.apps.caas-ekad-test01.rz.bankenit.de",
                                                              path: "/rest/de.fiduciagad.scan2bank.api.v1.Scan2BankApi"), 
                                                              tokenSource: nil)
```