### PR TITLE
ci(GiniBankSDK): Fix crash of the Github action `Release Bank SDK`

### DIFF
--- a/.github/workflows/bank-sdk.build.xcframeworks.yml
+++ b/.github/workflows/bank-sdk.build.xcframeworks.yml
@@ -9,12 +9,8 @@ on:
 jobs:
   prepare-frameworks:
     name: Create Release
-    runs-on: macos-13
+    runs-on: macos-latest
     steps:
-      - uses: maxim-lobanov/setup-xcode@v1.5.1
-        with:
-          xcode-version: '14.3.1'
-
       - name: Checkout repository
         uses: actions/checkout@v3
 
@@ -132,7 +128,7 @@ jobs:
 
           KEYCHAIN_PATH=$RUNNER_TEMP/app-signing.keychain-db
 
-          # import certificate and provisioning profile from secrets
+          # import certificate from secrets
           echo -n "$BUILD_CERTIFICATE_BASE64" | base64 --decode --output $CERTIFICATE_PATH
           echo -n "$BUILD_PROVISION_PROFILE_BASE64" | base64 --decode --output $PP_PATH1
           echo -n "$BUILD_PROVISION_PROFILE_EXTENSION_BASE64" | base64 --decode --output $PP_PATH2
@@ -171,4 +167,3 @@ jobs:
             GiniBankSDKPinning.xcframework
             GiniCaptureSDKPinning.xcframework
             GiniBankAPILibraryPinning.xcframework
-


### PR DESCRIPTION
- fixes the crash of the gitbub action but not also the signing of the XCFrameworks

PIA-4513