### PR TITLE
fix(GiniCaptureSDK): Hide extension UITableViewCell: ReuseIdentifiable {}

### DIFF
--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Extensions/ReuseIdentifier.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Extensions/ReuseIdentifier.swift
@@ -7,11 +7,11 @@
 
 import UIKit
 
-public protocol Reusable {
+protocol Reusable {
     static var reuseIdentifier: String { get }
 }
 
-public extension Reusable {
+extension Reusable {
     static var reuseIdentifier: String {
         String(describing: self)
     }


### PR DESCRIPTION
Hide extension UITableViewCell: ReuseIdentifiable {}

Customers had the compile issues about it.

PIA-4192