### PR TITLE
Pp 387 add onboarding screen events

### DIFF
--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Onboarding/OnboardingViewController.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Onboarding/OnboardingViewController.swift
@@ -133,8 +133,9 @@ class OnboardingViewController: UIViewController {
     @objc private func skipTapped() {
         // Handle the skip button tap if there are more onboarding pages.
         // The skip button is not present on the last onboarding page.
-        guard dataSource.currentPageIndex < dataSource.pageModels.count - 1 else { return }
-        track(event: .skipTapped, for: dataSource.currentPageIndex)
+        let currentPageIndex = dataSource.currentPageIndex
+        guard currentPageIndex < dataSource.pageModels.count - 1 else { return }
+        track(event: .skipTapped, for: currentPageIndex)
         close()
     }
 
@@ -148,11 +149,11 @@ class OnboardingViewController: UIViewController {
     }
 
     @objc private func nextPage() {
-
-        if dataSource.currentPageIndex < dataSource.pageModels.count - 1 {
+        let currentPageIndex = dataSource.currentPageIndex
+        if currentPageIndex < dataSource.pageModels.count - 1 {
             // Next button tapped
-            track(event: .nextStepTapped, for: dataSource.currentPageIndex)
-            let index = IndexPath(item: dataSource.currentPageIndex + 1, section: 0)
+            track(event: .nextStepTapped, for: currentPageIndex)
+            let index = IndexPath(item: currentPageIndex + 1, section: 0)
             pagesCollection.scrollToItem(at: index, at: .centeredHorizontally, animated: true)
             dataSource.isProgrammaticScroll = true
         } else {

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Onboarding/OnboardingViewController.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Onboarding/OnboardingViewController.swift
@@ -157,7 +157,7 @@ class OnboardingViewController: UIViewController {
             pagesCollection.scrollToItem(at: index, at: .centeredHorizontally, animated: true)
             dataSource.isProgrammaticScroll = true
         } else {
-           getStartedButtonAction()
+            getStartedButtonAction()
         }
     }
 

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Onboarding/OnboardingViewController.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Onboarding/OnboardingViewController.swift
@@ -106,7 +106,7 @@ class OnboardingViewController: UIViewController {
             self?.nextPage()
         }
         navigationBarBottomAdapter?.setSkipButtonClickedActionCallback { [weak self] in
-            self?.close()
+            self?.skipTapped()
         }
         navigationBarBottomAdapter?.setGetStartedButtonClickedActionCallback { [weak self] in
             self?.getStartedButtonAction()

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Onboarding/OnboardingViewController.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Onboarding/OnboardingViewController.swift
@@ -109,7 +109,7 @@ class OnboardingViewController: UIViewController {
             self?.close()
         }
         navigationBarBottomAdapter?.setGetStartedButtonClickedActionCallback { [weak self] in
-            self?.close()
+            self?.getStartedButtonAction()
         }
         if let navigationBar = navigationBarBottomAdapter?.injectedView() {
             bottomNavigationBar = navigationBar
@@ -149,19 +149,24 @@ class OnboardingViewController: UIViewController {
     }
 
     @objc private func nextPage() {
-        let currentPageScreenName = dataSource.pageModels[dataSource.currentPageIndex].analyticsScreen
 
         if dataSource.currentPageIndex < dataSource.pageModels.count - 1 {
             // Next button tapped
+            let currentPageScreenName = dataSource.pageModels[dataSource.currentPageIndex].analyticsScreen
             AnalyticsManager.track(event: .nextStepTapped, screenNameString: currentPageScreenName)
             let index = IndexPath(item: dataSource.currentPageIndex + 1, section: 0)
             pagesCollection.scrollToItem(at: index, at: .centeredHorizontally, animated: true)
             dataSource.isProgrammaticScroll = true
         } else {
-            // Get started button tapped
-            AnalyticsManager.track(event: .getStartedTapped, screenNameString: currentPageScreenName)
-            close()
+           getStartedButtonAction()
         }
+    }
+
+    private func getStartedButtonAction() {
+        let currentPageScreenName = dataSource.pageModels[dataSource.currentPageIndex].analyticsScreen
+        // Get started button tapped
+        AnalyticsManager.track(event: .getStartedTapped, screenNameString: currentPageScreenName)
+        close()
     }
 
     override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Onboarding/OnboardingViewController.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Onboarding/OnboardingViewController.swift
@@ -165,6 +165,7 @@ class OnboardingViewController: UIViewController {
         track(event: .getStartedTapped, for: dataSource.currentPageIndex)
         close()
     }
+
     private func track(event: AnalyticsEvent, for pageIndex: Int) {
         let pageModel = dataSource.pageModels[pageIndex]
         let currentPageScreenName = pageModel.analyticsScreen


### PR DESCRIPTION
Add missing `get_started_tapped ` and `skip_tapped` events from the bottom navigation bar.
Add missing `custom_onboarding_title ` property in all events for custom onboarding screens.