### PR TITLE
Pp 387 add onboarding screen events

### DIFF
--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Help/ViewControllers/HelpMenuViewController.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Help/ViewControllers/HelpMenuViewController.swift
@@ -68,7 +68,7 @@ final class HelpMenuViewController: UIViewController, HelpBottomBarEnabledViewCo
                                                  value: giniConfiguration.customMenuItems.isNotEmpty)]
 
         eventProperties.append(AnalyticsProperty(key: .helpItems,
-                                                     value: dataSource.helpItemsAnalyticsValues))
+                                                 value: dataSource.helpItemsAnalyticsValues))
         AnalyticsManager.trackScreenShown(screenName: .help,
                                           properties: eventProperties)
     }

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Onboarding/OnboardingDataSource.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Onboarding/OnboardingDataSource.swift
@@ -124,6 +124,9 @@ class OnboardingDataSource: NSObject, BaseCollectionViewDataSource {
         if pageModel.isCustom {
             eventProperties.append(.init(key: .customOnboardingTitle, value: pageModel.page.title))
         }
+        let hasCustomItems = giniConfiguration.customOnboardingPages?.isNotEmpty ?? false
+        eventProperties.append(AnalyticsProperty(key: .hasCustomItems,
+                                                 value: hasCustomItems))
         AnalyticsManager.trackScreenShown(screenNameString: pageModel.analyticsScreen,
                                           properties: eventProperties)
         pagesTracker.markPageAsSeen(pageModel)


### PR DESCRIPTION
Add missing property `has_custom_items ` to `screen_shown` event for all onboarding screens and fix the indentation.