### PR TITLE
PP 392 add error screen events

### DIFF
--- a/BankAPILibrary/GiniBankAPILibrary/Sources/GiniBankAPILibrary/Documents/Core/GiniError.swift
+++ b/BankAPILibrary/GiniBankAPILibrary/Sources/GiniBankAPILibrary/Documents/Core/GiniError.swift
@@ -48,9 +48,9 @@ public enum GiniError: Error, GiniErrorProtocol, Equatable {
     case requestCancelled
     case tooManyRequests(response: HTTPURLResponse? = nil, data: Data? = nil)
     case unauthorized(response: HTTPURLResponse? = nil, data: Data? = nil)
-    case maintenance
-    case outage
-    case server
+    case maintenance(errorCode: Int)
+    case outage(errorCode: Int)
+    case server(errorCode: Int)
     case unknown(response: HTTPURLResponse? = nil, data: Data? = nil)
     case noInternetConnection
 

--- a/BankAPILibrary/GiniBankAPILibrary/Sources/GiniBankAPILibrary/Documents/Core/SessionManager.swift
+++ b/BankAPILibrary/GiniBankAPILibrary/Sources/GiniBankAPILibrary/Documents/Core/SessionManager.swift
@@ -311,11 +311,11 @@ private extension SessionManager {
         case 429:
             completion(.failure(.tooManyRequests(response: response, data: data)))
         case 503:
-            completion(.failure(.maintenance))
+            completion(.failure(.maintenance(errorCode: statusCode)))
         case 500:
-            completion(.failure(.outage))
+            completion(.failure(.outage(errorCode: statusCode)))
         case 501, 502, 504...599:
-            completion(.failure(.server))
+            completion(.failure(.server(errorCode: statusCode)))
         default:
             completion(.failure(.unknown(response: response, data: data)))
         }

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Error/ErrorType.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Error/ErrorType.swift
@@ -17,6 +17,7 @@ import GiniBankAPILibrary
  - authentication: Error related to authentication.
  - unexpected: Unexpected error that is not covered by the other cases.
  - maintenance: Error returned when the system is under maintenance.
+ - outage: Error indicating that the service is unavailable due to outage.
  */
 
 @objc public enum ErrorType: Int {
@@ -27,6 +28,9 @@ import GiniBankAPILibrary
     case unexpected
     case maintenance
     case outage
+
+    // Dictionary to store ErrorAnalytics for each case
+    private static var errorAnalyticsDictionary: [ErrorType: ErrorAnalytics] = [:]
 
     /**
      Initializes a new instance of the `ErrorType` enum based on the given `GiniError`.
@@ -55,6 +59,11 @@ import GiniBankAPILibrary
         default:
             self = .unexpected
         }
+
+        // Generate error analytics using AnalyticsMapper
+        let errorAnalytics = AnalyticsMapper.errorAnalytics(from: error)
+        // Store error analytics in the dictionary
+        ErrorType.errorAnalyticsDictionary[self] = errorAnalytics
     }
 
     func iconName() -> String {
@@ -138,5 +147,16 @@ import GiniBankAPILibrary
                 "ginicapture.error.outage.title",
                 comment: "Outage error")
         }
+    }
+
+    /**
+     Get the error analytics for the current `ErrorType`.
+
+     - Returns: An `ErrorAnalytics` object representing the analytics for the error.
+     */
+    func errorAnalytics() -> ErrorAnalytics {
+        let unknownError = ErrorAnalytics(type: "", code: nil,
+                                          reason: "Error analytics not found for \(self)")
+        return ErrorType.errorAnalyticsDictionary[self] ?? unknownError
     }
 }

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/NoResult/NoResultScreenViewController.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/NoResult/NoResultScreenViewController.swift
@@ -30,19 +30,6 @@ final class NoResultScreenViewController: UIViewController {
                 return text
             }
         }
-
-        var analyticsValue: String {
-            switch self {
-            case .pdf:
-                return "pdf"
-            case .image:
-                return "image"
-            case .qrCode:
-                return "qrCode"
-            default:
-                return "unknown"
-            }
-        }
     }
 
     lazy var tableView: UITableView = {
@@ -125,8 +112,8 @@ final class NoResultScreenViewController: UIViewController {
         super.viewDidLoad()
         self.setupView()
 
-        let eventProperties = [AnalyticsProperty(key: .noResultType,
-                                                 value: type.analyticsValue)]
+        let eventProperties = [AnalyticsProperty(key: .documentType,
+                                                 value: AnalyticsMapper.documentTypeAnalytics(from: type))]
         AnalyticsManager.trackScreenShown(screenName: .noResults,
                                           properties: eventProperties)
     }

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Screen API Coordinator/GiniScreenAPICoordinator+Analysis.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Screen API Coordinator/GiniScreenAPICoordinator+Analysis.swift
@@ -107,7 +107,8 @@ extension GiniScreenAPICoordinator: AnalysisDelegate {
                         } else {
                             self?.screenAPINavigationController.dismiss(animated: animated)
                         }
-                    }, cancelPressed: { [weak self] in
+                    }, 
+                    cancelPressed: { [weak self] in
                         self?.closeScreenApi()
                 })
             } else {
@@ -118,7 +119,8 @@ extension GiniScreenAPICoordinator: AnalysisDelegate {
                         } else {
                             self?.screenAPINavigationController.dismiss(animated: animated)
                         }
-                    }, cancelPressed: { [weak self] in
+                    }, 
+                    cancelPressed: { [weak self] in
                     self?.closeScreenApi()
                 })
             }
