### PR TITLE
chores(GiniBankSDK): Swift Package Manager dependencies fixes

### DIFF
--- a/BankSDK/GiniBankSDKExample/GiniBankSDKExample.xcodeproj/project.pbxproj
+++ b/BankSDK/GiniBankSDKExample/GiniBankSDKExample.xcodeproj/project.pbxproj
@@ -1091,8 +1091,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/airbnb/lottie-ios.git";
 			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 3.0.0;
+				kind = exactVersion;
+				version = 3.0.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/GiniMobile.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/GiniMobile.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/airbnb/lottie-ios.git",
         "state": {
           "branch": null,
-          "revision": "314537ec697719fa33a9d48210f4d06a463286d3",
-          "version": "3.4.3"
+          "revision": "b4bd0604ded9574807f41b4004b57dd1226a30a4",
+          "version": "3.5.0"
         }
       },
       {


### PR DESCRIPTION
chores(GiniBankSDK): changed from `upToNextMajorVersion` to `exactVersion` to better control the updates of dependencies
- update `Lottie` dependency to the latest version