### PR TITLE
PP 504 check if the privacy manifests needs to be updated

### DIFF
--- a/BankSDK/GiniBankSDK/Sources/GiniBankSDK/PrivacyInfo.xcprivacy
+++ b/BankSDK/GiniBankSDK/Sources/GiniBankSDK/PrivacyInfo.xcprivacy
@@ -2,13 +2,13 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-    <key>NSPrivacyTracking</key>
-    <true/>
-    <key>NSPrivacyTrackingDomains</key>
-    <array>
-        <string>https://api-eu.mixpanel.com</string>
-        <string>https://api2.amplitude.com/</string>
-    </array>
+	<key>NSPrivacyTracking</key>
+	<true/>
+	<key>NSPrivacyTrackingDomains</key>
+	<array>
+		<string>https://api-eu.mixpanel.com</string>
+		<string>https://api.eu.amplitude.com/</string>
+	</array>
 	<key>NSPrivacyAccessedAPITypes</key>
 	<array>
 		<dict>

--- a/BankSDK/GiniBankSDK/Sources/GiniBankSDK/PrivacyInfo.xcprivacy
+++ b/BankSDK/GiniBankSDK/Sources/GiniBankSDK/PrivacyInfo.xcprivacy
@@ -6,7 +6,6 @@
 	<true/>
 	<key>NSPrivacyTrackingDomains</key>
 	<array>
-		<string>https://api-eu.mixpanel.com</string>
 		<string>https://api.eu.amplitude.com/</string>
 	</array>
 	<key>NSPrivacyAccessedAPITypes</key>

--- a/BankSDK/GiniBankSDK/Sources/GiniBankSDK/PrivacyInfo.xcprivacy
+++ b/BankSDK/GiniBankSDK/Sources/GiniBankSDK/PrivacyInfo.xcprivacy
@@ -2,6 +2,13 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+    <key>NSPrivacyTracking</key>
+    <true/>
+    <key>NSPrivacyTrackingDomains</key>
+    <array>
+        <string>https://api-eu.mixpanel.com</string>
+        <string>https://api2.amplitude.com/</string>
+    </array>
 	<key>NSPrivacyAccessedAPITypes</key>
 	<array>
 		<dict>

--- a/BankSDK/GiniBankSDKPinning/Sources/GiniBankSDKPinning/PrivacyInfo.xcprivacy
+++ b/BankSDK/GiniBankSDKPinning/Sources/GiniBankSDKPinning/PrivacyInfo.xcprivacy
@@ -2,13 +2,13 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-    <key>NSPrivacyTracking</key>
-    <true/>
-    <key>NSPrivacyTrackingDomains</key>
-    <array>
-        <string>https://api-eu.mixpanel.com</string>
-        <string>https://api2.amplitude.com/</string>
-    </array>
+	<key>NSPrivacyTracking</key>
+	<true/>
+	<key>NSPrivacyTrackingDomains</key>
+	<array>
+		<string>https://api-eu.mixpanel.com</string>
+		<string>https://api.eu.amplitude.com/</string>
+	</array>
 	<key>NSPrivacyAccessedAPITypes</key>
 	<array>
 		<dict>

--- a/BankSDK/GiniBankSDKPinning/Sources/GiniBankSDKPinning/PrivacyInfo.xcprivacy
+++ b/BankSDK/GiniBankSDKPinning/Sources/GiniBankSDKPinning/PrivacyInfo.xcprivacy
@@ -6,7 +6,6 @@
 	<true/>
 	<key>NSPrivacyTrackingDomains</key>
 	<array>
-		<string>https://api-eu.mixpanel.com</string>
 		<string>https://api.eu.amplitude.com/</string>
 	</array>
 	<key>NSPrivacyAccessedAPITypes</key>

--- a/BankSDK/GiniBankSDKPinning/Sources/GiniBankSDKPinning/PrivacyInfo.xcprivacy
+++ b/BankSDK/GiniBankSDKPinning/Sources/GiniBankSDKPinning/PrivacyInfo.xcprivacy
@@ -2,6 +2,13 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+    <key>NSPrivacyTracking</key>
+    <true/>
+    <key>NSPrivacyTrackingDomains</key>
+    <array>
+        <string>https://api-eu.mixpanel.com</string>
+        <string>https://api2.amplitude.com/</string>
+    </array>
 	<key>NSPrivacyAccessedAPITypes</key>
 	<array>
 		<dict>

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/PrivacyInfo.xcprivacy
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/PrivacyInfo.xcprivacy
@@ -2,13 +2,13 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-    <key>NSPrivacyTracking</key>
-    <true/>
-    <key>NSPrivacyTrackingDomains</key>
-    <array>
-        <string>https://api-eu.mixpanel.com</string>
-        <string>https://api2.amplitude.com/</string>
-    </array>
+	<key>NSPrivacyTracking</key>
+	<true/>
+	<key>NSPrivacyTrackingDomains</key>
+	<array>
+		<string>https://api-eu.mixpanel.com</string>
+		<string>https://api.eu.amplitude.com/</string>
+	</array>
 	<key>NSPrivacyAccessedAPITypes</key>
 	<array>
 		<dict>

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/PrivacyInfo.xcprivacy
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/PrivacyInfo.xcprivacy
@@ -6,7 +6,6 @@
 	<true/>
 	<key>NSPrivacyTrackingDomains</key>
 	<array>
