### PR TITLE
fix(GiniCaptureSDK): Fix color customisation to be applied for navigation left and right buttons

### DIFF
--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Custom views/GiniBarButton.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Custom views/GiniBarButton.swift
@@ -145,7 +145,7 @@ public final class GiniBarButton {
             } else {
                 stackView.accessibilityValue = backString
             }
-            icon = UIImageNamedPreferred(named: "barButton_back")
+            icon = UIImageNamedPreferred(named: "barButton_back")?.tintedImageWithColor(.GiniCapture.accent1)
         case .done:
             buttonTitle = NSLocalizedStringPreferredFormat("ginicapture.imagepicker.openbutton",
                                                            comment: "Done")


### PR DESCRIPTION
- used `tintedImageWithColor` method for the `back` button item

PIA-4413