### PR TITLE
Bsdk 35 create fastlane lane to generate release podspecs with the release version

### DIFF
--- a/BankSDK/GiniBankSDK/Pod/GiniBankSDK.podspec
+++ b/BankSDK/GiniBankSDK/Pod/GiniBankSDK.podspec
@@ -1,0 +1,33 @@
+Pod::Spec.new do |spec|
+  spec.name               = "GiniBankSDK"
+  spec.version            = "3.7.1"
+  spec.summary            = "Gini Bank SDK for iOS"
+  spec.description        = "The Gini Bank SDK provides components for capturing, reviewing and analyzing photos of invoices and remittance slips."
+  spec.homepage           = "https://gini.net"
+  spec.documentation_url  = "https://developer.gini.net/gini-mobile-ios/GiniBankSDK/#{spec.version.to_s}/"
+  spec.author             = "Gini GmbH"
+  spec.license            = { :type => 'Private', :text => <<-LICENSE
+                                Copyright (c) 2021-2024, Gini GmbH
+
+                                All rights reserved.
+                                
+                                The projects in this repository, if not stated otherwise, are licensed through Gini GmbH ("Gini") and may not be
+                                used, altered or copied in any way without explicit permission by Gini. The
+                                terms of usage are defined in a separate usage agreement between Gini and the
+                                licensee, where the licensee can gain access to a non-exclusive,
+                                non-transferable usage right which is restricted for the time of a contractual
+                                relationship between Gini and the licensee.
+                                
+                                For license related inquiries contact Gini via the email address
+                                technical-support@gini.net.
+                              LICENSE
+                            }
+  spec.source             = { :http => "https://github.com/gini/gini-podspecs/raw/master/GiniBankSDK/#{spec.version.to_s}/GiniBankSDK-XCFrameworks.zip" }
+  spec.swift_version      = "5.3"
+
+  # Supported deployment targets
+  spec.ios.deployment_target  = "12.0"
+
+  # Published binaries
+  spec.vendored_frameworks = "GiniBankSDK.xcframework", "GiniCaptureSDK.xcframework", "GiniBankAPILibrary.xcframework"
+end

--- a/BankSDK/GiniBankSDK/Pod/GiniBankSDK.podspec
+++ b/BankSDK/GiniBankSDK/Pod/GiniBankSDK.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name               = "GiniBankSDK"
-  spec.version            = "3.7.1"
+  spec.version            = "3.7.2"
   spec.summary            = "Gini Bank SDK for iOS"
   spec.description        = "The Gini Bank SDK provides components for capturing, reviewing and analyzing photos of invoices and remittance slips."
   spec.homepage           = "https://gini.net"

--- a/BankSDK/GiniBankSDK/Pod/README.md
+++ b/BankSDK/GiniBankSDK/Pod/README.md
@@ -1,0 +1,47 @@
+Distributing Gini Bank SDK XCFrameworks using CocoaPods
+======================================================
+
+How to release new versions
+---------------------------
+
+1. After the `.xcframeworks` have been created compress them into a zip named `GiniBankSDK-XCFrameworks.zip`.  
+   IMPORTANT: On MacOS the zip needs to be created by selecting all the XCFrameworks and compressing them. It won't work
+   if you compress the folder containing the XCFrameworks[^1].  
+   You can also use the following `zip` command inside the folder where all the XCFrameworks are (make sure you include
+   all the required XCFrameworks, this example might be outdated):
+   ```
+   zip -r GiniBankSDK-XCFrameworks.zip \
+   GiniBankAPILibrary.xcframework \
+   GiniBankSDK.xcframework \
+   GiniCaptureSDK.xcframework
+   ```
+2. Clone the `https://github.com/gini/gini-podspecs` repository.
+3. Go into the `gini-podspecs` repository folder and create a subfolder in `GiniBankSDK` which is named after the
+   version, for example `2.2.1`.
+4. Copy the `GiniBankSDK-XCFrameworks.zip` into the new folder.
+5. Copy the `GiniBankSDK.podspec` file from the folder where this readme is located into the new folder and update the
+   version with the corresponding one, for example `spec.version = 2.2.1`.
+6. Commit and push the new folder and its contents to `gini-podspecs` repo.
+
+[^1]: If we put the XCFrameworks into a folder and then zip that folder then the `unzip` command Cocoapods uses[^2] will
+put all the XCFrameworks into a subfolder with the same name as the zipped folder. This breaks adding the XCFrameworks
+to the project because Cocoapods can't find XCFrameworks in subfolders.
+
+[^2]: Cocoapods unzip command: `unzip GiniBankSDK-XCFrameworks.zip -d output-dir`
+
+How to use the GiniBankSDK pod
+------------------------------
+
+1. Add the following to your `Podfile`:
+   1. `source 'https://github.com/gini/gini-podspecs.git'`
+   2. `pod GiniBankSDK`
+2. Run `pod update` to fetch the latest Gini Bank SDK pod version.
+
+How to test the GiniBankSDK pod
+-------------------------------
+
+1. Clone the `cocoapods-xcframework-tester` repository: https://github.com/gini/cocoapods-xcframework-tester
+2. Go to your local `cocoapods-xcframework-tester` repo folder.
+3. Update the `Podfile` to use the `GiniBankSDK` pod.
+4. Run `pod update` to get the newest version of the pod.
+5. Open the `.xcworkspace` to build and run the project.

