### PR TITLE
Pia 4389 issues while deleting a failed page for multipage invoice

### DIFF
--- a/BankSDK/GiniBankSDKExample/GiniBankSDKExample.xcodeproj/project.pbxproj
+++ b/BankSDK/GiniBankSDKExample/GiniBankSDKExample.xcodeproj/project.pbxproj
@@ -843,7 +843,7 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = BQY9KX4V88;
+				DEVELOPMENT_TEAM = JA825X8F7Z;
 				INFOPLIST_FILE = Tests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Multipage Review/MultipageReviewViewController.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Multipage Review/MultipageReviewViewController.swift
@@ -538,17 +538,16 @@ extension MultipageReviewViewController {
     }
     
     @objc fileprivate func rotateImageButtonAction() {
-        if let currentIndexPath = visibleCell(in: self.mainCollection) {
-            presenter.rotateThumbnails(for: pages[currentIndexPath.row])
-            
-            mainCollection.reloadItems(at: [currentIndexPath])
-            pagesCollection.reloadItems(at: [currentIndexPath])
-            
-            selectItem(at: currentIndexPath.row)
-            delegate?.multipageReview(self, didRotate: pages[currentIndexPath.row])
-        }
-    }
-    
+		let currentIndexPath = IndexPath(row: currentSelectedItemPosition, section: 0)
+		presenter.rotateThumbnails(for: pages[currentIndexPath.row])
+		
+		mainCollection.reloadItems(at: [currentIndexPath])
+		pagesCollection.reloadItems(at: [currentIndexPath])
+		
+		selectItem(at: currentIndexPath.row)
+		delegate?.multipageReview(self, didRotate: pages[currentIndexPath.row])
+	}
+	
     @objc fileprivate func deleteImageButtonAction() {
 		let indexPath = IndexPath(row: currentSelectedItemPosition, section: 0)
 		deleteItem(at: indexPath)

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Multipage Review/MultipageReviewViewController.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Multipage Review/MultipageReviewViewController.swift
@@ -550,9 +550,8 @@ extension MultipageReviewViewController {
     }
     
     @objc fileprivate func deleteImageButtonAction() {
-        if let currentIndexPath = visibleCell(in: self.mainCollection) {
-            deleteItem(at: currentIndexPath)
-        }
+		let indexPath = IndexPath(row: currentSelectedItemPosition, section: 0)
+		deleteItem(at: indexPath)
     }
     
 }


### PR DESCRIPTION
- fix the deletion of the failed page of the multi-pages invoice using `currentSelectedItemPosition`
- fix logic for rotating the image when having multi-page loaded
- set the correct development team for `GiniBankSDKExample` target

PIA-4389