### PR TITLE
PP 400 user gets stuck in qr code detection analysis screen when multi pages are scanned

### DIFF
--- a/BankAPILibrary/GiniBankAPILibrary/Sources/GiniBankAPILibrary/Documents/Document.swift
+++ b/BankAPILibrary/GiniBankAPILibrary/Sources/GiniBankAPILibrary/Documents/Document.swift
@@ -48,16 +48,16 @@ public struct Document {
     }
     
     init(compositeDocuments: [CompositeDocument]?,
-                creationDate: Date,
-                id: String,
-                name: String,
-                origin: Origin,
-                pageCount: Int,
-                pages: [Page]?,
-                links: Links,
-                partialDocuments: [PartialDocumentInfo]?,
-                progress: Progress,
-                sourceClassification: SourceClassification){
+         creationDate: Date,
+         id: String,
+         name: String,
+         origin: Origin,
+         pageCount: Int,
+         pages: [Page]?,
+         links: Links,
+         partialDocuments: [PartialDocumentInfo]?,
+         progress: Progress,
+         sourceClassification: SourceClassification) {
         self.compositeDocuments = compositeDocuments
         self.creationDate = creationDate
         self.id = id
@@ -83,11 +83,21 @@ public struct Document {
      - note: Screen API with custom networking only.
      */
     public init(creationDate: Date,
-                     id: String,
-                     name: String,
-                     links: Links,
-                     sourceClassification: SourceClassification) {
-        self.init(compositeDocuments: [], creationDate: creationDate, id: id, name: name, origin: .upload, pageCount: 1, pages: [], links: links, partialDocuments: [], progress: .completed, sourceClassification: sourceClassification)
+                id: String,
+                name: String,
+                links: Links,
+                sourceClassification: SourceClassification) {
+        self.init(compositeDocuments: [], 
+                  creationDate: creationDate, 
+                  id: id, 
+                  name: name,
+                  origin: .upload,
+                  pageCount: 1, 
+                  pages: [],
+                  links: links,
+                  partialDocuments: [],
+                  progress: .completed, 
+                  sourceClassification: sourceClassification)
     }
 }
 

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Screen API Coordinator/GiniScreenAPICoordinator+Camera.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Screen API Coordinator/GiniScreenAPICoordinator+Camera.swift
@@ -272,8 +272,8 @@ extension GiniScreenAPICoordinator {
 
         for document in documentsToValidate where document.type == .qrcode {
             // Scanning a QR code takes priority, even if the user has already taken some pictures.
-            // we should discard the pages that have already been scanned and keep the document generated after scanning the QR code
-            // We should proceed with the QR code flow.
+            // All the pages that have already been scanned should be discarded and keep the document generated after scanning the QR code.
+            // The flow of the QR code scanning process should be followed
             documentsToValidate = [document]
             break
         }

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Screen API Coordinator/GiniScreenAPICoordinator+Camera.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Screen API Coordinator/GiniScreenAPICoordinator+Camera.swift
@@ -26,15 +26,13 @@ extension GiniScreenAPICoordinator: CameraViewControllerDelegate {
             loadingView.removeFromSuperview()
             switch result {
             case .success(let validatedPages):
-                if document.type == .qrcode {
-                    self.didCaptureAndValidate(document)
-                    // Skip the analysis screen and validate the QR code on the same screen
-                    return
-                }
-
                 let validatedPage = validatedPages[0]
                 self.addToDocuments(new: [validatedPage])
                 self.didCaptureAndValidate(document)
+                if document.type == .qrcode {
+                    // Skip the analysis screen and validate the QR code on the same screen
+                    return
+                }
                 self.showNextScreenAfterPicking(pages: [validatedPage])
             case .failure(let error):
                 var errorMessage = String(describing: error)

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Networking/DocumentService.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Networking/DocumentService.swift
@@ -34,7 +34,7 @@ public final class DocumentService: DocumentServiceProtocol {
     }
     
     public func upload(document: GiniCaptureDocument,
-                completion: UploadDocumentCompletion?) {
+                       completion: UploadDocumentCompletion?) {
         self.partialDocuments[document.id] =
             PartialDocument(info: (PartialDocumentInfo(document: nil, rotationDelta: 0)),
                             document: nil,

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Networking/DocumentService.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Networking/DocumentService.swift
@@ -57,8 +57,8 @@ public final class DocumentService: DocumentServiceProtocol {
 
     private func updatePartialDocuments(for document: GiniCaptureDocument, with createdDocument: Document) {
         // Scanning a QR code takes priority, even if the user has already taken some pictures.
-        // we should discard all the pages that have already been scanned and keep the document generated after scanning the QR code
-        // composite document should be created just with he document generated after scanning the QR cod
+        // All the pages that have already been scanned should be discarded and keep the document generated after scanning the QR code.
+        // The composite document should be created just with the document generated after scanning the QR cod
         if document.type == .qrcode && partialDocuments.isNotEmpty {
             partialDocuments.removeAll()
         }


### PR DESCRIPTION
- The QR code has priority even if the user already took some pictures and we should proceed with the QR code flow and no alert view should appear with the error message about types of files.
- Remove all the pages that have already been captured and keep the document generated after scanning the QR code