### PR TITLE
ci(project): Fix XCFramework generation in release workflow.

### DIFF
--- a/.github/workflows/bank-sdk.release.yml
+++ b/.github/workflows/bank-sdk.release.yml
@@ -70,3 +70,9 @@ jobs:
   build-xcframeworks:
     needs: release
     uses: gini/gini-mobile-ios/.github/workflows/bank-sdk.build.xcframeworks.yml@main
+    secrets:
+      BUILD_CERTIFICATE_BASE64: ${{ secrets.GINI_DISTRIBUTION_CERTIFICATE }}
+      P12_PASSWORD: ${{ secrets.GINI_DISTRIBUTION_CERTIFICATE_SECRET }}
+      BUILD_PROVISION_PROFILE_BASE64: ${{ secrets.GINI_BANK_SDK_EXAMPLE_ADHOC_DISTRIBUTION_PROVISION_PROFILE }}
+      BUILD_PROVISION_PROFILE_EXTENSION_BASE64: ${{ secrets.GINI_BANK_SDK_EXTENSION_ADHOC_DISTRIBUTION_PROVISION_PROFILE }}
+      KEYCHAIN_PASSWORD: ${{ secrets.GINI_DISTRIBUTION_CERTIFICATE_SECRET }}


### PR DESCRIPTION
I assumed that we're missing some credentials there
BSDK-263