### PR TITLE
PIA-4545-iOS-Headlines-on-DKB

### DIFF
--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/GiniConfiguration.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/GiniConfiguration.swift
@@ -174,13 +174,6 @@ import GiniBankAPILibrary
     @objc public var customNavigationController: UINavigationController?
 
     /**
-     Sets the tint color of the UIDocumentPickerViewController navigation bar.
-
-     - note: Use only if you have a custom `UIAppearance` for your UINavigationBar
-     */
-    @objc public var documentPickerNavigationBarTintColor: UIColor?
-
-    /**
      Sets the background color of an informal notice. Notices are small pieces of
      information appearing underneath the navigation bar.
      */

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/GiniConfiguration.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/GiniConfiguration.swift
@@ -174,30 +174,6 @@ import GiniBankAPILibrary
     @objc public var customNavigationController: UINavigationController?
 
     /**
-     Sets the background color of an informal notice. Notices are small pieces of
-     information appearing underneath the navigation bar.
-     */
-    @objc public var noticeInformationBackgroundColor = UIColor.black
-
-    /**
-     Sets the text color of an informal notice. Notices are small pieces of
-     information appearing underneath the navigation bar.
-     */
-    @objc public var noticeInformationTextColor = UIColor.white
-
-    /**
-     Sets the background color of an error notice. Notices are small pieces of
-     information appearing underneath the navigation bar.
-     */
-    @objc public var noticeErrorBackgroundColor = UIColor.red
-
-    /**
-     Sets the text color of an error notice. Notices are small pieces of
-     information appearing underneath the navigation bar.
-     */
-    @objc public var noticeErrorTextColor = UIColor.white
-
-    /**
      Indicates whether the open with feature is enabled or not. In case of `true`,
      a new option with the open with tutorial wil be shown in the Help menu.
      */
@@ -219,12 +195,6 @@ import GiniBankAPILibrary
     @objc public var statusBarStyle = UIStatusBarStyle.lightContent
 
     // MARK: Camera options
