### PR TITLE
Pm 81 fix for custom api domain

### DIFF
--- a/BankAPILibrary/GiniBankAPILibrary/Sources/GiniBankAPILibrary/Documents/Payments/PaymentService.swift
+++ b/BankAPILibrary/GiniBankAPILibrary/Sources/GiniBankAPILibrary/Documents/Payments/PaymentService.swift
@@ -140,7 +140,7 @@ extension PaymentService {
 
     func paymentRequest(id: String, resourceHandler: ResourceDataHandler<APIResource<PaymentRequest>>,
                         completion: @escaping CompletionResult<PaymentRequest>) {
-        let resource = APIResource<PaymentRequest>(method: .paymentRequest(id: id), apiDomain: .default, httpMethod: .get)
+        let resource = APIResource<PaymentRequest>(method: .paymentRequest(id: id), apiDomain: apiDomain, httpMethod: .get)
 
         resourceHandler(resource, { result in
             switch result {
@@ -155,7 +155,7 @@ extension PaymentService {
     func paymentRequests(limit: Int?,
                          offset: Int?, resourceHandler: ResourceDataHandler<APIResource<PaymentRequests>>,
                          completion: @escaping CompletionResult<PaymentRequests>) {
-        let resource = APIResource<PaymentRequests>(method: .paymentRequests(limit: limit, offset: offset), apiDomain: .default, httpMethod: .get)
+        let resource = APIResource<PaymentRequests>(method: .paymentRequests(limit: limit, offset: offset), apiDomain: apiDomain, httpMethod: .get)
 
         resourceHandler(resource, { result in
             switch result {
@@ -175,7 +175,7 @@ extension PaymentService {
             assertionFailure("The ResolvingPaymentRequestBody cannot be encoded")
             return
         }
-        let resource = APIResource<ResolvedPaymentRequest>(method: .resolvePaymentRequest(id: id), apiDomain: .default, httpMethod: .post, body: json)
+        let resource = APIResource<ResolvedPaymentRequest>(method: .resolvePaymentRequest(id: id), apiDomain: apiDomain, httpMethod: .post, body: json)
 
         resourceHandler(resource, { result in
             switch result {
@@ -190,7 +190,7 @@ extension PaymentService {
     func payment(id: String,
                  resourceHandler: ResourceDataHandler<APIResource<Payment>>,
                  completion: @escaping CompletionResult<Payment>) {
-        let resource = APIResource<Payment>(method: .payment(id: id), apiDomain: .default, httpMethod: .get)
+        let resource = APIResource<Payment>(method: .payment(id: id), apiDomain: apiDomain, httpMethod: .get)
 
         resourceHandler(resource, { result in
             switch result {

--- a/HealthAPILibrary/GiniHealthAPILibrary/Sources/GiniHealthAPILibrary/Documents/DocumentService.swift
+++ b/HealthAPILibrary/GiniHealthAPILibrary/Sources/GiniHealthAPILibrary/Documents/DocumentService.swift
@@ -319,7 +319,7 @@ extension DocumentService {
     func file(urlString: String,
                           resourceHandler: ResourceDataHandler<APIResource<Data>>,
                           completion: @escaping CompletionResult<Data>) {
-        var resource = APIResource<Data>(method: .file(urlString: urlString), apiDomain: .default, httpMethod: .get)
+        var resource = APIResource<Data>(method: .file(urlString: urlString), apiDomain: apiDomain, httpMethod: .get)
         resource.fullUrlString = urlString
         resourceHandler(resource) { result in
             switch result {

--- a/HealthAPILibrary/GiniHealthAPILibrary/Sources/GiniHealthAPILibrary/Documents/Payments/PaymentService.swift
+++ b/HealthAPILibrary/GiniHealthAPILibrary/Sources/GiniHealthAPILibrary/Documents/Payments/PaymentService.swift
@@ -169,7 +169,7 @@ extension PaymentService {
     
     func paymentProviders(resourceHandler: ResourceDataHandler<APIResource<[PaymentProviderResponse]>>,
                           completion: @escaping CompletionResult<PaymentProviders>) {
-        let resource = APIResource<[PaymentProviderResponse]>(method: .paymentProviders, apiDomain: .default, httpMethod: .get)
+        let resource = APIResource<[PaymentProviderResponse]>(method: .paymentProviders, apiDomain: apiDomain, httpMethod: .get)
         var providers = [PaymentProvider]()
         resourceHandler(resource, { result in
             switch result {
@@ -202,7 +202,7 @@ extension PaymentService {
 
     func paymentProvider(id: String, resourceHandler: ResourceDataHandler<APIResource<PaymentProviderResponse>>,
                          completion: @escaping CompletionResult<PaymentProvider>) {
-        let resource = APIResource<PaymentProviderResponse>(method: .paymentProvider(id: id), apiDomain: .default, httpMethod: .get)
+        let resource = APIResource<PaymentProviderResponse>(method: .paymentProvider(id: id), apiDomain: apiDomain, httpMethod: .get)
 
         resourceHandler(resource, { result in
             switch result {
@@ -251,7 +251,7 @@ extension PaymentService {
 
     func paymentRequest(id: String, resourceHandler: ResourceDataHandler<APIResource<PaymentRequest>>,
                         completion: @escaping CompletionResult<PaymentRequest>) {
-        let resource = APIResource<PaymentRequest>(method: .paymentRequest(id: id), apiDomain: .default, httpMethod: .get)
+        let resource = APIResource<PaymentRequest>(method: .paymentRequest(id: id), apiDomain: apiDomain, httpMethod: .get)
 
         resourceHandler(resource, { result in
             switch result {
@@ -266,7 +266,7 @@ extension PaymentService {
     func paymentRequests(limit: Int?,
                          offset: Int?, resourceHandler: ResourceDataHandler<APIResource<PaymentRequests>>,
                          completion: @escaping CompletionResult<PaymentRequests>) {
-        let resource = APIResource<PaymentRequests>(method: .paymentRequests(limit: limit, offset: offset), apiDomain: .default, httpMethod: .get)
+        let resource = APIResource<PaymentRequests>(method: .paymentRequests(limit: limit, offset: offset), apiDomain: apiDomain, httpMethod: .get)
 
         resourceHandler(resource, { result in
             switch result {
@@ -281,7 +281,7 @@ extension PaymentService {
     private func file(urlString: String,
                  resourceHandler: ResourceDataHandler<APIResource<Data>>,
                  completion: @escaping CompletionResult<Data>) {
-        var resource = APIResource<Data>(method: .file(urlString: urlString), apiDomain: .default, httpMethod: .get)
+        var resource = APIResource<Data>(method: .file(urlString: urlString), apiDomain: apiDomain, httpMethod: .get)
         resource.fullUrlString = urlString
         resourceHandler(resource) { result in
             switch result {


### PR DESCRIPTION
While testing the Health API on stage I discovered that some requests were always using the default api domain instead of the custom one and so I had to apply these small fixes to be able to test on stage.