### PR TITLE
chores: Fix swiftlint warnings

### DIFF
--- a/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/GiniBankConfiguration.swift
+++ b/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/GiniBankConfiguration.swift
@@ -530,6 +530,7 @@ public final class GiniBankConfiguration: NSObject {
 
         return configuration
     }
+    // swiftlint:enable function_body_length
 
     /**
      Sets the configuration flags back. Used only in the example app. See `SettingsViewController` for the details.
@@ -644,4 +645,5 @@ public final class GiniBankConfiguration: NSObject {
         self.documentService = nil
         self.lineItems = nil
     }
+    // swiftlint: enable function_parameter_count
 }

--- a/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/GiniBankConfiguration.swift
+++ b/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/GiniBankConfiguration.swift
@@ -645,5 +645,5 @@ public final class GiniBankConfiguration: NSObject {
         self.documentService = nil
         self.lineItems = nil
     }
-    // swiftlint:enable  function_parameter_count
+    // swiftlint:enable function_parameter_count
 }

--- a/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/GiniBankConfiguration.swift
+++ b/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/GiniBankConfiguration.swift
@@ -424,7 +424,7 @@ public final class GiniBankConfiguration: NSObject {
     .footnoteBold: UIFontMetrics(forTextStyle: .footnote).scaledFont(for: UIFont.boldSystemFont(ofSize: 13))
     ]
 
-    // swiftlint: disable function_body_length
+    // swiftlint:disable function_body_length
     public func captureConfiguration() -> GiniConfiguration {
         let configuration = GiniConfiguration.shared
         configuration.customDocumentValidations = self.customDocumentValidations
@@ -576,7 +576,7 @@ public final class GiniBankConfiguration: NSObject {
     var documentService: DocumentServiceProtocol?
     var lineItems: [[Extraction]]?
 
-    // swiftlint: disable function_parameter_count
+    // swiftlint:disable function_parameter_count
     /// Function for clean up
     /// - Parameters:
     ///   - paymentRecipient: paymentRecipient description
@@ -645,5 +645,5 @@ public final class GiniBankConfiguration: NSObject {
         self.documentService = nil
         self.lineItems = nil
     }
-    // swiftlint: enable function_parameter_count
+    // swiftlint:enable  function_parameter_count
 }

--- a/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/ReturnAssistant/DigitalInvoice/Model/LineItem.swift
+++ b/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/ReturnAssistant/DigitalInvoice/Model/LineItem.swift
@@ -129,7 +129,7 @@ extension DigitalInvoice {
     }
 }
 
-// swiftlint: disable implicit_getter
+// swiftlint:disable implicit_getter
 extension ReturnReason {
     var labelInLocalLanguageOrGerman: String {
         get {

--- a/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/ReturnAssistant/Onboarding/DigitalInvoiceOnboardingViewController.swift
+++ b/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/ReturnAssistant/Onboarding/DigitalInvoiceOnboardingViewController.swift
@@ -137,6 +137,7 @@ final class DigitalInvoiceOnboardingViewController: UIViewController {
 
         configureConstraints()
     }
+    // swiftlint:enable function_body_length
 
     private func configureConstraints() {
         if UIDevice.current.isIpad {

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Extensions/Array.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Extensions/Array.swift
@@ -7,8 +7,10 @@
 
 import Foundation
 
+// swiftlint:disable large_tuple
 typealias DiffResults<Element: Diffable> = (updated: [Element], removed: [Element], inserted: [Element])
 typealias DiffResultsIndexes = (updated: [Int], removed: [Int], inserted: [Int])
+// swiftlint:enable large_tuple
 
 extension Array where Element: Diffable {
     func diff(with second: [Element]) -> DiffResults<Element> {

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/GiniConfiguration.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/GiniConfiguration.swift
@@ -557,5 +557,5 @@ import GiniBankAPILibrary
          documentService.resetToInitialState()
          self.documentService = nil
      }
-    // swiftlint:enable  function_parameter_count
+    // swiftlint:enable function_parameter_count
 }

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/GiniConfiguration.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/GiniConfiguration.swift
@@ -495,7 +495,7 @@ import GiniBankAPILibrary
 
     var documentService: DocumentServiceProtocol?
 
-    // swiftlint: disable function_parameter_count
+    // swiftlint:disable function_parameter_count
      /// Function for clean up
      /// - Parameters:
      ///   - paymentRecipient: paymentRecipient description
@@ -557,5 +557,5 @@ import GiniBankAPILibrary
          documentService.resetToInitialState()
          self.documentService = nil
      }
-    // swiftlint: enable function_parameter_count
+    // swiftlint:enable  function_parameter_count
 }

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/GiniConfiguration.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/GiniConfiguration.swift
@@ -495,8 +495,7 @@ import GiniBankAPILibrary
 
     var documentService: DocumentServiceProtocol?
 
-    // swiftlint:disable function_body_length
-    // swiftlint:disable function_parameter_count
+    // swiftlint: disable function_parameter_count
      /// Function for clean up
      /// - Parameters:
      ///   - paymentRecipient: paymentRecipient description
@@ -558,4 +557,5 @@ import GiniBankAPILibrary
          documentService.resetToInitialState()
          self.documentService = nil
      }
+    // swiftlint: enable function_parameter_count
 }

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Models/GiniImageDocument.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Models/GiniImageDocument.swift
@@ -49,7 +49,7 @@ final public class GiniImageDocument: NSObject, GiniCaptureDocument {
         self.id = UUID().uuidString
 
         switch imageSource {
-        case .appName(name: _) :
+        case .appName(name: _):
             isFromOtherApp = true
         default:
             isFromOtherApp = false

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Camera/Camera2/Camera2ViewController.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Camera/Camera2/Camera2ViewController.swift
@@ -586,3 +586,4 @@ private extension Camera2ViewController {
         static let tableSwitcherSize: CGSize = CGSize(width: 40, height: 124)
     }
 }
+// swiftlint:enable type_body_length

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Camera/Camera2/CameraLensSwitcherView.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Camera/Camera2/CameraLensSwitcherView.swift
@@ -24,6 +24,7 @@ protocol CameraLensSwitcherViewDelegate: AnyObject {
     func cameraLensSwitcherDidSwitchTo(lens: CameraLensesAvailable, on: CameraLensSwitcherView)
 }
 
+// swiftlint: disable type_body_length
 final class CameraLensSwitcherView: UIView {
     private lazy var buttonContainerView: UIView = {
         let view = UIView()
@@ -415,3 +416,4 @@ private extension CameraLensSwitcherView {
         static let maxFontSize: CGFloat = 17
     }
 }
+// swiftlint: enable type_body_length

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Camera/Camera2/CameraLensSwitcherView.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Camera/Camera2/CameraLensSwitcherView.swift
@@ -416,4 +416,4 @@ private extension CameraLensSwitcherView {
         static let maxFontSize: CGFloat = 17
     }
 }
-// swiftlint:enable  type_body_length
+// swiftlint:enable type_body_length

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Camera/Camera2/CameraLensSwitcherView.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Camera/Camera2/CameraLensSwitcherView.swift
@@ -24,7 +24,7 @@ protocol CameraLensSwitcherViewDelegate: AnyObject {
     func cameraLensSwitcherDidSwitchTo(lens: CameraLensesAvailable, on: CameraLensSwitcherView)
 }
 
-// swiftlint: disable type_body_length
+// swiftlint:disable type_body_length
 final class CameraLensSwitcherView: UIView {
     private lazy var buttonContainerView: UIView = {
         let view = UIView()
@@ -416,4 +416,4 @@ private extension CameraLensSwitcherView {
         static let maxFontSize: CGFloat = 17
     }
 }
-// swiftlint: enable type_body_length
+// swiftlint:enable  type_body_length

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Document picker/Gallery/GalleryCoordinator.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Document picker/Gallery/GalleryCoordinator.swift
@@ -220,6 +220,7 @@ final class GalleryCoordinator: NSObject, Coordinator {
             }
         }
     }
+    // swiftlint:enable function_body_length
 }
 
 // MARK: UINavigationControllerDelegate

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Help/DataSources/HelpFormatsDataSource.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Help/DataSources/HelpFormatsDataSource.swift
@@ -8,9 +8,11 @@
 
 import UIKit
 
+// swiftlint:disable large_tuple
 typealias HelpFormatsCollectionSection = (title: String,
-    formats: [String],
-    formatsImage: UIImage?)
+                                          formats: [String],
+                                          formatsImage: UIImage?)
+// swiftlint:enable large_tuple
 
 class HelpFormatsDataSource: HelpRoundedCornersDataSource<HelpFormatsCollectionSection, HelpFormatCell> {
 

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Review/ReviewViewController.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Review/ReviewViewController.swift
@@ -6,14 +6,14 @@
 //
 
 import UIKit
-
+// swiftlint:disable file_length
 /**
  The ReviewViewControllerDelegate protocol defines methods that allow you to handle user actions in the
  ReviewViewControllerDelegate
  (tap add, delete...)
  
  - note: Component API only.
- - TODO:  - REMOVE Componen API
+ - TODO:  - REMOVE Component API
  */
 public protocol ReviewViewControllerDelegate: AnyObject {
     /**
@@ -63,8 +63,6 @@ public protocol ReviewViewControllerDelegate: AnyObject {
 
   - note: Component API only.
   */
-
-// swiftlint:disable file_length
 public final class ReviewViewController: UIViewController {
 
     /**
@@ -707,3 +705,4 @@ extension ReviewViewController {
         static let bottomNavigationBarHeight: CGFloat = 114
     }
 }
+// swiftlint:enable file_length


### PR DESCRIPTION
chores: Fix swiftlint warnings
- added enable rule for the ones that were missing after disabling them 

Remains to be fixed other two warnings:
`// swiftlint:disable force_cast` - we can discuss later
`// swiftlint:disable implicit_getter` - I have a suggestion to fix this 