### PR TITLE
fix(GiniBankSDKExample): Fix value type for the key `NSExtensionActivationSupportsImageWithMaxCount` in your Info.plist file

### DIFF
--- a/BankSDK/GiniBankSDKExample/GiniBankSDKShareExtension/Info.plist
+++ b/BankSDK/GiniBankSDKExample/GiniBankSDKShareExtension/Info.plist
@@ -9,7 +9,7 @@
 			<key>NSExtensionActivationRule</key>
 			<dict>
 				<key>NSExtensionActivationSupportsImageWithMaxCount</key>
-				<string>1</string>
+				<integer>1</integer>
 			</dict>
 		</dict>
 		<key>NSExtensionMainStoryboard</key>


### PR DESCRIPTION
- there was an error when trying to distribute via appstoreconnect due to an incorrect value type for the key `NSExtensionActivationSupportsImageWithMaxCount` in your Info.plist file This key expects a positive integer value, but currently, it has a string value.