--- a/BankSDK/GiniBankSDKPinning/Pod/GiniBankSDKPinning.podspec
+++ b/BankSDK/GiniBankSDKPinning/Pod/GiniBankSDKPinning.podspec
@@ -1,0 +1,36 @@
+Pod::Spec.new do |spec|
+  spec.name               = "GiniBankSDKPinning"
+  spec.version            = "1.13.0"
+  spec.summary            = "Gini Bank SDK for iOS with certificate pinning"
+  spec.description        = "The Gini Bank SDK provides components for capturing, reviewing and analyzing photos of invoices and remittance slips."
+  spec.homepage           = "gini.net"
+  spec.documentation_url  = "https://developer.gini.net/gini-mobile-ios/GiniBankSDK/#{spec.version.to_s}/"
+  spec.author             = "Gini GmbH"
+  spec.license            = { :type => 'Private', :text => <<-LICENSE
+                                Copyright (c) 2021-2023, Gini GmbH
+
+                                All rights reserved.
+                                
+                                The projects in this repository, if not stated otherwise, are licensed through Gini GmbH ("Gini") and may not be
+                                used, altered or copied in any way without explicit permission by Gini. The
+                                terms of usage are defined in a separate usage agreement between Gini and the
+                                licensee, where the licensee can gain access to a non-exclusive,
+                                non-transferable usage right which is restricted for the time of a contractual
+                                relationship between Gini and the licensee.
+                                
+                                For license related inquiries contact Gini via the email address
+                                technical-support@gini.net.
+                              LICENSE
+                            }
+  spec.source             = { :http => "https://github.com/gini/gini-podspecs/raw/master/GiniBankSDKPinning/#{spec.version.to_s}/GiniBankSDKPinning-XCFrameworks.zip" }
+  spec.swift_version      = "5.3"
+
+  # Supported deployment targets
+  spec.ios.deployment_target  = "12.0"
+
+  # Published binaries
+  spec.vendored_frameworks = ["GiniBankSDK.xcframework", "GiniBankSDKPinning.xcframework",
+                              "GiniCaptureSDK.xcframework", "GiniCaptureSDKPinning.xcframework", 
+                              "GiniBankAPILibrary.xcframework", "GiniBankAPILibraryPinning.xcframework",
+                              "TrustKit.xcframework"]
+end

--- a/BankSDK/GiniBankSDKPinning/Pod/GiniBankSDKPinning.podspec
+++ b/BankSDK/GiniBankSDKPinning/Pod/GiniBankSDKPinning.podspec
@@ -1,13 +1,13 @@
 Pod::Spec.new do |spec|
   spec.name               = "GiniBankSDKPinning"
