### PR TITLE
PP 67 Mapping of error messages with api defined status codes

### DIFF
--- a/BankAPILibrary/GiniBankAPILibrary/Sources/GiniBankAPILibrary/Documents/Core/Auth/SessionManager+Auth.swift
+++ b/BankAPILibrary/GiniBankAPILibrary/Sources/GiniBankAPILibrary/Documents/Core/Auth/SessionManager+Auth.swift
@@ -59,7 +59,7 @@ extension SessionManager: SessionAuthenticationProtocol {
                                     }
                                 }
                             } else {
-                                completion(.failure(.unknown(response: error.response, data: nil)))
+                                completion(.failure(error))
                             }
                     }
                 }

--- a/HealthAPILibrary/GiniHealthAPILibrary/Sources/GiniHealthAPILibrary/Documents/Core/Auth/SessionManager+Auth.swift
+++ b/HealthAPILibrary/GiniHealthAPILibrary/Sources/GiniHealthAPILibrary/Documents/Core/Auth/SessionManager+Auth.swift
@@ -63,7 +63,7 @@ extension SessionManager: SessionAuthenticationProtocol {
                                     }
                                 }
                             } else {
-                                completion(.failure(.unknown(response: error.response, data: nil)))
+                                completion(.failure(error))
                             }
                     }
                 }

--- a/HealthAPILibrary/GiniHealthAPILibraryPinningExample/GiniHealthAPILibraryPinningExampleTests/GiniHealthAPILibraryPinningIntegrationWrongCertificatesTests.swift
+++ b/HealthAPILibrary/GiniHealthAPILibraryPinningExample/GiniHealthAPILibraryPinningExampleTests/GiniHealthAPILibraryPinningIntegrationWrongCertificatesTests.swift
@@ -47,7 +47,7 @@ class HealthAPILibraryPinningWrongCertificatesTests: XCTestCase {
             case .success:
                 XCTFail("creating a payment request should have failed due to wrong pinning certificates")
             case let .failure(error):
-                XCTAssertEqual(error, GiniHealthAPILibrary.GiniError.unknown())
+                XCTAssertEqual(error, GiniHealthAPILibrary.GiniError.noResponse)
                 expect.fulfill()
             }
         }

--- a/HealthSDK/GiniHealthSDKExample/GiniHealthSDKPinningExampleTests/GiniHealthSDKPinningExampleWrongCertificatesTests.swift
+++ b/HealthSDK/GiniHealthSDKExample/GiniHealthSDKPinningExampleTests/GiniHealthSDKPinningExampleWrongCertificatesTests.swift
@@ -62,7 +62,7 @@ class GiniHealthSDKPinningExampleWrongCertificatesTests: XCTestCase {
             case .success:
                 XCTFail("creating a payment request should have failed due to wrong pinning certificates")
             case let .failure(error):
-                XCTAssertEqual(error, GiniError.unknown())
+                XCTAssertEqual(error, GiniError.noResponse)
                 expect.fulfill()
             }
         }


### PR DESCRIPTION
Fix the error type when fetching the user access token so the error is not `unauthorized` one and tests