### PR TITLE
PIA-4592  Optional response fields are decoded as required

### DIFF
--- a/BankAPILibrary/GiniBankAPILibrary/Sources/GiniBankAPILibrary/Documents/Core/Auth/Token.swift
+++ b/BankAPILibrary/GiniBankAPILibrary/Sources/GiniBankAPILibrary/Documents/Core/Auth/Token.swift
@@ -35,8 +35,8 @@ extension Token: Decodable {
         let container = try decoder.container(keyedBy: Keys.self)
         let expiresIn = try container.decode(Double.self, forKey: .expiresIn) // seconds
         let expiration = Date(timeInterval: expiresIn, since: Date())
-        let scope = try container.decode(String.self, forKey: .scope)
-        let type = try container.decode(String.self, forKey: .type)
+        let scope = try container.decodeIfPresent(String.self, forKey: .scope)
+        let type = try container.decodeIfPresent(String.self, forKey: .type)
         let accessToken = try container.decode(String.self, forKey: .accessToken)
 
         self.init(expiration: expiration,

--- a/BankAPILibrary/GiniBankAPILibrary/Sources/GiniBankAPILibrary/Documents/PartialDocumentInfo.swift
+++ b/BankAPILibrary/GiniBankAPILibrary/Sources/GiniBankAPILibrary/Documents/PartialDocumentInfo.swift
@@ -37,7 +37,7 @@ extension PartialDocumentInfo: Codable {
     
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        document = try container.decode(URL.self, forKey: .document)
+        document = try container.decodeIfPresent(URL.self, forKey: .document)
         rotationDelta = try container.decodeIfPresent(Int.self, forKey: .rotationDelta) ?? 0
     }
 }

--- a/BankAPILibrary/GiniBankAPILibrary/Tests/GiniBankAPILibraryTests/AccessTokenTests.swift
+++ b/BankAPILibrary/GiniBankAPILibrary/Tests/GiniBankAPILibraryTests/AccessTokenTests.swift
@@ -11,7 +11,7 @@ import XCTest
 
 final class AccessTokenTests: XCTestCase {
 
-    func testValue() {
+    func testAccessToken() {
         let jsonReponse = """
                             {"access_token": "1eb7ca49-d99f-40cb-b86d-8dd689ca2345",
                              "token_type": "bearer",

--- a/BankAPILibrary/GiniBankAPILibrary/Tests/GiniBankAPILibraryTests/AccessTokenTests.swift
+++ b/BankAPILibrary/GiniBankAPILibrary/Tests/GiniBankAPILibraryTests/AccessTokenTests.swift
@@ -10,26 +10,123 @@ import XCTest
 @testable import GiniBankAPILibrary
 
 final class AccessTokenTests: XCTestCase {
-    
-    let token = try? JSONDecoder().decode(Token.self,
-                                     from: ("{\"access_token\":\"1eb7ca49-d99f-40cb-b86d-8dd689ca2345\"," +
-        "\"token_type\":\"bearer\",\"expires_in\":43199,\"scope\":\"read\"}").data(using: .utf8)!)
 
     func testValue() {
-        XCTAssertEqual(token?.accessToken, "1eb7ca49-d99f-40cb-b86d-8dd689ca2345")
+        let jsonReponse = """
+                            {"access_token": "1eb7ca49-d99f-40cb-b86d-8dd689ca2345",
+                             "token_type": "bearer",
+                             "expires_in": 43199,
+                             "scope": "read"
+                            }
+                          """
+        XCTAssertNotNil(token(from: jsonReponse)?.accessToken, "Expected a `accessToken`, but found nil.")
+        XCTAssertEqual(token(from: jsonReponse)?.accessToken, "1eb7ca49-d99f-40cb-b86d-8dd689ca2345")
     }
     
     func testType() {
-        XCTAssertEqual(token?.type, "bearer")
+        let jsonReponse = """
+                            {"access_token": "1eb7ca49-d99f-40cb-b86d-8dd689ca2345",
+                             "token_type": "bearer",
+                             "expires_in": 43199,
+                             "scope": "read"
+                            }
+                          """
+        XCTAssertEqual(token(from: jsonReponse)?.type, "bearer")
     }
+
+    func testTypeOptionl() {
+        let jsonReponse = """
+                            {"access_token": "1eb7ca49-d99f-40cb-b86d-8dd689ca2345",
+                             "expires_in": 43199,
+                             "scope": "read"
+                            }
+                          """
+        let type = token(from: jsonReponse)?.type
+        XCTAssertNil(type, "Expected nil, but found \(String(describing: type)).")
+    }
+
     
     func testExpirationDate() {
-        XCTAssertTrue(token!.expiration < Date(timeInterval: 43199, since: Date()))
-        XCTAssertTrue(token!.expiration > Date())
+        let jsonReponse = """
+                            {"access_token": "1eb7ca49-d99f-40cb-b86d-8dd689ca2345",
+                             "token_type": "bearer",
+                             "expires_in": 43199,
+                             "scope": "read"
+                            }
+                          """
+        XCTAssertNotNil(token(from: jsonReponse)?.expiration, "Expected a `expires_in`, but found nil.")
+        XCTAssertTrue(token(from: jsonReponse)!.expiration < Date(timeInterval: 43199, since: Date()))
+        XCTAssertTrue(token(from: jsonReponse)!.expiration > Date())
     }
     
     func testScope() {
-        XCTAssertEqual(token?.scope, "read")
+        let jsonReponse = """
+                            {"access_token": "1eb7ca49-d99f-40cb-b86d-8dd689ca2345",
+                             "token_type": "bearer",
+                             "expires_in": 43199,
+                             "scope": "read"
+                            }
+                          """
+        XCTAssertEqual(token(from: jsonReponse)?.scope, "read")
     }
-    
+
+    func testScopeOptionl() {
+        let jsonReponse = """
+                            {"access_token": "1eb7ca49-d99f-40cb-b86d-8dd689ca2345",
+                             "token_type": "bearer",
+                             "expires_in": 43199
+                            }
+                          """
+        let scope = token(from: jsonReponse)?.scope
+        XCTAssertNil(scope, "Expected nil, but found \(String(describing: scope)).")
+    }
+
+    func testTokenCorrectDecoding() {
+        let jsonReponse = """
+                            {"access_token": "1eb7ca49-d99f-40cb-b86d-8dd689ca2345",
+                             "token_type": "bearer",
+                             "expires_in": 43199,
+                             "scope": "read"
+                            }
+                          """
+        guard let token = token(from: jsonReponse) else {
+            XCTFail("Failed to decode Token response data")
+            fatalError()
+        }
+
+        XCTAssertNotNil(token, "Expected a `token`, but found nil.")
+    }
+
+    func testTokenMissingOptionalFieldsDecoding() {
+        let jsonReponse = """
+                            {"access_token": "1eb7ca49-d99f-40cb-b86d-8dd689ca2345",
+                             "expires_in": 43199
+                            }
+                          """
+        guard let token = token(from: jsonReponse) else {
+            XCTFail("Failed to decode Token response data")
+            fatalError()
+        }
+
+        XCTAssertNotNil(token, "Expected a `token`, but found nil.")
+    }
+
+    func testTokenMissingRequiredFieldsDecoding() {
+        let jsonReponse = """
+                            {"access_token": "1eb7ca49-d99f-40cb-b86d-8dd689ca2345",
+                             "token_type": "bearer",
+                             "scope": "read"
+                            }
+                          """
+        guard let token = token(from: jsonReponse) else {
+            XCTAssertNil(token(from: jsonReponse),"Failed to decode Token response data")
+            return
+        }
+
+        XCTAssertNotNil(token, "Expected a `token`, but found nil.")
+    }
+
+    private func token(from mockRespose: String) -> Token? {
+        return try? JSONDecoder().decode(Token.self, from: (mockRespose).data(using: .utf8)!)
+    }
 }

--- a/HealthAPILibrary/GiniHealthAPILibrary/Sources/GiniHealthAPILibrary/Documents/Core/Auth/Token.swift
+++ b/HealthAPILibrary/GiniHealthAPILibrary/Sources/GiniHealthAPILibrary/Documents/Core/Auth/Token.swift
@@ -35,8 +35,8 @@ extension Token: Decodable {
         let container = try decoder.container(keyedBy: Keys.self)
         let expiresIn = try container.decode(Double.self, forKey: .expiresIn) // seconds
         let expiration = Date(timeInterval: expiresIn, since: Date())
-        let scope = try container.decode(String.self, forKey: .scope)
-        let type = try container.decode(String.self, forKey: .type)
+        let scope = try container.decodeIfPresent(String.self, forKey: .scope)
+        let type = try container.decodeIfPresent(String.self, forKey: .type)
         let accessToken = try container.decode(String.self, forKey: .accessToken)
 
         self.init(expiration: expiration,

--- a/HealthAPILibrary/GiniHealthAPILibrary/Sources/GiniHealthAPILibrary/Documents/PartialDocumentInfo.swift
+++ b/HealthAPILibrary/GiniHealthAPILibrary/Sources/GiniHealthAPILibrary/Documents/PartialDocumentInfo.swift
@@ -37,7 +37,7 @@ extension PartialDocumentInfo: Codable {
     
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        document = try container.decode(URL.self, forKey: .document)
+        document = try container.decodeIfPresent(URL.self, forKey: .document)
         rotationDelta = try container.decodeIfPresent(Int.self, forKey: .rotationDelta) ?? 0
     }
 }

--- a/HealthAPILibrary/GiniHealthAPILibrary/Tests/GiniHealthAPILibraryTests/AccessTokenTests.swift
+++ b/HealthAPILibrary/GiniHealthAPILibrary/Tests/GiniHealthAPILibraryTests/AccessTokenTests.swift
@@ -11,25 +11,122 @@ import XCTest
 
 final class AccessTokenTests: XCTestCase {
     
-    let token = try? JSONDecoder().decode(Token.self,
-                                     from: ("{\"access_token\":\"1eb7ca49-d99f-40cb-b86d-8dd689ca2345\"," +
-        "\"token_type\":\"bearer\",\"expires_in\":43199,\"scope\":\"read\"}").data(using: .utf8)!)
+    func testAccessToken() {
+        let jsonReponse = """
+                            {"access_token": "1eb7ca49-d99f-40cb-b86d-8dd689ca2345",
+                             "token_type": "bearer",
+                             "expires_in": 43199,
+                             "scope": "read"
+                            }
+                          """
+        XCTAssertNotNil(token(from: jsonReponse)?.accessToken, "Expected a `accessToken`, but found nil.")
+        XCTAssertEqual(token(from: jsonReponse)?.accessToken, "1eb7ca49-d99f-40cb-b86d-8dd689ca2345")
+    }
 
-    func testValue() {
-        XCTAssertEqual(token?.accessToken, "1eb7ca49-d99f-40cb-b86d-8dd689ca2345")
-    }
-    
     func testType() {
-        XCTAssertEqual(token?.type, "bearer")
+        let jsonReponse = """
+                            {"access_token": "1eb7ca49-d99f-40cb-b86d-8dd689ca2345",
+                             "token_type": "bearer",
+                             "expires_in": 43199,
+                             "scope": "read"
+                            }
+                          """
+        XCTAssertEqual(token(from: jsonReponse)?.type, "bearer")
     }
-    
+
+    func testTypeOptionl() {
+        let jsonReponse = """
+                            {"access_token": "1eb7ca49-d99f-40cb-b86d-8dd689ca2345",
+                             "expires_in": 43199,
+                             "scope": "read"
+                            }
+                          """
+        let type = token(from: jsonReponse)?.type
+        XCTAssertNil(type, "Expected nil, but found \(String(describing: type)).")
+    }
+
+
     func testExpirationDate() {
-        XCTAssertTrue(token!.expiration < Date(timeInterval: 43199, since: Date()))
-        XCTAssertTrue(token!.expiration > Date())
+        let jsonReponse = """
+                            {"access_token": "1eb7ca49-d99f-40cb-b86d-8dd689ca2345",
+                             "token_type": "bearer",
+                             "expires_in": 43199,
+                             "scope": "read"
+                            }
+                          """
+        XCTAssertNotNil(token(from: jsonReponse)?.expiration, "Expected a `expires_in`, but found nil.")
+        XCTAssertTrue(token(from: jsonReponse)!.expiration < Date(timeInterval: 43199, since: Date()))
+        XCTAssertTrue(token(from: jsonReponse)!.expiration > Date())
     }
-    
+
     func testScope() {
-        XCTAssertEqual(token?.scope, "read")
+        let jsonReponse = """
+                            {"access_token": "1eb7ca49-d99f-40cb-b86d-8dd689ca2345",
+                             "token_type": "bearer",
+                             "expires_in": 43199,
+                             "scope": "read"
+                            }
+                          """
+        XCTAssertEqual(token(from: jsonReponse)?.scope, "read")
     }
-    
+
+    func testScopeOptionl() {
+        let jsonReponse = """
+                            {"access_token": "1eb7ca49-d99f-40cb-b86d-8dd689ca2345",
+                             "token_type": "bearer",
+                             "expires_in": 43199
+                            }
+                          """
+        let scope = token(from: jsonReponse)?.scope
+        XCTAssertNil(scope, "Expected nil, but found \(String(describing: scope)).")
+    }
+
+    func testTokenCorrectDecoding() {
+        let jsonReponse = """
+                            {"access_token": "1eb7ca49-d99f-40cb-b86d-8dd689ca2345",
+                             "token_type": "bearer",
+                             "expires_in": 43199,
+                             "scope": "read"
+                            }
+                          """
+        guard let token = token(from: jsonReponse) else {
+            XCTFail("Failed to decode Token response data")
+            fatalError()
+        }
+
+        XCTAssertNotNil(token, "Expected a `token`, but found nil.")
+    }
+
+    func testTokenMissingOptionalFieldsDecoding() {
+        let jsonReponse = """
+                            {"access_token": "1eb7ca49-d99f-40cb-b86d-8dd689ca2345",
+                             "expires_in": 43199
+                            }
+                          """
+        guard let token = token(from: jsonReponse) else {
+            XCTFail("Failed to decode Token response data")
+            fatalError()
+        }
+
+        XCTAssertNotNil(token, "Expected a `token`, but found nil.")
+    }
+
+    func testTokenMissingRequiredFieldsDecoding() {
+        let jsonReponse = """
+                            {"access_token": "1eb7ca49-d99f-40cb-b86d-8dd689ca2345",
+                             "token_type": "bearer",
+                             "scope": "read"
+                            }
+                          """
+        guard let token = token(from: jsonReponse) else {
+            XCTAssertNil(token(from: jsonReponse),"Failed to decode Token response data")
+            return
+        }
+
+        XCTAssertNotNil(token, "Expected a `token`, but found nil.")
+    }
+
+    private func token(from mockRespose: String) -> Token? {
+        return try? JSONDecoder().decode(Token.self, from: (mockRespose).data(using: .utf8)!)
+    }
 }


### PR DESCRIPTION
fix(GiniBankAPILibrary, GiniHealthAPILibrary): Fix the optional response fields that are decoded as required

- fixes the `scope` and the `type` properties in `Token` object to be decoded as optional
- fixes the `document` property in `PartialDocumentInfo` object to be decoded as optional
- add extra  unit tests

PIA-4592