-  spec.version            = "1.13.0"
+  spec.version            = "3.7.1"
   spec.summary            = "Gini Bank SDK for iOS with certificate pinning"
   spec.description        = "The Gini Bank SDK provides components for capturing, reviewing and analyzing photos of invoices and remittance slips."
   spec.homepage           = "gini.net"
   spec.documentation_url  = "https://developer.gini.net/gini-mobile-ios/GiniBankSDK/#{spec.version.to_s}/"
   spec.author             = "Gini GmbH"
   spec.license            = { :type => 'Private', :text => <<-LICENSE
-                                Copyright (c) 2021-2023, Gini GmbH
+                                Copyright (c) 2021-2024, Gini GmbH
 
                                 All rights reserved.
                                 

--- a/BankSDK/GiniBankSDKPinning/Pod/GiniBankSDKPinning.podspec
+++ b/BankSDK/GiniBankSDKPinning/Pod/GiniBankSDKPinning.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name               = "GiniBankSDKPinning"
-  spec.version            = "3.7.1"
+  spec.version            = "3.7.2"
   spec.summary            = "Gini Bank SDK for iOS with certificate pinning"
   spec.description        = "The Gini Bank SDK provides components for capturing, reviewing and analyzing photos of invoices and remittance slips."
   spec.homepage           = "gini.net"

--- a/BankSDK/GiniBankSDKPinning/Pod/README.md
+++ b/BankSDK/GiniBankSDKPinning/Pod/README.md
@@ -1,0 +1,51 @@
+Distributing Gini Bank SDK Pinning XCFrameworks using CocoaPods
+======================================================
+
+How to release new versions
+---------------------------
+
+1. After the `.xcframeworks` have been created compress them into a zip named `GiniBankSDKPinning-XCFrameworks.zip`.  
+   IMPORTANT: On MacOS the zip needs to be created by selecting all the XCFrameworks and compressing them. It won't work
+   if you compress the folder containing the XCFrameworks[^1].  
+   You can also use the following `zip` command inside the folder where all the XCFrameworks are (make sure you include
+   all the required XCFrameworks, this example might be outdated):
+   ```
+   zip -r GiniBankSDKPinning-XCFrameworks.zip \
+   GiniBankAPILibrary.xcframework \
+   GiniBankAPILibraryPinning.xcframework \
+   GiniBankSDK.xcframework \
+   GiniBankSDKPinning.xcframework \
+   GiniCaptureSDK.xcframework \
+   GiniCaptureSDKPinning.xcframework \
+   TrustKit.xcframework
+   ```
+2. Clone the `https://github.com/gini/gini-podspecs` repository.
+3. Go into the `gini-podspecs` repository folder and create a subfolder in `GiniBankSDKPinning` which is named after the
+   version, for example `2.2.1`.
+4. Copy the `GiniBankSDKPinning-XCFrameworks.zip` into the new folder.
+5. Copy the `GiniBankSDKPinning.podspec` file from the folder where this readme is located into the new folder and update the
+   version with the corresponding one, for example `spec.version = 2.2.1`.
+6. Commit and push the new folder and its contents to `gini-podspecs` repo.
+
+[^1]: If we put the XCFrameworks into a folder and then zip that folder then the `unzip` command Cocoapods uses[^2] will
+put all the XCFrameworks into a subfolder with the same name as the zipped folder. This breaks adding the XCFrameworks
+to the project because Cocoapods can't find XCFrameworks in subfolders.
+
+[^2]: Cocoapods unzip command: `unzip GiniBankSDKPinning-XCFrameworks.zip -d output-dir`
+
+How to use the GiniBankSDKPinning pod
+-------------------------------------
+
+1. Add the following to your `Podfile`:
+   1. `source 'https://github.com/gini/gini-podspecs.git'`
+   2. `pod GiniBankSDKPinning`
+2. Run `pod update` to fetch the latest Gini Bank SDK pod version.
+
+How to test the GiniBankSDKPinning pod
+--------------------------------------
+
+1. Clone the `cocoapods-xcframework-tester` repository: https://github.com/gini/cocoapods-xcframework-tester
+2. Go to your local `cocoapods-xcframework-tester` repo folder.
+3. Update the `Podfile` to use the `GiniBankSDKPinning` pod.
+4. Run `pod update` to get the newest version of the pod.
+5. Open the `.xcworkspace` to build and run the project.

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -440,17 +440,17 @@ platform :ios do
   DOC
   lane :publish_podspec do |options|
 
-    (xcframeworks_folder_path, podspec_name, podspecs_repo_sdk_folder_path, template_podspec_path) = 
-      check_and_get_options(options, [:xcframeworks_folder_path, :podspec_name, :podspecs_repo_sdk_folder_path, :template_podspec_path], UI)
+    (xcframeworks_folder_path, pod_name, podspecs_repo_sdk_folder_path, template_podspec_path) = 
+      check_and_get_options(options, [:xcframeworks_folder_path, :pod_name, :podspecs_repo_sdk_folder_path, :template_podspec_path], UI)
 
     # Get the latest Git tag
     latest_tag = sh("git describe --tags --abbrev=0").strip
 
     # Extract the version from the tag (assuming the tag format is "GiniBankSDK;X.X.X")
-    version_folder = get_latest_version_from_release_tags(podspec_name, UI)
+    version_folder = get_latest_version_from_release_tags(pod_name, UI)
     
     # Step 1: Compress the XCFrameworks into a zip file
-    zip_name = "#{podspec_name}-XCFrameworks.zip" #e.g GiniBankSDK or GiniBankSDKPinning
+    zip_name = "#{pod_name}-XCFrameworks.zip" #e.g GiniBankSDK or GiniBankSDKPinning
     sh "cd #{xcframeworks_folder_path} && zip -r #{zip_name} ."
     
     # Step 2: Create a subfolder named after the version
@@ -459,17 +459,17 @@ platform :ios do
 
     # Step 3: Copy the zip file and podspec into the new folder
     sh "cp #{xcframeworks_folder_path}/#{zip_name} #{sdk_folder}/"
-    sh "cp ../BankSDK/#{podspec_name}/Pod/#{podspec_name}.podspec #{sdk_folder}/" #e.g: BankSDK/GiniBankSDK or BankSDK/GiniBankSDKPinning
+    sh "cp ../BankSDK/#{pod_name}/Pod/#{pod_name}.podspec #{sdk_folder}/" #e.g: BankSDK/GiniBankSDK or BankSDK/GiniBankSDKPinning
     
     # Step 4: Update the version in the podspec
-    podspec_file_path = "#{sdk_folder}/#{podspec_name}.podspec"
+    podspec_file_path = "#{sdk_folder}/#{pod_name}.podspec"
     sh "sed -i '' 's/spec.version[[:space:]]*=[[:space:]]*\".*\"/spec.version = \"#{version_folder}\"/' #{podspec_file_path}"
 
     # Step 5: Copy the recently created version folder (e.g. 3.7.2) in gini-podspecs repo folder
     sh "cp -r #{sdk_folder} #{podspecs_repo_sdk_folder_path}/"
 
     # Step 6: Commit the changes to gini-podspecs repo
-    sh "cd #{podspecs_repo_sdk_folder_path} && git add . && git commit -m '[Update] #{podspec_name} (#{version_folder})'" 
+    sh "cd #{podspecs_repo_sdk_folder_path} && git add . && git commit -m '[Update] #{pod_name} (#{version_folder})'" 
 
     # Step 7: Push the changes to gini-podspecs repo
     if UI.confirm("Are you sure you want to commit this changes to gini-podspecs repo?")

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -442,10 +442,7 @@ platform :ios do
 
     (xcframeworks_folder_path, pod_name, podspecs_repo_sdk_folder_path, template_podspec_path) = 
       check_and_get_options(options, [:xcframeworks_folder_path, :pod_name, :podspecs_repo_sdk_folder_path, :template_podspec_path], UI)
-
-    # Get the latest Git tag
-    latest_tag = sh("git describe --tags --abbrev=0").strip
-
+    
     # Extract the version from the tag (assuming the tag format is "GiniBankSDK;X.X.X")
     # Remove "Pinning" suffix, if needed, because we don't tag pinning releases separately (pinning version is released together with the non-pinning version)
     project_id = pod_name.sub('Pinning', '') 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -448,7 +448,7 @@ platform :ios do
     latest_tag = sh("git describe --tags --abbrev=0").strip
 
     # Extract the version from the tag (assuming the tag format is "GiniBankSDK;X.X.X")
-    version_folder = latest_tag.match(/;(\d+\.\d+\.\d+)/).captures.first
+    version_folder = get_latest_version_from_release_tags(podspec_name, UI)
     
     # Step 1: Compress the XCFrameworks into a zip file
     zip_name = "#{podspec_name}-XCFrameworks.zip" #e.g GiniBankSDK or GiniBankSDKPinning

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -428,7 +428,16 @@ platform :ios do
 
   end
 
-  desc "Generate release podspecs"
+  desc <<~DOC
+  Generate a release podspec and publish it on https://github.com/gini/gini-podspecs.
+  
+  Parameters:
+    xcframeworks_folder_path        - path to the folder which contains the .xcframeworks files
+    pod_name                        - name of the pod, usually the same as the Swift package name, e.g. GiniBankSDK or GiniCaptureSDKPinning
+    podspecs_repo_sdk_folder_path   - path to the folder which contains the local clone of the https://github.com/gini/gini-podspecs repo
+    template_podspec_path           - path to the template podspec file, which is modified and used for the new pod version
+
+  DOC
   lane :generate_release_podspecs do |options|
 
     xcframeworks_folder_path = options[:xcframeworks_folder_path]

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -438,7 +438,7 @@ platform :ios do
     template_podspec_path           - path to the template podspec file, which is modified and used for the new pod version
 
   DOC
-  lane :generate_release_podspecs do |options|
+  lane :publish_podspec do |options|
 
     xcframeworks_folder_path = options[:xcframeworks_folder_path]
     podspec_name = options[:podspec_name] #e.g: GiniBankSDK or GiniBankSDKPinning

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -447,7 +447,9 @@ platform :ios do
     latest_tag = sh("git describe --tags --abbrev=0").strip
 
     # Extract the version from the tag (assuming the tag format is "GiniBankSDK;X.X.X")
-    version_folder = get_latest_version_from_release_tags(pod_name, UI)
+    # Remove "Pinning" suffix, if needed, because we don't tag pinning releases separately (pinning version is released together with the non-pinning version)
+    project_id = pod_name.sub('Pinning', '') 
+    version_folder = get_latest_version_from_release_tags(project_id, UI)
     
     # Step 1: Compress the XCFrameworks into a zip file
     zip_name = "#{pod_name}-XCFrameworks.zip" #e.g GiniBankSDK or GiniBankSDKPinning

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -428,11 +428,12 @@ platform :ios do
 
   end
 
-  desc "Generate release podspecs for GiniBankSDK"
+  desc "Generate release podspecs"
   lane :generate_release_podspecs do |options|
 
     xcframeworks_folder_path = options[:xcframeworks_folder_path]
-    podspecs_repo_folder_path = options[:podspecs_repo_folder_path]
+    podspec_name = options[:podspec_name] #e.g: GiniBankSDK or GiniBankSDKPinning
+    podspecs_repo_sdk_folder_path = options[:podspecs_repo_sdk_folder_path]
 
     # Get the latest Git tag
     latest_tag = sh("git describe --tags --abbrev=0").strip
@@ -441,29 +442,30 @@ platform :ios do
     version_folder = latest_tag.match(/;(\d+\.\d+\.\d+)/).captures.first
     
     # Step 1: Compress the XCFrameworks into a zip file
-    zip_name = "GiniBankSDK-XCFrameworks.zip"
+    zip_name = "#{podspec_name}-XCFrameworks.zip" #e.g GiniBankSDK or GiniBankSDKPinning
     sh "cd #{xcframeworks_folder_path} && zip -r #{zip_name} ."
     
-    # Step 2: Create a subfolder in GiniBankSDK named after the version
+    # Step 2: Create a subfolder named after the version
     sdk_folder = "#{xcframeworks_folder_path}/#{version_folder}"
     sh "mkdir -p #{sdk_folder}"
 
     # Step 3: Copy the zip file and podspec into the new folder
     sh "cp #{xcframeworks_folder_path}/#{zip_name} #{sdk_folder}/"
-    sh "cp ../BankSDK/GiniBankSDK/Pod/GiniBankSDK.podspec #{sdk_folder}/"
+    sh "cp ../BankSDK/#{podspec_name}/Pod/#{podspec_name}.podspec #{sdk_folder}/" #e.g: BankSDK/GiniBankSDK or BankSDK/GiniBankSDKPinning
     
     # Step 4: Update the version in the podspec
-    podspec_file_path = "#{sdk_folder}/GiniBankSDK.podspec"
+    podspec_file_path = "#{sdk_folder}/#{podspec_name}.podspec"
     sh "sed -i '' 's/spec.version[[:space:]]*=[[:space:]]*\".*\"/spec.version = \"#{version_folder}\"/' #{podspec_file_path}"
 
     # Step 5: Copy the recently created version folder (e.g. 3.7.2) in gini-podspecs repo folder
-    sh "cp -r #{sdk_folder} #{podspecs_repo_folder_path}/"
+    sh "cp -r #{sdk_folder} #{podspecs_repo_sdk_folder_path}/"
 
-    # Step 6: Commit and push the changes to gini-podspecs repo
-    sh "cd #{podspecs_repo_folder_path} && git add . && git commit -m '[Update] GiniBankSDK (#{version_folder})'" 
+    # Step 6: Commit the changes to gini-podspecs repo
+    sh "cd #{podspecs_repo_sdk_folder_path} && git add . && git commit -m '[Update] #{podspec_name} (#{version_folder})'" 
 
-    if UI.confirm("Do you realy want to commit this chnages to gini-podspecs repo?")
-      sh "git push origin master"
+    # Step 7: Push the changes to gini-podspecs repo
+    if UI.confirm("Are you sure you want to commit this changes to gini-podspecs repo?")
+      sh "cd #{podspecs_repo_sdk_folder_path} && git push origin master"
     end
   end
 end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -428,4 +428,42 @@ platform :ios do
 
   end
 
+  desc "Generate release podspecs for GiniBankSDK"
+  lane :generate_release_podspecs do |options|
+
+    xcframeworks_folder_path = options[:xcframeworks_folder_path]
+    podspecs_repo_folder_path = options[:podspecs_repo_folder_path]
+
+    # Get the latest Git tag
+    latest_tag = sh("git describe --tags --abbrev=0").strip
+
+    # Extract the version from the tag (assuming the tag format is "GiniBankSDK;X.X.X")
+    version_folder = latest_tag.match(/;(\d+\.\d+\.\d+)/).captures.first
+    
+    # Step 1: Compress the XCFrameworks into a zip file
+    zip_name = "GiniBankSDK-XCFrameworks.zip"
+    sh "cd #{xcframeworks_folder_path} && zip -r #{zip_name} ."
+    
+    # Step 2: Create a subfolder in GiniBankSDK named after the version
+    sdk_folder = "#{xcframeworks_folder_path}/#{version_folder}"
+    sh "mkdir -p #{sdk_folder}"
+
+    # Step 3: Copy the zip file and podspec into the new folder
+    sh "cp #{xcframeworks_folder_path}/#{zip_name} #{sdk_folder}/"
+    sh "cp ../BankSDK/GiniBankSDK/Pod/GiniBankSDK.podspec #{sdk_folder}/"
+    
+    # Step 4: Update the version in the podspec
+    podspec_file_path = "#{sdk_folder}/GiniBankSDK.podspec"
+    sh "sed -i '' 's/spec.version[[:space:]]*=[[:space:]]*\".*\"/spec.version = \"#{version_folder}\"/' #{podspec_file_path}"
+
+    # Step 5: Copy the recently created version folder (e.g. 3.7.2) in gini-podspecs repo folder
+    sh "cp -r #{sdk_folder} #{podspecs_repo_folder_path}/"
+
+    # Step 6: Commit and push the changes to gini-podspecs repo
+    sh "cd #{podspecs_repo_folder_path} && git add . && git commit -m '[Update] GiniBankSDK (#{version_folder})'" 
+
+    if UI.confirm("Do you realy want to commit this chnages to gini-podspecs repo?")
+      sh "git push origin master"
+    end
+  end
 end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -440,9 +440,8 @@ platform :ios do
   DOC
   lane :publish_podspec do |options|
 
-    xcframeworks_folder_path = options[:xcframeworks_folder_path]
-    podspec_name = options[:podspec_name] #e.g: GiniBankSDK or GiniBankSDKPinning
-    podspecs_repo_sdk_folder_path = options[:podspecs_repo_sdk_folder_path]
+    (xcframeworks_folder_path, podspec_name, podspecs_repo_sdk_folder_path, template_podspec_path) = 
+      check_and_get_options(options, [:xcframeworks_folder_path, :podspec_name, :podspecs_repo_sdk_folder_path, :template_podspec_path], UI)
 
     # Get the latest Git tag
     latest_tag = sh("git describe --tags --abbrev=0").strip

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -435,7 +435,7 @@ platform :ios do
     xcframeworks_folder_path        - path to the folder which contains the .xcframeworks files
     pod_name                        - name of the pod, usually the same as the Swift package name, e.g. GiniBankSDK or GiniCaptureSDKPinning
     podspecs_repo_sdk_folder_path   - path to the folder which contains the local clone of the https://github.com/gini/gini-podspecs repo
-    template_podspec_path           - path to the template podspec file, which is modified and used for the new pod version
+    template_podspec_path           - path to the template podspec file, which is modified and used for the new pod version e.g: BankSDK/GiniBankSDK/Pod/GiniBankSDK.podspec
 
   DOC
   lane :publish_podspec do |options|
@@ -459,7 +459,8 @@ platform :ios do
 
     # Step 3: Copy the zip file and podspec into the new folder
     sh "cp #{xcframeworks_folder_path}/#{zip_name} #{sdk_folder}/"
-    sh "cp ../BankSDK/#{pod_name}/Pod/#{pod_name}.podspec #{sdk_folder}/" #e.g: BankSDK/GiniBankSDK or BankSDK/GiniBankSDKPinning
+    # template_podspec_path sould look like: BankSDK/GiniBankSDK/Pod/GiniBankSDK.podspec or BankSDK/GiniBankSDKPinning/Pod/GiniBankSDKPinning.podspec
+    sh "cp #{template_podspec_path} #{sdk_folder}/"
     
     # Step 4: Update the version in the podspec
     podspec_file_path = "#{sdk_folder}/#{pod_name}.podspec"

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -473,7 +473,7 @@ platform :ios do
     sh "cd #{podspecs_repo_sdk_folder_path} && git add . && git commit -m '[Update] #{pod_name} (#{version_folder})'" 
 
     # Step 7: Push the changes to gini-podspecs repo
-    if UI.confirm("Are you sure you want to commit this changes to gini-podspecs repo?")
+    if if UI.confirm("Are you sure you want to push these changes to the https://github.com/gini/gini-podspecs repo?")
       sh "cd #{podspecs_repo_sdk_folder_path} && git push origin master"
     end
   end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -475,7 +475,7 @@ platform :ios do
     sh "cd #{podspecs_repo_sdk_folder_path} && git add . && git commit -m '[Update] #{pod_name} (#{version_folder})'" 
 
     # Step 7: Push the changes to gini-podspecs repo
-    if if UI.confirm("Are you sure you want to push these changes to the https://github.com/gini/gini-podspecs repo?")
+    if UI.confirm("Are you sure you want to push these changes to the https://github.com/gini/gini-podspecs repo?")
       sh "cd #{podspecs_repo_sdk_folder_path} && git push origin master"
     end
   end

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -129,7 +129,7 @@ Parameters:
 
 
 
-### ios generate_release_podspecs
+### ios publish_podspec
 
 ```sh
 [bundle exec] fastlane ios publish_podspec
@@ -138,10 +138,13 @@ Parameters:
 Generate a release podspec and publish it on https://github.com/gini/gini-podspecs.
 
 Parameters:
-      xcframeworks_folder_path        - path to the folder which contains the .xcframeworks files
-      pod_name                        - name of the pod, usually the same as the Swift package name, e.g. GiniBankSDK or GiniCaptureSDKPinning
-      podspecs_repo_sdk_folder_path   - path to the folder which contains the local clone of the https://github.com/gini/gini-podspecs repo
-      template_podspec_path           - path to the template podspec file, which is modified and used for the new pod version
+  xcframeworks_folder_path        - path to the folder which contains the .xcframeworks files
+  pod_name                        - name of the pod, usually the same as the Swift package name, e.g. GiniBankSDK or GiniCaptureSDKPinning
+  podspecs_repo_sdk_folder_path   - path to the folder which contains the local clone of the https://github.com/gini/gini-podspecs repo
+  template_podspec_path           - path to the template podspec file, which is modified and used for the new pod version e.g: BankSDK/GiniBankSDK/Pod/GiniBankSDK.podspec
+
+
+
 ----
 
 This README.md is auto-generated and will be re-generated every time [_fastlane_](https://fastlane.tools) is run.

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -132,7 +132,7 @@ Parameters:
 ### ios generate_release_podspecs
 
 ```sh
-[bundle exec] fastlane ios generate_release_podspecs
+[bundle exec] fastlane ios publish_podspec
 ```
 
 Generate a release podspec and publish it on https://github.com/gini/gini-podspecs.

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -129,6 +129,16 @@ Parameters:
 
 
 
+### ios generate_release_podspecs
+
+```sh
+[bundle exec] fastlane ios generate_release_podspecs
+```
+
+Generate release podspecs for GiniBankSDK
+Parameters:
+  xcframeworks_folder_path        - the path where all the needed framework are located
+  podspecs_repo_folder_path       - the path for the `podspecs_repo` where the folder for the new verson of `.podspec` file and frameworks archived is located
 ----
 
 This README.md is auto-generated and will be re-generated every time [_fastlane_](https://fastlane.tools) is run.

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -135,10 +135,8 @@ Parameters:
 [bundle exec] fastlane ios generate_release_podspecs
 ```
 
-Generate release podspecs for GiniBankSDK
-Parameters:
-  xcframeworks_folder_path        - the path where all the needed framework are located
-  podspecs_repo_folder_path       - the path for the `podspecs_repo` where the folder for the new verson of `.podspec` file and frameworks archived is located
+Generate release podspecs
+
 ----
 
 This README.md is auto-generated and will be re-generated every time [_fastlane_](https://fastlane.tools) is run.

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -135,12 +135,13 @@ Parameters:
 [bundle exec] fastlane ios generate_release_podspecs
 ```
 
-Generate release podspecs
-Parameters:
-  xcframeworks_folder_path        - the path where all the needed framework are located
-  podspec_name                    - the name of the `.podspec` file, the zip file with all the needed frameworks and the destination folder in the `podspecs_repo` repo. The folder which contains all folders for each versions of the respectiv SDK.
-  podspecs_repo_sdk_folder_path   - the path for the `podspecs_repo` where the folder for the new verson of `.podspec` file and frameworks archived is located
+Generate a release podspec and publish it on https://github.com/gini/gini-podspecs.
 
+Parameters:
+      xcframeworks_folder_path        - path to the folder which contains the .xcframeworks files
+      pod_name                        - name of the pod, usually the same as the Swift package name, e.g. GiniBankSDK or GiniCaptureSDKPinning
+      podspecs_repo_sdk_folder_path   - path to the folder which contains the local clone of the https://github.com/gini/gini-podspecs repo
+      template_podspec_path           - path to the template podspec file, which is modified and used for the new pod version
 ----
 
 This README.md is auto-generated and will be re-generated every time [_fastlane_](https://fastlane.tools) is run.

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -136,6 +136,10 @@ Parameters:
 ```
 
 Generate release podspecs
+Parameters:
+  xcframeworks_folder_path        - the path where all the needed framework are located
+  podspec_name                    - the name of the `.podspec` file, the zip file with all the needed frameworks and the destination folder in the `podspecs_repo` repo. The folder which contains all folders for each versions of the respectiv SDK.
+  podspecs_repo_sdk_folder_path   - the path for the `podspecs_repo` where the folder for the new verson of `.podspec` file and frameworks archived is located
 
 ----
 


### PR DESCRIPTION
- add a Readme file with manual steps for how to release a new version of podspecs in `gini-podspecs`
- add an example of `podspecs` file 
- create a Fastlane lane to generate release podspecs with the release version

**Steps to test this locally**:
- add the folder with the needed frameworks for GiniBankSDK(GiniBankSDK, GiniBankApiLibrary, and GiniCaptureSDK) in the recently added folder `Pod` which can be found in the `GiniBankSDK` folder from `BankSDK` from the main folder of the project
- locate the local path for this folder from your computer
- locate the local path for the `gini-podspecs` repo from your computer
- pod_name: name of the `podspecs` file 
-  template_podspec_path : path to the template podspec file from the local clone of the mono repo project, which is modified and used for the new pod version e.g: BankSDK/GiniBankSDK/Pod/GiniBankSDK.podspec
- go to the terminal and navigate to the main folder of the `gini-mobile-ios` repo
- run this command 
```
fastlane publish_podspec xcframeworks_folder_path:</path/to/xcframeworks> pod_name:<Name> podspecs_repo_sdk_folder_path:</path/to/gini-podspecs> template_podspec_path:</path/to/Pod/<Pod_Name.podspec>
```
 and replace all the paths.

Example:
```
fastlane publish_podspec xcframeworks_folder_path:/Users/valentinaiancu/Documents/Workspace/gini-mobile-ios/BankSDK/GiniBankSDK/Pod/GiniBankSDKPinning_3.7.2_XCFrameworks pod_name:GiniBankSDK podspecs_repo_sdk_folder_path:/Users/valentinaiancu/Documents/Workspace/gini-podspecs/GiniBankSDK template_podspec_path:/Users/valentinaiancu/Documents/Workspace/gini-mobile-ios/BankSDK/GiniBankSDK/Pod/GiniBankSDK.podspec
```
