### PR TITLE
fix(GiniCaptureSDK): Fix the display of the error screen on the main thread after the server returned the error

### DIFF
--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Networking/GiniNetworkingScreenAPICoordinator.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Networking/GiniNetworkingScreenAPICoordinator.swift
@@ -139,7 +139,9 @@ extension GiniNetworkingScreenAPICoordinator {
                 self.deliver(result: extractions, and: self.documentService.document, to: networkDelegate)
             case .failure(let error):
                 guard error != .requestCancelled else { return }
-                networkDelegate.displayError(errorType: ErrorType(error: error), animated: true)
+                DispatchQueue.main.async {
+                    networkDelegate.displayError(errorType: ErrorType(error: error), animated: true)
+                }
             }
         }
     }

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Networking/GiniNetworkingScreenAPICoordinator.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Networking/GiniNetworkingScreenAPICoordinator.swift
@@ -134,12 +134,12 @@ import GiniBankAPILibrary
 extension GiniNetworkingScreenAPICoordinator {
     fileprivate func startAnalysis(networkDelegate: GiniCaptureNetworkDelegate) {
         self.documentService.startAnalysis { result in
-            switch result {
-            case .success(let extractions):
-                self.deliver(result: extractions, and: self.documentService.document, to: networkDelegate)
-            case .failure(let error):
-                guard error != .requestCancelled else { return }
-                DispatchQueue.main.async {
+            DispatchQueue.main.async {
+                switch result {
+                case .success(let extractions):
+                    self.deliver(result: extractions, and: self.documentService.document, to: networkDelegate)
+                case .failure(let error):
+                    guard error != .requestCancelled else { return }
                     networkDelegate.displayError(errorType: ErrorType(error: error), animated: true)
                 }
             }

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Networking/GiniNetworkingScreenAPICoordinator.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Networking/GiniNetworkingScreenAPICoordinator.swift
@@ -167,7 +167,9 @@ extension GiniNetworkingScreenAPICoordinator {
             self.startAnalysis(networkDelegate: networkDelegate)
         }, didFail: { _, error in
             guard let giniError = error as? GiniError, giniError != .requestCancelled else { return }
-            networkDelegate.displayError(errorType: ErrorType(error: giniError), animated: true)
+            DispatchQueue.main.async {
+                networkDelegate.displayError(errorType: ErrorType(error: giniError), animated: true)
+            }
         })
     }
 }

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Networking/GiniNetworkingScreenAPICoordinator.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Networking/GiniNetworkingScreenAPICoordinator.swift
@@ -134,12 +134,12 @@ import GiniBankAPILibrary
 extension GiniNetworkingScreenAPICoordinator {
     fileprivate func startAnalysis(networkDelegate: GiniCaptureNetworkDelegate) {
         self.documentService.startAnalysis { result in
-            DispatchQueue.main.async {
-                switch result {
-                case .success(let extractions):
-                    self.deliver(result: extractions, and: self.documentService.document, to: networkDelegate)
-                case .failure(let error):
-                    guard error != .requestCancelled else { return }
+            switch result {
+            case .success(let extractions):
+                self.deliver(result: extractions, and: self.documentService.document, to: networkDelegate)
+            case .failure(let error):
+                guard error != .requestCancelled else { return }
+                DispatchQueue.main.async {
                     networkDelegate.displayError(errorType: ErrorType(error: error), animated: true)
                 }
             }


### PR DESCRIPTION
Fix the display of the error screen on the main thread after the server returned the error

PIA-4271