### PR TITLE
Bsdk 94 make flash off by default

### DIFF
--- a/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/GiniBankConfiguration.swift
+++ b/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/GiniBankConfiguration.swift
@@ -162,9 +162,9 @@ public final class GiniBankConfiguration: NSObject {
     public var flashToggleEnabled = false
 
     /**
-     When the flash toggle is enabled, this flag indicates if the flash is on by default.
+     Set whether the camera flash should be on or off when the SDK starts. The flash is off by default.
      */
-    public var flashOnByDefault = true
+    public var flashOnByDefault = false
 
     /**
      Set an adapter implementation to show a custom bottom navigation bar on the camera screen.

--- a/BankSDK/GiniBankSDKExample/GiniBankSDKExample/SettingsViewController/SettingsViewController+SwitchOptionModel.swift
+++ b/BankSDK/GiniBankSDKExample/GiniBankSDKExample/SettingsViewController/SettingsViewController+SwitchOptionModel.swift
@@ -62,9 +62,9 @@ struct SwitchOptionModel {
 			case .multipage:
 				return "Multipage"
 			case .flashToggle:
-				return "Flash toggle"
+				return "Display flash button"
 			case .flashOnByDefault:
-				return "Flash ON by default"
+				return "Flash default state"
 			case .bottomNavigationBar:
 				return "Bottom navigation bar"
 			case .helpNavigationBarBottomAdapter:
@@ -140,8 +140,10 @@ struct SwitchOptionModel {
 			switch self {
 			case .qrCodeScanningOnly:
 				return "This will work if the `QR code scanning` switch is also enabled."
+            case .flashToggle:
+                return "Display flash button in camera screen"
 			case .flashOnByDefault:
-				return "This will work if the `Flash toggle` switch is also enabled."
+				return "This will work if the `Flash button` switch is also enabled."
 			case .onButtonLoadingIndicator:
 				return "Set custom loading indicator on the buttons which support loading."
 			case .customLoadingIndicator:

--- a/BankSDK/GiniBankSDKExample/Tests/SettingsViewControllerTests.swift
+++ b/BankSDK/GiniBankSDKExample/Tests/SettingsViewControllerTests.swift
@@ -21,7 +21,7 @@ final class SettingsViewControllerTests: XCTestCase {
 		configuration.onlyQRCodeScanningEnabled = false
 		configuration.multipageEnabled = true
 		configuration.flashToggleEnabled = true
-		configuration.flashOnByDefault = true
+		configuration.flashOnByDefault = false
 		configuration.bottomNavigationBarEnabled = false
 		configuration.helpNavigationBarBottomAdapter = nil
 		configuration.cameraNavigationBarBottomAdapter = nil

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/GiniConfiguration.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/GiniConfiguration.swift
@@ -206,13 +206,13 @@ import GiniBankAPILibrary
     @objc public var flashToggleEnabled = false
 
     /**
-     When the flash toggle is enabled, this flag indicates if the flash is on by default.
+     Set whether the camera flash should be on or off when the SDK starts. The flash is off by default.
      */
-    @objc public var flashOnByDefault = true
+    @objc public var flashOnByDefault = false
 
     /**
      Sets the close button text in the navigation bar on the camera screen.
-          */
+    */
     @objc public var navigationBarCameraTitleCloseButton = ""
 
     /**


### PR DESCRIPTION
- make `flashOnByDefault` disabled by default when the SDK starts
- adjust the name of the two settings options in the Settings screen related to flash

BSDK-94