### PR TITLE
fix(GiniBankSDK): Fix UI issues in Digital Invoice screen after disabling one item

### DIFF
--- a/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/ReturnAssistant/DigitalInvoice/Components/DigitalLineItemTableViewCell.swift
+++ b/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/ReturnAssistant/DigitalInvoice/Components/DigitalLineItemTableViewCell.swift
@@ -89,10 +89,7 @@ class DigitalLineItemTableViewCell: UITableViewCell {
         selectionStyle = .none
 
         if viewModel?.index == 0 {
-            clipsToBounds = true
-            layer.cornerRadius = 8
-            layer.maskedCorners = [.layerMaxXMinYCorner, .layerMinXMinYCorner]
-
+            round(corners: [.topLeft, .topRight], radius: 8)
             separatorView.isHidden = true
         }
 
@@ -112,6 +109,13 @@ class DigitalLineItemTableViewCell: UITableViewCell {
         nameLabel.font = configuration.textStyleFonts[.body]
         unitPriceLabel.font = configuration.textStyleFonts[.body]
         editButton.titleLabel?.font = configuration.textStyleFonts[.body]
+    }
+
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        // When reusing cells, reset the rounded corners and the separator view visibility to their default values
+        round(radius: 0)
+        separatorView.isHidden = false
     }
 
     @objc func modeSwitchValueChange(sender: UISwitch) {


### PR DESCRIPTION
- rounded corners and the separator visibility need to be reset to their default values when reusing cells after the call of `tableView.reloadData()`

BSDK-163