-		<string>https://api-eu.mixpanel.com</string>
 		<string>https://api.eu.amplitude.com/</string>
 	</array>
 	<key>NSPrivacyAccessedAPITypes</key>

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/PrivacyInfo.xcprivacy
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/PrivacyInfo.xcprivacy
@@ -2,6 +2,13 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+    <key>NSPrivacyTracking</key>
+    <true/>
+    <key>NSPrivacyTrackingDomains</key>
+    <array>
+        <string>https://api-eu.mixpanel.com</string>
+        <string>https://api2.amplitude.com/</string>
+    </array>
 	<key>NSPrivacyAccessedAPITypes</key>
 	<array>
 		<dict>

--- a/CaptureSDK/GiniCaptureSDKPinning/Sources/GiniCaptureSDKPinning/PrivacyInfo.xcprivacy
+++ b/CaptureSDK/GiniCaptureSDKPinning/Sources/GiniCaptureSDKPinning/PrivacyInfo.xcprivacy
@@ -2,13 +2,13 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-    <key>NSPrivacyTracking</key>
-    <true/>
-    <key>NSPrivacyTrackingDomains</key>
-    <array>
-        <string>https://api-eu.mixpanel.com</string>
-        <string>https://api2.amplitude.com/</string>
-    </array>
+	<key>NSPrivacyTracking</key>
+	<true/>
+	<key>NSPrivacyTrackingDomains</key>
+	<array>
+		<string>https://api-eu.mixpanel.com</string>
+		<string>https://api.eu.amplitude.com/</string>
+	</array>
 	<key>NSPrivacyAccessedAPITypes</key>
 	<array>
 		<dict>

--- a/CaptureSDK/GiniCaptureSDKPinning/Sources/GiniCaptureSDKPinning/PrivacyInfo.xcprivacy
+++ b/CaptureSDK/GiniCaptureSDKPinning/Sources/GiniCaptureSDKPinning/PrivacyInfo.xcprivacy
@@ -6,7 +6,6 @@
 	<true/>
 	<key>NSPrivacyTrackingDomains</key>
 	<array>
-		<string>https://api-eu.mixpanel.com</string>
 		<string>https://api.eu.amplitude.com/</string>
 	</array>
 	<key>NSPrivacyAccessedAPITypes</key>

--- a/CaptureSDK/GiniCaptureSDKPinning/Sources/GiniCaptureSDKPinning/PrivacyInfo.xcprivacy
+++ b/CaptureSDK/GiniCaptureSDKPinning/Sources/GiniCaptureSDKPinning/PrivacyInfo.xcprivacy
@@ -2,6 +2,13 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+    <key>NSPrivacyTracking</key>
+    <true/>
+    <key>NSPrivacyTrackingDomains</key>
+    <array>
+        <string>https://api-eu.mixpanel.com</string>
+        <string>https://api2.amplitude.com/</string>
+    </array>
 	<key>NSPrivacyAccessedAPITypes</key>
 	<array>
 		<dict>


### PR DESCRIPTION
Update privacy manifest files with tracking information:
Apple documentation:

"At the top level of this property list file, add the following keys to the dictionary:

NSPrivacyTracking
A Boolean that indicates whether your app or third-party SDK uses data for tracking as defined under the App Tracking Transparency framework. For more information, see [User Privacy and Data Use](https://developer.apple.com/app-store/user-privacy-and-data-use/).

NSPrivacyTrackingDomains
An array of strings that lists the internet domains your app or third-party SDK connects to that engage in tracking. If the user has not granted tracking permission through the App Tracking Transparency framework, network requests to these domains fail and your app receives an error.

**To provide a list of internet domains in NSPrivacyTrackingDomains, set NSPrivacyTracking to true.** "

Check also the ticket comments https://ginis.atlassian.net/browse/PP-504  where you can find links to the Apple documentation.