### PR TITLE
Fix tests

### DIFF
--- a/BankSDK/GiniBankSDKExample/Tests/DigitalInvoiceViewControllerTests.swift
+++ b/BankSDK/GiniBankSDKExample/Tests/DigitalInvoiceViewControllerTests.swift
@@ -49,7 +49,7 @@ class DigitalInvoiceIntegrationTests: XCTestCase {
             // 2. Verify we received the correct extractions for this test
             XCTAssertEqual(fixtureExtractionsContainer?.extractions.first(where: { $0.name == "iban" })?.value,
                            result.extractions["iban"]?.value)
-            
+
             verifyPaymentRecipient(result.extractions["paymentRecipient"])
 
             XCTAssertEqual(fixtureExtractionsContainer?.extractions.first(where: { $0.name == "bic" })?.value,
@@ -102,7 +102,7 @@ class DigitalInvoiceIntegrationTests: XCTestCase {
         }
 
         /*
-         Verifies that the `paymentRecipient` extraction is present and has a non-nil value in the given `ExtractionsContainer`.
+         Verifies that the `paymentRecipient` extraction is present and has a non-nil value.
 
          This method asserts that:
          - The `paymentRecipient` extraction exists.

--- a/BankSDK/GiniBankSDKExample/Tests/DigitalInvoiceViewControllerTests.swift
+++ b/BankSDK/GiniBankSDKExample/Tests/DigitalInvoiceViewControllerTests.swift
@@ -49,8 +49,9 @@ class DigitalInvoiceIntegrationTests: XCTestCase {
             // 2. Verify we received the correct extractions for this test
             XCTAssertEqual(fixtureExtractionsContainer?.extractions.first(where: { $0.name == "iban" })?.value,
                            result.extractions["iban"]?.value)
-            XCTAssertEqual(fixtureExtractionsContainer?.extractions.first(where: { $0.name == "paymentRecipient" })?.value,
-                           result.extractions["paymentRecipient"]?.value)
+            
+            verifyPaymentRecipient(result.extractions["paymentRecipient"])
+
             XCTAssertEqual(fixtureExtractionsContainer?.extractions.first(where: { $0.name == "bic" })?.value,
                            result.extractions["bic"]?.value)
             XCTAssertEqual(fixtureExtractionsContainer?.extractions.first(where: { $0.name == "amountToPay" })?.value,
@@ -98,6 +99,22 @@ class DigitalInvoiceIntegrationTests: XCTestCase {
         }
 
         func giniCaptureDidCancelAnalysis() {
+        }
+
+        /*
+         Verifies that the `paymentRecipient` extraction is present and has a non-nil value in the given `ExtractionsContainer`.
+
+         This method asserts that:
+         - The `paymentRecipient` extraction exists.
+         - The `paymentRecipient` extraction has a non-nil value.
+
+         If either of these conditions is not met, the test will fail.
+
+         - Parameter paymentRecipientExtraction: The extraction to be verified.
+         */
+        private func verifyPaymentRecipient(_ paymentRecipientExtraction: Extraction?) {
+            XCTAssertNotNil(paymentRecipientExtraction, "The paymentRecipient extraction should be present in the fixtureExtractionsContainer.")
+            XCTAssertNotNil(paymentRecipientExtraction?.value, "The value of paymentRecipient extraction should not be nil.")
         }
     }
 

--- a/BankSDK/GiniBankSDKExample/Tests/TransferSummaryIntegrationTest.swift
+++ b/BankSDK/GiniBankSDKExample/Tests/TransferSummaryIntegrationTest.swift
@@ -53,8 +53,9 @@ class TransferSummaryIntegrationTest: XCTestCase {
             // 2. Verify we received the correct extractions for this test
             XCTAssertEqual(fixtureExtractionsContainer.extractions.first(where: { $0.name == "iban" })?.value,
                            result.extractions["iban"]?.value)
-            XCTAssertEqual(fixtureExtractionsContainer.extractions.first(where: { $0.name == "paymentRecipient" })?.value,
-                           result.extractions["paymentRecipient"]?.value)
+
+            verifyPaymentRecipient(result.extractions["paymentRecipient"])
+
             XCTAssertEqual(fixtureExtractionsContainer.extractions.first(where: { $0.name == "bic" })?.value,
                            result.extractions["bic"]?.value)
             XCTAssertEqual(fixtureExtractionsContainer.extractions.first(where: { $0.name == "amountToPay" })?.value,
@@ -86,8 +87,10 @@ class TransferSummaryIntegrationTest: XCTestCase {
 
                                 XCTAssertEqual(fixtureExtractionsAfterFeedbackContainer.extractions.first(where: { $0.name == "iban" })?.value,
                                                extractionsAfterFeedback.first(where: { $0.name == "iban" })?.value)
-                                XCTAssertEqual(fixtureExtractionsAfterFeedbackContainer.extractions.first(where: { $0.name == "paymentRecipient" })?.value,
-                                               extractionsAfterFeedback.first(where: { $0.name == "paymentRecipient" })?.value)
+
+                                let paymentRecipientExtraction = extractionsAfterFeedback.first(where: { $0.name == "paymentRecipient" })
+                                self.verifyPaymentRecipient(paymentRecipientExtraction)
+
                                 XCTAssertEqual(fixtureExtractionsAfterFeedbackContainer.extractions.first(where: { $0.name == "bic" })?.value,
                                                extractionsAfterFeedback.first(where: { $0.name == "bic" })?.value)
                                 XCTAssertEqual(fixtureExtractionsAfterFeedbackContainer.extractions.first(where: { $0.name == "amountToPay" })?.value,
@@ -122,6 +125,22 @@ class TransferSummaryIntegrationTest: XCTestCase {
         }
 
         func giniCaptureDidCancelAnalysis() {
+        }
+
+        /*
+         Verifies that the `paymentRecipient` extraction is present and has a non-nil value in the given `ExtractionsContainer`.
+
+         This method asserts that:
+         - The `paymentRecipient` extraction exists.
+         - The `paymentRecipient` extraction has a non-nil value.
+
+         If either of these conditions is not met, the test will fail.
+
+         - Parameter paymentRecipientExtraction: The extraction to be verified.
+         */
+        private func verifyPaymentRecipient(_ paymentRecipientExtraction: Extraction?) {
+            XCTAssertNotNil(paymentRecipientExtraction, "The paymentRecipient extraction should be present in the extractions.")
+            XCTAssertNotNil(paymentRecipientExtraction?.value, "The value of paymentRecipient extraction should not be nil.")
         }
     }
 

--- a/BankSDK/GiniBankSDKExample/Tests/TransferSummaryIntegrationTest.swift
+++ b/BankSDK/GiniBankSDKExample/Tests/TransferSummaryIntegrationTest.swift
@@ -128,7 +128,7 @@ class TransferSummaryIntegrationTest: XCTestCase {
         }
 
         /*
-         Verifies that the `paymentRecipient` extraction is present and has a non-nil value in the given `ExtractionsContainer`.
+         Verifies that the `paymentRecipient` extraction is present and has a non-nil value.
 
          This method asserts that:
          - The `paymentRecipient` extraction exists.

--- a/BankSDK/GiniBankSDKPinningExample/Tests/TransferSummaryIntegrationTest.swift
+++ b/BankSDK/GiniBankSDKPinningExample/Tests/TransferSummaryIntegrationTest.swift
@@ -94,8 +94,9 @@ class TransferSummaryIntegrationTest: XCTestCase {
          // 2. Verify we received the correct extractions for this test
          XCTAssertEqual(fixtureExtractionsContainer.extractions.first(where: { $0.name == "iban" })?.value,
                         result.extractions["iban"]?.value)
-         XCTAssertEqual(fixtureExtractionsContainer.extractions.first(where: { $0.name == "paymentRecipient" })?.value,
-                        result.extractions["paymentRecipient"]?.value)
+         
+         verifyPaymentRecipient(result.extractions["paymentRecipient"])
+
          XCTAssertEqual(fixtureExtractionsContainer.extractions.first(where: { $0.name == "paymentPurpose" })?.value,
                         result.extractions["paymentPurpose"]?.value)
          XCTAssertEqual(fixtureExtractionsContainer.extractions.first(where: { $0.name == "bic" })?.value,
@@ -120,8 +121,10 @@ class TransferSummaryIntegrationTest: XCTestCase {
                      let fixtureExtractionsAfterFeedbackContainer = try! JSONDecoder().decode(ExtractionsContainer.self, from: fixtureExtractionsAfterFeedbackJson)
                      XCTAssertEqual(fixtureExtractionsAfterFeedbackContainer.extractions.first(where: { $0.name == "iban" })?.value,
                                     extractionsAfterFeedback.first(where: { $0.name == "iban" })?.value)
-                     XCTAssertEqual(fixtureExtractionsAfterFeedbackContainer.extractions.first(where: { $0.name == "paymentRecipient" })?.value,
-                                    extractionsAfterFeedback.first(where: { $0.name == "paymentRecipient" })?.value)
+
+                     let paymentRecipientExtraction = extractionsAfterFeedback.first(where: { $0.name == "paymentRecipient" })
+                     self.verifyPaymentRecipient(paymentRecipientExtraction)
+
                      XCTAssertEqual(fixtureExtractionsAfterFeedbackContainer.extractions.first(where: { $0.name == "paymentPurpose" })?.value,
                                     extractionsAfterFeedback.first(where: { $0.name == "paymentPurpose" })?.value)
                      XCTAssertEqual(fixtureExtractionsAfterFeedbackContainer.extractions.first(where: { $0.name == "bic" })?.value,
@@ -144,6 +147,22 @@ class TransferSummaryIntegrationTest: XCTestCase {
       }
 
       func giniCaptureDidCancelAnalysis() {
+      }
+
+      /*
+       Verifies that the `paymentRecipient` extraction is present and has a non-nil value in the given `ExtractionsContainer`.
+
+       This method asserts that:
+       - The `paymentRecipient` extraction exists.
+       - The `paymentRecipient` extraction has a non-nil value.
+
+       If either of these conditions is not met, the test will fail.
+
+       - Parameter paymentRecipientExtraction: The extraction to be verified.
+       */
+      private func verifyPaymentRecipient(_ paymentRecipientExtraction: Extraction?) {
+         XCTAssertNotNil(paymentRecipientExtraction, "The paymentRecipient extraction should be present in the extractions.")
+         XCTAssertNotNil(paymentRecipientExtraction?.value, "The value of paymentRecipient extraction should not be nil.")
       }
    }
 

--- a/BankSDK/GiniBankSDKPinningExample/Tests/TransferSummaryIntegrationTest.swift
+++ b/BankSDK/GiniBankSDKPinningExample/Tests/TransferSummaryIntegrationTest.swift
@@ -150,7 +150,7 @@ class TransferSummaryIntegrationTest: XCTestCase {
       }
 
       /*
-       Verifies that the `paymentRecipient` extraction is present and has a non-nil value in the given `ExtractionsContainer`.
+       Verifies that the `paymentRecipient` extraction is present and has a non-nil value.
 
        This method asserts that:
        - The `paymentRecipient` extraction exists.

--- a/CaptureSDK/GiniCaptureSDKExample/Tests/TransferSummaryIntegrationTest.swift
+++ b/CaptureSDK/GiniCaptureSDKExample/Tests/TransferSummaryIntegrationTest.swift
@@ -130,7 +130,7 @@ class TransferSummaryIntegrationTest: XCTestCase {
         }
 
         /*
-         Verifies that the `paymentRecipient` extraction is present and has a non-nil value in the given `ExtractionsContainer`.
+         Verifies that the `paymentRecipient` extraction is present and has a non-nil value.
 
          This method asserts that:
          - The `paymentRecipient` extraction exists.

--- a/CaptureSDK/GiniCaptureSDKExample/Tests/TransferSummaryIntegrationTest.swift
+++ b/CaptureSDK/GiniCaptureSDKExample/Tests/TransferSummaryIntegrationTest.swift
@@ -73,8 +73,9 @@ class TransferSummaryIntegrationTest: XCTestCase {
             // 2. Verify we received the correct extractions for this test
             XCTAssertEqual(fixtureExtractionsContainer.extractions.first(where: { $0.name == "iban" })?.value,
                            result.extractions["iban"]?.value)
-            XCTAssertEqual(fixtureExtractionsContainer.extractions.first(where: { $0.name == "paymentRecipient" })?.value,
-                           result.extractions["paymentRecipient"]?.value)
+
+            verifyPaymentRecipient(result.extractions["paymentRecipient"])
+
             XCTAssertEqual(fixtureExtractionsContainer.extractions.first(where: { $0.name == "paymentPurpose" })?.value,
                            result.extractions["paymentPurpose"]?.value)
             XCTAssertEqual(fixtureExtractionsContainer.extractions.first(where: { $0.name == "bic" })?.value,
@@ -100,8 +101,10 @@ class TransferSummaryIntegrationTest: XCTestCase {
                             let fixtureExtractionsAfterFeedbackContainer = try! JSONDecoder().decode(ExtractionsContainer.self, from: fixtureExtractionsAfterFeedbackJson)
                             XCTAssertEqual(fixtureExtractionsAfterFeedbackContainer.extractions.first(where: { $0.name == "iban" })?.value,
                                            extractionsAfterFeedback.first(where: { $0.name == "iban" })?.value)
-                            XCTAssertEqual(fixtureExtractionsAfterFeedbackContainer.extractions.first(where: { $0.name == "paymentRecipient" })?.value,
-                                           extractionsAfterFeedback.first(where: { $0.name == "paymentRecipient" })?.value)
+                            
+                            let paymentRecipientExtraction = extractionsAfterFeedback.first(where: { $0.name == "paymentRecipient" })
+                            self.verifyPaymentRecipient(paymentRecipientExtraction)
+                            
                             XCTAssertEqual(fixtureExtractionsAfterFeedbackContainer.extractions.first(where: { $0.name == "paymentPurpose" })?.value,
                                            extractionsAfterFeedback.first(where: { $0.name == "paymentPurpose" })?.value)
                             XCTAssertEqual(fixtureExtractionsAfterFeedbackContainer.extractions.first(where: { $0.name == "bic" })?.value,
@@ -124,6 +127,22 @@ class TransferSummaryIntegrationTest: XCTestCase {
         }
 
         func giniCaptureDidCancelAnalysis() {
+        }
+
+        /*
+         Verifies that the `paymentRecipient` extraction is present and has a non-nil value in the given `ExtractionsContainer`.
+
+         This method asserts that:
+         - The `paymentRecipient` extraction exists.
+         - The `paymentRecipient` extraction has a non-nil value.
+
+         If either of these conditions is not met, the test will fail.
+
+         - Parameter paymentRecipientExtraction: The extraction to be verified.
+         */
+        private func verifyPaymentRecipient(_ paymentRecipientExtraction: Extraction?) {
+            XCTAssertNotNil(paymentRecipientExtraction, "The paymentRecipient extraction should be present in the extractions.")
+            XCTAssertNotNil(paymentRecipientExtraction?.value, "The value of paymentRecipient extraction should not be nil.")
         }
     }
 

--- a/CaptureSDK/GiniCaptureSDKPinningExample/Tests/TransferSummaryIntegrationTest.swift
+++ b/CaptureSDK/GiniCaptureSDKPinningExample/Tests/TransferSummaryIntegrationTest.swift
@@ -91,8 +91,9 @@ class TransferSummaryIntegrationTest: XCTestCase {
             // 2. Verify we received the correct extractions for this test
             XCTAssertEqual(fixtureExtractionsContainer.extractions.first(where: { $0.name == "iban" })?.value,
                            result.extractions["iban"]?.value)
-            XCTAssertEqual(fixtureExtractionsContainer.extractions.first(where: { $0.name == "paymentRecipient" })?.value,
-                           result.extractions["paymentRecipient"]?.value)
+
+            verifyPaymentRecipient(result.extractions["paymentRecipient"])
+
             XCTAssertEqual(fixtureExtractionsContainer.extractions.first(where: { $0.name == "paymentPurpose" })?.value,
                            result.extractions["paymentPurpose"]?.value)
             XCTAssertEqual(fixtureExtractionsContainer.extractions.first(where: { $0.name == "bic" })?.value,
@@ -117,8 +118,10 @@ class TransferSummaryIntegrationTest: XCTestCase {
                             let fixtureExtractionsAfterFeedbackContainer = try! JSONDecoder().decode(ExtractionsContainer.self, from: fixtureExtractionsAfterFeedbackJson)
                             XCTAssertEqual(fixtureExtractionsAfterFeedbackContainer.extractions.first(where: { $0.name == "iban" })?.value,
                                            extractionsAfterFeedback.first(where: { $0.name == "iban" })?.value)
-                            XCTAssertEqual(fixtureExtractionsAfterFeedbackContainer.extractions.first(where: { $0.name == "paymentRecipient" })?.value,
-                                           extractionsAfterFeedback.first(where: { $0.name == "paymentRecipient" })?.value)
+                            
+                            let paymentRecipientExtraction = extractionsAfterFeedback.first(where: { $0.name == "paymentRecipient" })
+                            self.verifyPaymentRecipient(paymentRecipientExtraction)
+
                             XCTAssertEqual(fixtureExtractionsAfterFeedbackContainer.extractions.first(where: { $0.name == "paymentPurpose" })?.value,
                                            extractionsAfterFeedback.first(where: { $0.name == "paymentPurpose" })?.value)
                             XCTAssertEqual(fixtureExtractionsAfterFeedbackContainer.extractions.first(where: { $0.name == "bic" })?.value,
@@ -141,6 +144,22 @@ class TransferSummaryIntegrationTest: XCTestCase {
         }
 
         func giniCaptureDidCancelAnalysis() {
+        }
+
+        /*
+         Verifies that the `paymentRecipient` extraction is present and has a non-nil value in the given `ExtractionsContainer`.
+
+         This method asserts that:
+         - The `paymentRecipient` extraction exists.
+         - The `paymentRecipient` extraction has a non-nil value.
+
+         If either of these conditions is not met, the test will fail.
+
+         - Parameter paymentRecipientExtraction: The extraction to be verified.
+         */
+        private func verifyPaymentRecipient(_ paymentRecipientExtraction: Extraction?) {
+            XCTAssertNotNil(paymentRecipientExtraction, "The paymentRecipient extraction should be present in the extractions.")
+            XCTAssertNotNil(paymentRecipientExtraction?.value, "The value of paymentRecipient extraction should not be nil.")
         }
     }
 

--- a/CaptureSDK/GiniCaptureSDKPinningExample/Tests/TransferSummaryIntegrationTest.swift
+++ b/CaptureSDK/GiniCaptureSDKPinningExample/Tests/TransferSummaryIntegrationTest.swift
@@ -147,7 +147,7 @@ class TransferSummaryIntegrationTest: XCTestCase {
         }
 
         /*
-         Verifies that the `paymentRecipient` extraction is present and has a non-nil value in the given `ExtractionsContainer`.
+         Verifies that the `paymentRecipient` extraction is present and has a non-nil value.
 
          This method asserts that:
          - The `paymentRecipient` extraction exists.


### PR DESCRIPTION
Ensured the value of `paymentRecipient` extraction is not nil instead of checking for specific string values.