-
-    /**
-     Sets the color of the loading indicator on the camera screen to the specified color.
-     */
-    @objc public var cameraSetupLoadingIndicatorColor = UIColor.white
-
     /**
      Set the types supported by the file import feature. `GiniCaptureImportFileTypes.none` by default.
      */

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Camera/CameraPreviewViewController.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Camera/CameraPreviewViewController.swift
@@ -36,7 +36,7 @@ final class CameraPreviewViewController: UIViewController {
 
     private lazy var spinner: UIActivityIndicatorView = {
         let spinner = UIActivityIndicatorView(style: .whiteLarge)
-        spinner.color = self.giniConfiguration.cameraSetupLoadingIndicatorColor
+        spinner.color = GiniColor(light: .GiniCapture.light1, dark: .GiniCapture.dark1).uiColor()
         spinner.hidesWhenStopped = true
         return spinner
     }()

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Document picker/DocumentPickerCoordinator.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Document picker/DocumentPickerCoordinator.swift
@@ -94,11 +94,6 @@ public final class DocumentPickerCoordinator: NSObject {
     let galleryCoordinator: GalleryCoordinator
     let giniConfiguration: GiniConfiguration
 
-    fileprivate lazy var navigationBarAppearance: UINavigationBar = .init()
-    fileprivate lazy var searchBarAppearance: UISearchBar = .init()
-    fileprivate lazy var barButtonItemAppearance: UIBarButtonItem = .init()
-    fileprivate lazy var barButtonItemAppearanceInSearchBar: UIBarButtonItem = .init()
-
     fileprivate var acceptedDocumentTypes: [String] {
         switch giniConfiguration.fileImportSupportedTypes {
         case .pdf_and_images:
@@ -176,20 +171,8 @@ public final class DocumentPickerCoordinator: NSObject {
         documentPicker.delegate = self
 
         documentPicker.allowsMultipleSelection = giniConfiguration.multipageEnabled
-
-        if let tintColor = giniConfiguration.documentPickerNavigationBarTintColor {
-            // Starting with iOS 11.0, the UIDocumentPickerViewController navigation bar almost can't be customized,
-            // only being possible to customize the tint color. To avoid issues with custom UIAppearance styles,
-            // this is reset to default, saving the current state in order to restore it during dismissal.
-            saveCurrentNavBarAppearance()
-            applyDefaultNavBarAppearance()
-
-            UINavigationBar.appearance().tintColor = tintColor
-            UIBarButtonItem.appearance(whenContainedInInstancesOf: [UISearchBar.self])
-                .setTitleTextAttributes([.foregroundColor: tintColor],
-                                        for: .normal)
-        }
-
+        documentPicker.view.tintColor = .GiniCapture.accent1
+    
         currentPickerDismissesAutomatically = true
         currentPickerViewController = documentPicker
 
@@ -235,57 +218,6 @@ fileprivate extension DocumentPickerCoordinator {
 
         return (nil, nil)
     }
-
-    func saveCurrentNavBarAppearance() {
-        update(navigationBarAppearance, with: UINavigationBar.appearance())
-        update(searchBarAppearance, with: UISearchBar.appearance())
-        update(barButtonItemAppearance, with: UIBarButtonItem.appearance())
-        update(barButtonItemAppearanceInSearchBar,
-               with: UIBarButtonItem.appearance(whenContainedInInstancesOf: [UISearchBar.self]))
-    }
-
-    func applyDefaultNavBarAppearance() {
-        update(UINavigationBar.appearance(), with: nil)
-        update(UISearchBar.appearance(), with: nil)
-        update(UIBarButtonItem.appearance(), with: nil)
-        update(UIBarButtonItem.appearance(whenContainedInInstancesOf: [UISearchBar.self]),
-               with: nil)
-    }
-
-    func restoreSavedNavBarAppearance() {
-        update(UINavigationBar.appearance(), with: navigationBarAppearance)
-        update(UISearchBar.appearance(), with: searchBarAppearance)
-        update(UIBarButtonItem.appearance(), with: barButtonItemAppearance)
-        update(UIBarButtonItem.appearance(whenContainedInInstancesOf: [UISearchBar.self]),
-               with: barButtonItemAppearance)
-    }
-
-    func update(_ currentNavigationBar: UINavigationBar, with navigationBar: UINavigationBar?) {
-        currentNavigationBar.barTintColor = navigationBar?.barTintColor
-        currentNavigationBar.tintColor = navigationBar?.tintColor
-        currentNavigationBar.backgroundColor = navigationBar?.backgroundColor
-        currentNavigationBar.isTranslucent = navigationBar?.isTranslucent ?? true
-        currentNavigationBar.barStyle = navigationBar?.barStyle ?? .default
-        currentNavigationBar.shadowImage = navigationBar?.shadowImage
-        currentNavigationBar.setBackgroundImage(navigationBar?.backIndicatorImage, for: .default)
-    }
-
-    func update(_ currentSearchBar: UISearchBar, with searchBar: UISearchBar?) {
-        currentSearchBar.backgroundColor = searchBar?.backgroundColor
-        currentSearchBar.barTintColor = searchBar?.barTintColor
-        currentSearchBar.tintColor = searchBar?.tintColor
-        currentSearchBar.searchBarStyle = searchBar?.searchBarStyle ?? .default
-        currentSearchBar.setImage(searchBar?.image(for: .search, state: .normal), for: .search, state: .normal)
-    }
-
-    func update(_ currentBarButtonItem: UIBarButtonItem, with barButtonItem: UIBarButtonItem?) {
-        currentBarButtonItem.setTitleTextAttributes(barButtonItem?.titleTextAttributes(for: .normal),
-                                                    for: .normal)
-        currentBarButtonItem.setTitleTextAttributes(barButtonItem?.titleTextAttributes(for: .highlighted),
-                                                    for: .highlighted)
-        currentBarButtonItem.setTitleTextAttributes(barButtonItem?.titleTextAttributes(for: .selected),
-                                                    for: .selected)
-    }
 }
 
 // MARK: GalleryCoordinatorDelegate
@@ -314,10 +246,6 @@ extension DocumentPickerCoordinator: UIDocumentPickerDelegate {
             return
         }
 
-        if #available(iOS 12.0, *), giniConfiguration.documentPickerNavigationBarTintColor != nil {
-            restoreSavedNavBarAppearance()
-        }
-
         delegate?.documentPicker(self, didPick: documents)
     }
 
@@ -326,10 +254,6 @@ extension DocumentPickerCoordinator: UIDocumentPickerDelegate {
     }
 
     public func documentPickerWasCancelled(_ controller: UIDocumentPickerViewController) {
-        if #available(iOS 12.0, *), giniConfiguration.documentPickerNavigationBarTintColor != nil {
-            restoreSavedNavBarAppearance()
-        }
-
         controller.dismiss(animated: false, completion: nil)
     }
 }


### PR DESCRIPTION
 fix(GiniCaptureSDK): Remove unused Gini configuration option
- `documentPickerNavigationBarTintColor` was removed from the configuration since is not needed
- additional cleanup was done

PIA-4442