### PR TITLE
fix(GiniCaptureSDK): Removed open override `layoutSubviews`

### DIFF
--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Helpers/Utils.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Helpers/Utils.swift
@@ -24,11 +24,6 @@ extension UITableViewCell {
         layer.mask = nil
         clipsToBounds = true
     }
-
-    open override func layoutSubviews() {
-        super.layoutSubviews()
-        layer.mask?.frame = bounds
-    }
 }
 
 public struct GiniMargins {


### PR DESCRIPTION
fix(GiniCaptureSDK): Removed open override `layoutSubviews`
It is corrupting the table view layout where UITableViewCell was used

PIA-4381

The original commit message was: `fix(GiniCaptureSDK): fix layouting issues in help format screen PIA-3134`
https://ginis.atlassian.net/browse/PIA-3134