@@ -126,17 +128,18 @@ extension GiniScreenAPICoordinator: AnalysisDelegate {
             viewModel = BottomButtonsViewModel(
                 manuallyPressed: { [weak self] in
                     self?.screenAPINavigationController.dismiss(animated: true)
-                }, cancelPressed: { [weak self] in
+                }, 
+                cancelPressed: { [weak self] in
                 self?.closeScreenApi()
             })
         }
 
         self.trackingDelegate?.onAnalysisScreenEvent(event: Event(type: .error))
-        let viewController = ErrorScreenViewController(
-            giniConfiguration: giniConfiguration,
-            type: errorType,
-            documentType: pages.type ?? .pdf,
-            viewModel: viewModel)
+        let viewController = ErrorScreenViewController(giniConfiguration: giniConfiguration,
+                                                       type: errorType,
+                                                       documentType: pages.type ?? .pdf,
+                                                       viewModel: viewModel, 
+                                                       errorAnalytics: ErrorAnalytics(type: ""))
 
         screenAPINavigationController.pushViewController(viewController, animated: animated)
     }

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Screen API Coordinator/GiniScreenAPICoordinator+Camera.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Screen API Coordinator/GiniScreenAPICoordinator+Camera.swift
@@ -335,9 +335,8 @@ extension GiniScreenAPICoordinator: UploadDelegate {
             guard let self = self else { return }
             self.update(document, withError: error, isUploaded: false)
 
-            let errorLog = ErrorLog(
-                description: String(describing: error),
-                error: error)
+            let errorLog = ErrorLog(description: String(describing: error),
+                                    error: error)
             self.giniConfiguration.errorLogger.handleErrorLog(error: errorLog)
             guard let giniError = error as? GiniError, giniError != .requestCancelled else { return }
             self.displayError(errorType: ErrorType(error: giniError), animated: true)

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Tracking/AnalyticsEvent.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Tracking/AnalyticsEvent.swift
@@ -31,4 +31,5 @@ enum AnalyticsEvent: String {
     // MARK: - No Results and Error
     case enterManuallyTapped = "enter_manually_tapped"
     case retakeImagesTapped = "retake_images_tapped"
+    case backToCameraTapped = "back_to_camera_tapped"
 }

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Tracking/AnalyticsMapper.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Tracking/AnalyticsMapper.swift
@@ -1,0 +1,66 @@
+//
+//  AnalyticsMapper.swift
+//
+//  Copyright © 2024 Gini GmbH. All rights reserved.
+//
+
+import Foundation
+import GiniBankAPILibrary
+
+class AnalyticsMapper {
+
+    static func documentTypeAnalytics(from noResultType: NoResultScreenViewController.NoResultType) -> String {
+        switch noResultType {
+        case .pdf:
+            return "pdf"
+        case .image:
+            return "image"
+        case .qrCode:
+            return "qrCode"
+        default:
+            return "unknown"
+        }
+    }
+
+    static func documentTypeAnalytics(from documentType: GiniCaptureDocumentType) -> String {
+        switch documentType {
+        case .pdf:
+            return "pdf"
+        case .image:
+            return "image"
+        case .qrcode:
+            return "qrCode"
+        }
+    }
+
+    static func errorAnalytics(from error: GiniError) -> ErrorAnalytics {
+        switch error {
+        case .badRequest(let response, _):
+            return ErrorAnalytics(type: "bad_request", code: response?.statusCode, reason: error.message)
+        case .notAcceptable(let response, _):
+            return ErrorAnalytics(type: "not_acceptable", code: response?.statusCode, reason: error.message)
+        case .notFound(let response, _):
+            return ErrorAnalytics(type: "not_found", code: response?.statusCode, reason: error.message)
+        case .noResponse:
+            return ErrorAnalytics(type: "no_reponse", reason: error.message)
+        case .parseError(_, let response, _):
+            return ErrorAnalytics(type: "bad_request", code: response?.statusCode, reason: error.message)
+        case .requestCancelled:
+            return ErrorAnalytics(type: "request_cancelled", reason: error.message)
+        case .tooManyRequests(let response, _):
+            return ErrorAnalytics(type: "too_many_requests", code: response?.statusCode, reason: error.message)
+        case .unauthorized(let response, _):
+            return ErrorAnalytics(type: "unauthorized", code: response?.statusCode, reason: error.message)
+        case .maintenance(let errorCode):
+            return ErrorAnalytics(type: "maintenance", code: errorCode, reason: error.message)
+        case .outage(let errorCode):
+            return ErrorAnalytics(type: "outage", code: errorCode, reason: error.message)
+        case .server(let errorCode):
+            return ErrorAnalytics(type: "server", code: errorCode, reason: error.message)
+        case .unknown(let response, _):
+            return ErrorAnalytics(type: "unknown", code: response?.statusCode, reason: error.message)
+        case .noInternetConnection:
+            return ErrorAnalytics(type: "no_internet")
+        }
+    }
+}

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Tracking/AnalyticsProperties.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Tracking/AnalyticsProperties.swift
@@ -40,6 +40,9 @@ enum AnalyticsPropertyKey: String {
     case documentPageNumber = "document_page_number"
     case ibanDetectionLayerVisible = "iban_detection_layer_visible"
 
+    case documentId = "document_id"
     case errorMessage = "error_message"
-    case noResultType = "no_result_type"
+    case documentType = "document_type"
+    case errorCode = "error_code"
+    case errorType = "error_type"
 }

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Tracking/AnalyticsScreen.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Tracking/AnalyticsScreen.swift
@@ -4,7 +4,6 @@
 //  Copyright © 2024 Gini GmbH. All rights reserved.
 //
 
-
 import Foundation
 
 enum AnalyticsScreen: String {
@@ -13,4 +12,5 @@ enum AnalyticsScreen: String {
     case review
     case analysis
     case noResults = "no_results"
+    case error
 }

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Tracking/ErrorAnalytics.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Tracking/ErrorAnalytics.swift
@@ -1,0 +1,19 @@
+//
+//  ErrorAnalytics.swift
+//
+//  Copyright © 2024 Gini GmbH. All rights reserved.
+//
+
+import Foundation
+
+public struct ErrorAnalytics {
+    let type: String
+    let code: Int?
+    let reason: String?
+
+    init(type: String, code: Int? = nil, reason: String? = nil) {
+        self.type = type
+        self.code = code
+        self.reason = reason
+    }
+}

--- a/CaptureSDK/GiniCaptureSDK/Tests/GiniCaptureSDKTests/GiniScreenAPICoordinatorTests.swift
+++ b/CaptureSDK/GiniCaptureSDK/Tests/GiniCaptureSDKTests/GiniScreenAPICoordinatorTests.swift
@@ -174,7 +174,7 @@ final class GiniScreenAPICoordinatorTests: XCTestCase {
 
         let rootViewController = coordinator.start(withDocuments: capturedImages)
         _ = rootViewController.view
-        let errorType = ErrorType(error: .server)
+        let errorType = ErrorType(error: .server(errorCode: 502))
         coordinator.displayError(errorType: errorType, animated: false)
         let screenNavigator = rootViewController.children.first as? UINavigationController
         let errorScreen = screenNavigator?.viewControllers.last as? ErrorScreenViewController
@@ -193,7 +193,7 @@ final class GiniScreenAPICoordinatorTests: XCTestCase {
 
         let rootViewController = coordinator.start(withDocuments: capturedImages)
         _ = rootViewController.view
-        let errorType = ErrorType(error: .maintenance)
+        let errorType = ErrorType(error: .maintenance(errorCode: 503))
         coordinator.displayError(errorType: errorType, animated: false)
         let screenNavigator = rootViewController.children.first as? UINavigationController
         let errorScreen = screenNavigator?.viewControllers.last as? ErrorScreenViewController
@@ -212,7 +212,7 @@ final class GiniScreenAPICoordinatorTests: XCTestCase {
 
         let rootViewController = coordinator.start(withDocuments: capturedImages)
         _ = rootViewController.view
-        let errorType = ErrorType(error: .outage)
+        let errorType = ErrorType(error: .outage(errorCode: 500))
         coordinator.displayError(errorType: errorType, animated: false)
         let screenNavigator = rootViewController.children.first as? UINavigationController
         let errorScreen = screenNavigator?.viewControllers.last as? ErrorScreenViewController


### PR DESCRIPTION
- events added: `screen_shown`, `close_tapped`, `enter_manually_tapped`, `retake_images_tapped`
- refactor no results screen `screen_shown` event properties to use `AnalyticsMapper`
- fix indentation