### PR TITLE
Pp 422 tapping the help button multiple times before the camera is active help screen is pushed multiple times

### DIFF
--- a/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/ReturnAssistant/DigitalInvoice/Components/DigitalLineItemTableViewCell.swift
+++ b/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/ReturnAssistant/DigitalInvoice/Components/DigitalLineItemTableViewCell.swift
@@ -98,6 +98,7 @@ class DigitalLineItemTableViewCell: UITableViewCell {
         let editTitle = NSLocalizedStringPreferredGiniBankFormat("ginibank.digitalinvoice.lineitem.editbutton",
                                                                  comment: "Edit")
         editButton.setTitle(editTitle, for: .normal)
+        editButton.isExclusiveTouch = true
 
         separatorView.backgroundColor = GiniColor(light: .GiniBank.light3, dark: .GiniBank.dark4).uiColor()
         unitPriceLabel.textColor = .GiniBank.dark7

--- a/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/ReturnAssistant/EditLineItem/Components/QuantityView.swift
+++ b/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/ReturnAssistant/EditLineItem/Components/QuantityView.swift
@@ -45,6 +45,7 @@ final class QuantityView: UIView {
         let button = UIButton()
         button.setImage(prefferedImage(named: "quantity_minus_icon"), for: .normal)
         button.addTarget(self, action: #selector(decreaseQuantity), for: .touchUpInside)
+        button.isExclusiveTouch = true
         button.translatesAutoresizingMaskIntoConstraints = false
         let descriptor = NSLocalizedStringPreferredGiniBankFormat("ginibank.digitalinvoice.edit.minus.button.accessibility",
                                                                   comment: "Decrease quantity")
@@ -56,6 +57,7 @@ final class QuantityView: UIView {
         let button = UIButton()
         button.setImage(prefferedImage(named: "quantity_plus_icon"), for: .normal)
         button.addTarget(self, action: #selector(increaseQuantity), for: .touchUpInside)
+        button.isExclusiveTouch = true
         button.translatesAutoresizingMaskIntoConstraints = false
         let descriptor = NSLocalizedStringPreferredGiniBankFormat("ginibank.digitalinvoice.edit.plus.button.accessibility",
                                                                   comment: "Increase quantity")

--- a/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/ReturnAssistant/EditLineItem/EditLineItemView.swift
+++ b/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/ReturnAssistant/EditLineItem/EditLineItemView.swift
@@ -19,6 +19,7 @@ final class EditLineItemView: UIView {
                                   for: .normal)
         button.setTitle(title, for: .normal)
         button.addTarget(self, action: #selector(didTapCancel), for: .touchUpInside)
+        button.isExclusiveTouch = true
         // The color is set twice because in some iOS versions the `setTitleColor` does not change the color
         button.setTitleColor(.GiniBank.accent1, for: .normal)
         button.titleLabel?.textColor = .GiniBank.accent1
@@ -47,6 +48,7 @@ final class EditLineItemView: UIView {
         button.setAttributedTitle(NSAttributedString(string: title, attributes: textAttributes(for: .bodyBold)),
                                   for: .normal)
         button.addTarget(self, action: #selector(didTapSave), for: .touchUpInside)
+        button.isExclusiveTouch = true
         // The color is set twice because in some iOS versions the `setTitleColor` does not change the color
         button.setTitleColor(.GiniBank.accent1, for: .normal)
         button.titleLabel?.textColor = .GiniBank.accent1

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Custom views/BottomLabelButton.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Custom views/BottomLabelButton.swift
@@ -15,6 +15,7 @@ final class BottomLabelButton: UIView {
         let button = UIButton()
         button.translatesAutoresizingMaskIntoConstraints = false
         button.addTarget(self, action: #selector(didPressButton(_:)), for: .touchUpInside)
+        button.isExclusiveTouch = true
         return button
     }()
 

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Custom views/FileImportButtonView.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Custom views/FileImportButtonView.swift
@@ -21,6 +21,7 @@ final class FileImportButtonView: UIView {
         button.setImage(self.documentImportButtonImage, for: .normal)
         button.imageView?.contentMode = .scaleAspectFit
         button.addTarget(self, action: #selector(showImportFileSheet), for: .touchUpInside)
+        button.isExclusiveTouch = true
         button.imageEdgeInsets = UIEdgeInsets(top: 4, left: 4, bottom: 4, right: 4)
         return button
     }()

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Custom views/GiniBarButton.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Custom views/GiniBarButton.swift
@@ -56,6 +56,7 @@ public final class GiniBarButton {
     public func addAction(_ target: Any?, _ action: Selector) {
         let tapRecognizer = UITapGestureRecognizer(target: target, action: action)
         stackView.addGestureRecognizer(tapRecognizer)
+        stackView.isExclusiveTouch = true
     }
 
     /**

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Custom views/MultilineTitleButton.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Custom views/MultilineTitleButton.swift
@@ -40,6 +40,7 @@ public class MultilineTitleButton: UIButton {
         titleLabel?.textAlignment = .center
         setContentHuggingPriority(UILayoutPriority.defaultLow + 1, for: .vertical)
         setContentHuggingPriority(UILayoutPriority.defaultLow + 1, for: .horizontal)
+        isExclusiveTouch = true
     }
 
     /**

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Helpers/PreferredButtonResource.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Helpers/PreferredButtonResource.swift
@@ -37,7 +37,7 @@ class GiniPreferredButtonResource: PreferredButtonResource {
     private let localizedConfigEntry: String?
     private let appBundle = Bundle.main
     private let libBundle = giniCaptureBundle()
-    private var customBundle : Bundle {
+    private var customBundle: Bundle {
          guard let customBundle = GiniConfiguration.shared.customResourceBundle else {
              return Bundle.main
          }

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Camera/Camera/CameraLensSwitcherView.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Camera/Camera/CameraLensSwitcherView.swift
@@ -38,6 +38,7 @@ final class CameraLensSwitcherView: UIView {
         button.isHidden = true
         button.setTitleColor(.GiniCapture.light1, for: .normal)
         button.backgroundColor = .GiniCapture.dark4.withAlphaComponent(Constants.inactiveStateAlpha)
+        button.isExclusiveTouch = true
         button.translatesAutoresizingMaskIntoConstraints = false
         if let font = GiniConfiguration.shared.textStyleFonts[.caption2] {
             if font.pointSize > Constants.maxFontSize {
@@ -54,6 +55,7 @@ final class CameraLensSwitcherView: UIView {
         button.isHidden = true
         button.setTitleColor(.GiniCapture.light1, for: .normal)
         button.backgroundColor = .GiniCapture.dark4.withAlphaComponent(Constants.inactiveStateAlpha)
+        button.isExclusiveTouch = true
         button.translatesAutoresizingMaskIntoConstraints = false
         if let font = GiniConfiguration.shared.textStyleFonts[.caption2] {
             if font.pointSize > Constants.maxFontSize {
@@ -70,6 +72,7 @@ final class CameraLensSwitcherView: UIView {
         button.isHidden = true
         button.setTitleColor(.GiniCapture.light1, for: .normal)
         button.backgroundColor = .GiniCapture.dark4.withAlphaComponent(Constants.inactiveStateAlpha)
+        button.isExclusiveTouch = true
         button.translatesAutoresizingMaskIntoConstraints = false
         if let font = GiniConfiguration.shared.textStyleFonts[.caption2] {
             if font.pointSize > Constants.maxFontSize {

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Camera/Views/CameraNotAuthorizedView.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Camera/Views/CameraNotAuthorizedView.swift
@@ -59,6 +59,7 @@ final class CameraNotAuthorizedView: UIView {
                                         .limitingFontSize(to: Constants.maximumFontSize)
         button.titleLabel?.adjustsFontForContentSizeCategory = true
         button.addTarget(self, action: #selector(openSettings), for: .touchUpInside)
+        button.isExclusiveTouch = true
         return button
     }()
 

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Camera/Views/CameraPane.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Camera/Views/CameraPane.swift
@@ -29,6 +29,7 @@ final class CameraPane: UIView {
             light: UIColor.GiniCapture.dark1,
             dark: UIColor.GiniCapture.dark1).uiColor().withAlphaComponent(0.4)
         captureButton.setTitle("", for: .normal)
+        captureButton.isExclusiveTouch = true
         thumbnailView.isHidden = true
         fileUploadButton.setupButton(with: UIImageNamedPreferred(named: "folder") ?? UIImage(),
                                      name: NSLocalizedStringPreferredFormat("ginicapture.camera.fileImportButtonLabel",

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Camera/Views/ThumbnailView.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Camera/Views/ThumbnailView.swift
@@ -23,6 +23,7 @@ final class ThumbnailView: UIView {
         let button = UIButton()
         button.translatesAutoresizingMaskIntoConstraints = false
         button.addTarget(self, action: #selector(thumbnailButtonAction), for: .touchUpInside)
+        button.isExclusiveTouch = true
         return button
     }()
 

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Document picker/Gallery/AlbumsHeaderView.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Document picker/Gallery/AlbumsHeaderView.swift
@@ -26,6 +26,7 @@ final class AlbumsHeaderView: UITableViewHeaderFooterView {
         selectPhotosButton.setTitleColor(.GiniCapture.accent1, for: .normal)
         selectPhotosButton.sizeToFit()
         selectPhotosButton.titleLabel?.adjustsFontForContentSizeCategory = true
+        selectPhotosButton.isExclusiveTouch = true
     }
 
     override init(reuseIdentifier: String?) {

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Onboarding/Views/OnboardingBottomNavigationBar.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Onboarding/Views/OnboardingBottomNavigationBar.swift
@@ -30,14 +30,17 @@ final class OnboardingBottomNavigationBar: UIView {
         nextButton.titleLabel?.font = configuration.textStyleFonts[.bodyBold]
         nextButton.configure(with: configuration.primaryButtonConfiguration)
         nextButton.isAccessibilityElement = true
+        nextButton.isExclusiveTouch = true
 
         skipButton.titleLabel?.font = configuration.textStyleFonts[.bodyBold]
         skipButton.configure(with: configuration.transparentButtonConfiguration)
         skipButton.isAccessibilityElement = true
+        skipButton.isExclusiveTouch = true
 
         getStarted.titleLabel?.font = configuration.textStyleFonts[.bodyBold]
         getStarted.configure(with: configuration.primaryButtonConfiguration)
         getStarted.isAccessibilityElement = true
+        getStarted.isExclusiveTouch = true
 
         skipButton.setTitle(NSLocalizedStringPreferredFormat("ginicapture.onboarding.skip",
                                                              comment: "Skip button"), for: .normal)

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Review/ReviewCollectionCell.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Review/ReviewCollectionCell.swift
@@ -33,6 +33,7 @@ final class ReviewCollectionCell: UICollectionViewCell {
         button.setImage(deleteIcon, for: .normal)
         button.imageView?.contentMode = .scaleAspectFit
         button.addTarget(self, action: #selector(didTapDelete), for: .touchUpInside)
+        button.isExclusiveTouch = true
         button.isHidden = true
         button.isAccessibilityElement = true
         button.accessibilityLabel = NSLocalizedStringPreferredFormat("ginicapture.review.delete", comment: "Delete")

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Review/ReviewZoomViewController.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Review/ReviewZoomViewController.swift
@@ -16,6 +16,7 @@ final class ReviewZoomViewController: UIViewController {
         closeButton.setImage(UIImageNamedPreferred(named: "close_icon"), for: .normal)
         closeButton.imageView?.contentMode = .scaleAspectFit
         closeButton.addTarget(self, action: #selector(didTapCloseButton), for: .touchUpInside)
+        closeButton.isExclusiveTouch = true
         return closeButton
     }()
     private var page: GiniCapturePage


### PR DESCRIPTION
By setting `isExclusiveTouch` to `true`, we ensure that only one touch event is recognized at a time on that particular UI element.