### PR TITLE
fix(GiniBankSDK): Fix localization for the Return Assistant strings

### DIFF
--- a/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/ReturnAssistant/DigitalInvoice/DigitalInvoiceViewController.swift
+++ b/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/ReturnAssistant/DigitalInvoice/DigitalInvoiceViewController.swift
@@ -96,7 +96,7 @@ final class DigitalInvoiceViewController: UIViewController {
 
     private func setupView() {
         title = NSLocalizedStringPreferredGiniBankFormat("ginibank.digitalinvoice.screentitle",
-                                                    comment: "Digital invoice")
+                                                         comment: "Digital invoice")
         edgesForExtendedLayout = []
         view.backgroundColor = GiniColor(light: .GiniBank.light2, dark: .GiniBank.dark2).uiColor()
         if configuration.bottomNavigationBarEnabled {

--- a/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/ReturnAssistant/DigitalInvoice/DigitalInvoiceViewController.swift
+++ b/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/ReturnAssistant/DigitalInvoice/DigitalInvoiceViewController.swift
@@ -95,9 +95,8 @@ final class DigitalInvoiceViewController: UIViewController {
     }
 
     private func setupView() {
-        title = NSLocalizedStringPreferredFormat("ginibank.digitalinvoice.screentitle",
-                                                 comment: "Digital invoice")
-
+        title = NSLocalizedStringPreferredGiniBankFormat("ginibank.digitalinvoice.screentitle",
+                                                    comment: "Digital invoice")
         edgesForExtendedLayout = []
         view.backgroundColor = GiniColor(light: .GiniBank.light2, dark: .GiniBank.dark2).uiColor()
         if configuration.bottomNavigationBarEnabled {

--- a/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/ReturnAssistant/EditLineItem/Components/QuantityView.swift
+++ b/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/ReturnAssistant/EditLineItem/Components/QuantityView.swift
@@ -46,7 +46,7 @@ final class QuantityView: UIView {
         button.setImage(prefferedImage(named: "quantity_minus_icon"), for: .normal)
         button.addTarget(self, action: #selector(decreaseQuantity), for: .touchUpInside)
         button.translatesAutoresizingMaskIntoConstraints = false
-        let descriptor = NSLocalizedStringPreferredFormat("ginibank.digitalinvoice.edit.minus.button.accessibility",
+        let descriptor = NSLocalizedStringPreferredGiniBankFormat("ginibank.digitalinvoice.edit.minus.button.accessibility",
                                                           comment: "Decrease quantity")
         button.accessibilityValue = descriptor
         return button
@@ -57,7 +57,7 @@ final class QuantityView: UIView {
         button.setImage(prefferedImage(named: "quantity_plus_icon"), for: .normal)
         button.addTarget(self, action: #selector(increaseQuantity), for: .touchUpInside)
         button.translatesAutoresizingMaskIntoConstraints = false
-        let descriptor = NSLocalizedStringPreferredFormat("ginibank.digitalinvoice.edit.plus.button.accessibility",
+        let descriptor = NSLocalizedStringPreferredGiniBankFormat("ginibank.digitalinvoice.edit.plus.button.accessibility",
                                                           comment: "Increase quantity")
         button.accessibilityValue = descriptor
         return button

--- a/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/ReturnAssistant/EditLineItem/Components/QuantityView.swift
+++ b/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/ReturnAssistant/EditLineItem/Components/QuantityView.swift
@@ -47,7 +47,7 @@ final class QuantityView: UIView {
         button.addTarget(self, action: #selector(decreaseQuantity), for: .touchUpInside)
         button.translatesAutoresizingMaskIntoConstraints = false
         let descriptor = NSLocalizedStringPreferredGiniBankFormat("ginibank.digitalinvoice.edit.minus.button.accessibility",
-                                                          comment: "Decrease quantity")
+                                                                  comment: "Decrease quantity")
         button.accessibilityValue = descriptor
         return button
     }()
@@ -58,7 +58,7 @@ final class QuantityView: UIView {
         button.addTarget(self, action: #selector(increaseQuantity), for: .touchUpInside)
         button.translatesAutoresizingMaskIntoConstraints = false
         let descriptor = NSLocalizedStringPreferredGiniBankFormat("ginibank.digitalinvoice.edit.plus.button.accessibility",
-                                                          comment: "Increase quantity")
+                                                                  comment: "Increase quantity")
         button.accessibilityValue = descriptor
         return button
     }()

--- a/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/ReturnAssistant/Help/DigitalInvoiceHelpViewController.swift
+++ b/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/ReturnAssistant/Help/DigitalInvoiceHelpViewController.swift
@@ -59,7 +59,7 @@ final class DigitalInvoiceHelpViewController: UIViewController {
         scrollView.addSubview(contentView)
         contentView.addSubview(stackView)
 
-        let backButtonTitle = NSLocalizedStringPreferredFormat("ginibank.digitalinvoice.help.backToInvoice",
+        let backButtonTitle = NSLocalizedStringPreferredGiniBankFormat("ginibank.digitalinvoice.help.backToInvoice",
                                                                comment: "Digital Invoice")
         let backButton = GiniBarButton(ofType: .back(title: backButtonTitle))
         backButton.addAction(self, #selector(dismissViewController))

--- a/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/ReturnAssistant/Help/DigitalInvoiceHelpViewController.swift
+++ b/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/ReturnAssistant/Help/DigitalInvoiceHelpViewController.swift
@@ -60,7 +60,7 @@ final class DigitalInvoiceHelpViewController: UIViewController {
         contentView.addSubview(stackView)
 
         let backButtonTitle = NSLocalizedStringPreferredGiniBankFormat("ginibank.digitalinvoice.help.backToInvoice",
-                                                               comment: "Digital Invoice")
+                                                                       comment: "Digital Invoice")
         let backButton = GiniBarButton(ofType: .back(title: backButtonTitle))
         backButton.addAction(self, #selector(dismissViewController))
         navigationItem.leftBarButtonItem = backButton.barButton

--- a/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/ReturnAssistant/Onboarding/DigitalInvoiceOnboardingViewController.swift
+++ b/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/ReturnAssistant/Onboarding/DigitalInvoiceOnboardingViewController.swift
@@ -73,8 +73,7 @@ final class DigitalInvoiceOnboardingViewController: UIViewController {
     // swiftlint:disable function_body_length
     private func configureUI() {
         let configuration = GiniBankConfiguration.shared
-        title = NSLocalizedStringPreferredFormat("ginibank.digitalinvoice.screentitle",
-                                                 comment: "Digital invoice")
+
         view.backgroundColor = GiniColor(light: UIColor.GiniBank.light2, dark: UIColor.GiniBank.dark2).uiColor()
         contentView.backgroundColor = .clear
 


### PR DESCRIPTION
For customizing the localizable strings from GiniBankSDK we use "NSLocalizedStringPreferredGiniBankFormat" Remove unused title for the Digital Invoice Onboarding screen

PIA-4034