### PR TITLE
Pia 2548 custom bundle

### DIFF
--- a/.github/workflows/bank-sdk.build.xcframeworks.yml
+++ b/.github/workflows/bank-sdk.build.xcframeworks.yml
@@ -2,7 +2,7 @@ name: Build BankSDK XCFrameworks
 on:
   push:
     tags:
-      - 'GiniBankSDK;[0-9]+.[0-9]+.[0-9]+;xcframeworks**'
+      - 'GiniBankSDK;CustomBundle;xcframeworks'
   workflow_call:
 jobs:
   prepare-frameworks:

--- a/.github/workflows/bank-sdk.build.xcframeworks.yml
+++ b/.github/workflows/bank-sdk.build.xcframeworks.yml
@@ -2,7 +2,7 @@ name: Build BankSDK XCFrameworks
 on:
   push:
     tags:
-      - 'GiniBankSDK;CustomBundle;xcframeworks'
+      - 'GiniBankSDK;[0-9]+.[0-9]+.[0-9]+;xcframeworks**'
   workflow_call:
 jobs:
   prepare-frameworks:

--- a/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/GiniBankConfiguration.swift
+++ b/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/GiniBankConfiguration.swift
@@ -1189,6 +1189,11 @@ public final class GiniBankConfiguration: NSObject {
      */
     public var localizedStringsTableName: String?
     
+    /**
+    Should be set if the main app's bundle is not used.
+    */
+    public var customResourceBundle: Bundle?
+    
     public func captureConfiguration() -> GiniConfiguration {
      let configuration = GiniConfiguration()
         
@@ -1332,6 +1337,7 @@ public final class GiniBankConfiguration: NSObject {
         configuration.nextButtonResource = self.nextButtonResource
         configuration.cancelButtonResource = self.cancelButtonResource
         configuration.localizedStringsTableName = self.localizedStringsTableName
+        configuration.customResourceBundle = self.customResourceBundle
         
         GiniCapture.setConfiguration(configuration)
         
@@ -1582,6 +1588,7 @@ public final class GiniBankConfiguration: NSObject {
         giniBankConfiguration.localizedStringsTableName = configuration.localizedStringsTableName
         
         giniBankConfiguration.albumsScreenSelectMorePhotosTextColor = configuration.albumsScreenSelectMorePhotosTextColor
+        giniBankConfiguration.customResourceBundle = configuration.customResourceBundle
         
         // Undocumented--Xamarin only
         giniBankConfiguration.closeButtonResource = configuration.closeButtonResource

--- a/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/GiniBankUtils.swift
+++ b/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/GiniBankUtils.swift
@@ -66,7 +66,7 @@ func prefferedImage(named name: String) -> UIImage? {
     if let mainBundleImage = UIImage(named: name, in: Bundle.main, compatibleWith: nil) {
         return mainBundleImage
     }
-    if let customBundle = GiniConfiguration.shared.customResourceBundle,
+    if let customBundle = GiniBankConfiguration.shared.customResourceBundle,
        let customBundleImage = UIImage(named: name, in: customBundle, compatibleWith: nil) {
         return customBundleImage
     }

--- a/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/GiniBankUtils.swift
+++ b/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/GiniBankUtils.swift
@@ -22,33 +22,52 @@ func NSLocalizedStringPreferredGiniBankFormat(_ key: String,
                                               fallbackKey: String = "",
                                               comment: String,
                                               isCustomizable: Bool = true) -> String {
-    var clientString: String
-    var fallbackClientString: String
-    if let localizedResourceName = GiniBankConfiguration.shared.localizedStringsTableName {
-        clientString = NSLocalizedString(key, tableName: localizedResourceName, comment: comment)
-        fallbackClientString = NSLocalizedString(fallbackKey,tableName: localizedResourceName, comment: comment)
-    } else {
-        clientString = NSLocalizedString(key, comment: comment)
-        fallbackClientString = NSLocalizedString(fallbackKey, comment: comment)
-    }
+    if isCustomizable {
+        if let clientLocalizedStringMainBundle = clientLocalizedString(key, fallbackKey: fallbackKey, comment: comment, bundle: .main) {
 
-    let format: String
-    
-    if (clientString.lowercased() != key.lowercased() || fallbackClientString.lowercased() != fallbackKey.lowercased())
-        && isCustomizable {
-        format = clientString
-    } else {
-        let bundle = giniBankBundle()
-        var defaultFormat = NSLocalizedString(key, bundle: bundle, comment: comment)
-        
-        if defaultFormat.lowercased() == key.lowercased() {
-            defaultFormat = NSLocalizedString(fallbackKey, bundle: bundle, comment: comment)
+            return clientLocalizedStringMainBundle
+            
+        } else if let customBundle = GiniBankConfiguration.shared.customResourceBundle,
+                  let clientLocalizedStringCustomBundle = clientLocalizedString(key, fallbackKey: fallbackKey, comment: comment, bundle: customBundle) {
+            
+            return clientLocalizedStringCustomBundle
         }
-        
-        format = defaultFormat
     }
     
-    return format
+    return giniLocalizedString(key, fallbackKey: fallbackKey, comment: comment)
+}
+
+private func clientLocalizedString(_ key: String,
+                                   fallbackKey: String,
+                                   comment: String,
+                                   bundle: Bundle) -> String? {
+    var clientString = NSLocalizedString(key, bundle: bundle, comment: comment)
+    var fallbackClientString = NSLocalizedString(fallbackKey,bundle: bundle, comment: comment)
+    
+    if let localizedResourceName = GiniBankConfiguration.shared.localizedStringsTableName {
+        clientString = NSLocalizedString(key, tableName: localizedResourceName, bundle: bundle, comment: comment)
+        fallbackClientString = NSLocalizedString(fallbackKey,tableName: localizedResourceName, bundle: bundle, comment: comment)
+    }
+    
+    guard (clientString.lowercased() != key.lowercased() || fallbackClientString.lowercased() != fallbackKey.lowercased()) else {
+        return nil
+    }
+    
+    return clientString
+}
+
+private func giniLocalizedString(_ key: String,
+                                 fallbackKey: String,
+                                 comment: String) -> String {
+    let bundle = giniBankBundle()
+    
+    var defaultFormat = NSLocalizedString(key, bundle: bundle, comment: comment)
+    
+    if defaultFormat.lowercased() == key.lowercased() {
+        defaultFormat = NSLocalizedString(fallbackKey, bundle: bundle, comment: comment)
+    }
+    
+    return defaultFormat
 }
 
 func giniBankBundle() -> Bundle {

--- a/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/GiniBankUtils.swift
+++ b/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/GiniBankUtils.swift
@@ -38,7 +38,7 @@ func NSLocalizedStringPreferredGiniBankFormat(_ key: String,
         && isCustomizable {
         format = clientString
     } else {
-        let bundle = prefferedBundle()
+        let bundle = giniBankBundle()
         var defaultFormat = NSLocalizedString(key, bundle: bundle, comment: comment)
         
         if defaultFormat.lowercased() == key.lowercased() {
@@ -63,18 +63,15 @@ func giniBankBundle() -> Bundle {
  - returns: Image if found with name.
  */
 func prefferedImage(named name: String) -> UIImage? {
-    if let clientImage = UIImage(named: name) {
-        return clientImage
+    if let mainBundleImage = UIImage(named: name, in: Bundle.main, compatibleWith: nil) {
+        return mainBundleImage
     }
-    return UIImage(named: name, in: prefferedBundle(), compatibleWith: nil)
-}
-
-private func prefferedBundle() -> Bundle {
-    if let customBundle = GiniBankConfiguration.shared.customResourceBundle {
-        return customBundle
-    } else {
-        return giniBankBundle()
+    if let customBundle = GiniConfiguration.shared.customResourceBundle,
+       let customBundleImage = UIImage(named: name, in: customBundle, compatibleWith: nil) {
+        return customBundleImage
     }
+    
+    return UIImage(named: name, in: giniBankBundle(), compatibleWith: nil)
 }
 
 /**

--- a/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/GiniBankUtils.swift
+++ b/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/GiniBankUtils.swift
@@ -38,7 +38,7 @@ func NSLocalizedStringPreferredGiniBankFormat(_ key: String,
         && isCustomizable {
         format = clientString
     } else {
-        let bundle = giniBankBundle()
+        let bundle = prefferedBundle()
         var defaultFormat = NSLocalizedString(key, bundle: bundle, comment: comment)
         
         if defaultFormat.lowercased() == key.lowercased() {
@@ -66,8 +66,15 @@ func prefferedImage(named name: String) -> UIImage? {
     if let clientImage = UIImage(named: name) {
         return clientImage
     }
-    let bundle = giniBankBundle()
-    return UIImage(named: name, in: bundle, compatibleWith: nil)
+    return UIImage(named: name, in: prefferedBundle(), compatibleWith: nil)
+}
+
+private func prefferedBundle() -> Bundle {
+    if let customBundle = GiniBankConfiguration.shared.customResourceBundle {
+        return customBundle
+    } else {
+        return giniBankBundle()
+    }
 }
 
 /**

--- a/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/GiniBankUtils.swift
+++ b/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/GiniBankUtils.swift
@@ -19,9 +19,9 @@ public protocol GiniBankAnalysisDelegate : AnalysisDelegate {}
  - returns: String resource for the given key.
  */
 func NSLocalizedStringPreferredGiniBankFormat(_ key: String,
-                                      fallbackKey: String = "",
-                                      comment: String,
-                                      isCustomizable: Bool = true) -> String {
+                                              fallbackKey: String = "",
+                                              comment: String,
+                                              isCustomizable: Bool = true) -> String {
     var clientString: String
     var fallbackClientString: String
     if let localizedResourceName = GiniBankConfiguration.shared.localizedStringsTableName {

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/GiniConfiguration.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/GiniConfiguration.swift
@@ -739,6 +739,11 @@ import UIKit
      Should be set if the default name "Localizable.strings" are not used.
      */
     public var localizedStringsTableName: String?
+    
+    /**
+    Should be set if the main app's bundle is not used.
+    */
+    public var customResourceBundle: Bundle?
 
     // Undocumented--Xamarin only
     @objc public var closeButtonResource: PreferredButtonResource?

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Helpers/GiniCaptureUtils.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Helpers/GiniCaptureUtils.swift
@@ -23,7 +23,15 @@ public func UIImageNamedPreferred(named name: String) -> UIImage? {
     if let clientImage = UIImage(named: name) {
         return clientImage
     }
-    return UIImage(named: name, in: giniCaptureBundle(), compatibleWith: nil)
+    return UIImage(named: name, in: prefferedBundle(), compatibleWith: nil)
+}
+
+private func prefferedBundle() -> Bundle {
+    if let customBundle = GiniConfiguration.shared.customResourceBundle {
+        return customBundle
+    } else {
+        return giniCaptureBundle()
+    }
 }
 
 /**
@@ -53,7 +61,7 @@ public func NSLocalizedStringPreferredFormat(_ key: String,
         && isCustomizable {
         format = clientString
     } else {
-        let bundle = giniCaptureBundle()
+        let bundle = prefferedBundle()
 
         var defaultFormat = NSLocalizedString(key, bundle: bundle, comment: comment)
         

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Helpers/GiniCaptureUtils.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Helpers/GiniCaptureUtils.swift
@@ -23,11 +23,12 @@ public func UIImageNamedPreferred(named name: String) -> UIImage? {
     if let mainBundleImage = UIImage(named: name, in: Bundle.main, compatibleWith: nil) {
         return mainBundleImage
     }
+    
     if let customBundle = GiniConfiguration.shared.customResourceBundle,
        let customBundleImage = UIImage(named: name, in: customBundle, compatibleWith: nil) {
         return customBundleImage
     }
-    
+   
     return UIImage(named: name, in: giniCaptureBundle(), compatibleWith: nil)
 }
 

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Helpers/GiniCaptureUtils.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Helpers/GiniCaptureUtils.swift
@@ -44,33 +44,52 @@ public func NSLocalizedStringPreferredFormat(_ key: String,
                                              fallbackKey: String = "",
                                              comment: String,
                                              isCustomizable: Bool = true) -> String {
-    var clientString: String
-    var fallbackClientString: String
-    if let localizedResourceName = GiniConfiguration.shared.localizedStringsTableName {
-        clientString = NSLocalizedString(key, tableName: localizedResourceName, comment: comment)
-        fallbackClientString = NSLocalizedString(fallbackKey,tableName: localizedResourceName, comment: comment)
-    } else {
-        clientString = NSLocalizedString(key, comment: comment)
-        fallbackClientString = NSLocalizedString(fallbackKey, comment: comment)
-    }
-        
-    let format: String
-    if (clientString.lowercased() != key.lowercased() || fallbackClientString.lowercased() != fallbackKey.lowercased())
-        && isCustomizable {
-        format = clientString
-    } else {
-        let bundle = giniCaptureBundle()
-
-        var defaultFormat = NSLocalizedString(key, bundle: bundle, comment: comment)
-        
-        if defaultFormat.lowercased() == key.lowercased() {
-            defaultFormat = NSLocalizedString(fallbackKey, bundle: bundle, comment: comment)
+    if isCustomizable {
+        if let clientLocalizedStringMainBundle = clientLocalizedString(key, fallbackKey: fallbackKey, comment: comment, bundle: .main) {
+            
+            return clientLocalizedStringMainBundle
+            
+        } else if let customBundle = GiniConfiguration.shared.customResourceBundle,
+                  let clientLocalizedStringCustomBundle = clientLocalizedString(key, fallbackKey: fallbackKey, comment: comment, bundle: customBundle) {
+            
+            return clientLocalizedStringCustomBundle
         }
-        
-        format = defaultFormat
     }
     
-    return format
+    return giniLocalizedString(key, fallbackKey: fallbackKey, comment: comment)
+}
+
+private func clientLocalizedString(_ key: String,
+                                   fallbackKey: String,
+                                   comment: String,
+                                   bundle: Bundle) -> String? {
+    var clientString = NSLocalizedString(key, bundle: bundle, comment: comment)
+    var fallbackClientString = NSLocalizedString(fallbackKey, bundle: bundle, comment: comment)
+    
+    if let localizedResourceName = GiniConfiguration.shared.localizedStringsTableName {
+        clientString = NSLocalizedString(key, tableName: localizedResourceName, bundle: bundle, comment: comment)
+        fallbackClientString = NSLocalizedString(fallbackKey,tableName: localizedResourceName, bundle: bundle, comment: comment)
+    }
+    
+    guard (clientString.lowercased() != key.lowercased() || fallbackClientString.lowercased() != fallbackKey.lowercased()) else {
+        return nil
+    }
+    
+    return clientString
+}
+
+private func giniLocalizedString(_ key: String,
+                                 fallbackKey: String,
+                                 comment: String) -> String {
+    let bundle = giniCaptureBundle()
+    
+    var defaultFormat = NSLocalizedString(key, bundle: bundle, comment: comment)
+    
+    if defaultFormat.lowercased() == key.lowercased() {
+        defaultFormat = NSLocalizedString(fallbackKey, bundle: bundle, comment: comment)
+    }
+    
+    return defaultFormat
 }
 
 struct AnimationDuration {

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Helpers/GiniCaptureUtils.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Helpers/GiniCaptureUtils.swift
@@ -20,18 +20,15 @@ public func giniCaptureBundle() -> Bundle {
  - returns: Image if found with name.
  */
 public func UIImageNamedPreferred(named name: String) -> UIImage? {
-    if let clientImage = UIImage(named: name) {
-        return clientImage
+    if let mainBundleImage = UIImage(named: name, in: Bundle.main, compatibleWith: nil) {
+        return mainBundleImage
     }
-    return UIImage(named: name, in: prefferedBundle(), compatibleWith: nil)
-}
-
-private func prefferedBundle() -> Bundle {
-    if let customBundle = GiniConfiguration.shared.customResourceBundle {
-        return customBundle
-    } else {
-        return giniCaptureBundle()
+    if let customBundle = GiniConfiguration.shared.customResourceBundle,
+       let customBundleImage = UIImage(named: name, in: customBundle, compatibleWith: nil) {
+        return customBundleImage
     }
+    
+    return UIImage(named: name, in: giniCaptureBundle(), compatibleWith: nil)
 }
 
 /**
@@ -61,7 +58,7 @@ public func NSLocalizedStringPreferredFormat(_ key: String,
         && isCustomizable {
         format = clientString
     } else {
-        let bundle = prefferedBundle()
+        let bundle = giniCaptureBundle()
 
         var defaultFormat = NSLocalizedString(key, bundle: bundle, comment: comment)
         

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Helpers/GiniCaptureUtils.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Helpers/GiniCaptureUtils.swift
@@ -40,9 +40,9 @@ public func UIImageNamedPreferred(named name: String) -> UIImage? {
  - returns: String resource for the given key.
  */
 public func NSLocalizedStringPreferredFormat(_ key: String,
-                                      fallbackKey: String = "",
-                                      comment: String,
-                                      isCustomizable: Bool = true) -> String {
+                                             fallbackKey: String = "",
+                                             comment: String,
+                                             isCustomizable: Bool = true) -> String {
     var clientString: String
     var fallbackClientString: String
     if let localizedResourceName = GiniConfiguration.shared.localizedStringsTableName {
@@ -85,14 +85,14 @@ public class Constraints {
     }
     
     public class func active(item view1: Any!,
-                      attr attr1: NSLayoutConstraint.Attribute,
-                      relatedBy relation: NSLayoutConstraint.Relation,
-                      to view2: Any?,
-                      attr attr2: NSLayoutConstraint.Attribute,
-                      multiplier: CGFloat = 1.0,
-                      constant: CGFloat = 0,
-                      priority: Float = 1000,
-                      identifier: String? = nil) {
+                             attr attr1: NSLayoutConstraint.Attribute,
+                             relatedBy relation: NSLayoutConstraint.Relation,
+                             to view2: Any?,
+                             attr attr2: NSLayoutConstraint.Attribute,
+                             multiplier: CGFloat = 1.0,
+                             constant: CGFloat = 0,
+                             priority: Float = 1000,
+                             identifier: String? = nil) {
         
         let constraint = NSLayoutConstraint(item: view1!,
                                             attribute: attr1,

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Helpers/PreferredButtonResource.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Helpers/PreferredButtonResource.swift
@@ -35,11 +35,17 @@ class GiniPreferredButtonResource: PreferredButtonResource {
     private let localizedTextKey: String?
     private let localizedTextComment: String?
     private let localizedConfigEntry: String?
-    private let appBundle = Bundle.main
+    private var customBundle : Bundle {
+        guard let customBundle = GiniConfiguration.shared.customResourceBundle else {
+            return Bundle.main
+        }
+        return customBundle
+    }
+    
     private let libBundle = giniCaptureBundle()
     private var imageSource: ResourceOrigin {
         if let name = imageName {
-            if UIImage(named: name, in: appBundle, compatibleWith: nil) != nil {
+            if UIImage(named: name, in: customBundle, compatibleWith: nil) != nil {
                 return .custom
             } else if UIImage(named: name, in: libBundle, compatibleWith: nil) != nil {
                 return .library


### PR DESCRIPTION
Add the possibility of having a custom bundle for images and localizable strings.

In order to test this please use the project from this repro https://github.com/gini/cocoapods-xcframework-tester/tree/PIA-2548-test-project . It should contain everything that is needed to test.
