### PR TITLE
Ipc 291 fix share with flow

### DIFF
--- a/HealthSDK/GiniHealthSDK/Sources/GiniHealthSDK/Core/GiniHealth.swift
+++ b/HealthSDK/GiniHealthSDK/Sources/GiniHealthSDK/Core/GiniHealth.swift
@@ -268,7 +268,6 @@ public struct DataForReview {
                 switch result {
                 case let .success(requestID):
                     completion(.success(requestID))
-                    self.delegate?.didCreatePaymentRequest(paymentRequestID: requestID)
                 case let .failure(error):
                     completion(.failure(.apiError(error)))
                 }

--- a/HealthSDK/GiniHealthSDK/Sources/GiniHealthSDK/Core/PaymentReviewModel.swift
+++ b/HealthSDK/GiniHealthSDK/Sources/GiniHealthSDK/Core/PaymentReviewModel.swift
@@ -51,7 +51,7 @@ public class PaymentReviewModel: NSObject {
     }
 
     public var documentId: String
-    private var healthSDK: GiniHealth
+    var healthSDK: GiniHealth
     private var selectedPaymentProvider: PaymentProvider?
 
     private var cellViewModels: [PageCollectionCellViewModel] = [PageCollectionCellViewModel]() {

--- a/HealthSDK/GiniHealthSDK/Sources/GiniHealthSDK/Core/PaymentReviewViewController.swift
+++ b/HealthSDK/GiniHealthSDK/Sources/GiniHealthSDK/Core/PaymentReviewViewController.swift
@@ -578,6 +578,9 @@ public final class PaymentReviewViewController: UIViewController, UIGestureRecog
         if !amountTextFieldView.textField.isReallyEmpty {
             let paymentInfo = obtainPaymentInfo()
             model?.createPaymentRequest(paymentInfo: paymentInfo, completion: { [weak self] requestId in
+                // Publish the payment request id before launching the payment provider app
+                self?.model?.healthSDK.delegate?.didCreatePaymentRequest(paymentRequestID: requestId)
+                
                 self?.model?.openPaymentProviderApp(requestId: requestId, universalLink: paymentInfo.paymentUniversalLink)
             })
             sendFeedback(paymentInfo: paymentInfo)

--- a/HealthSDK/GiniHealthSDKExample/GiniHealthSDKExample/AppCoordinator.swift
+++ b/HealthSDK/GiniHealthSDKExample/GiniHealthSDKExample/AppCoordinator.swift
@@ -330,6 +330,10 @@ extension AppCoordinator: GiniHealthDelegate {
     
     func didCreatePaymentRequest(paymentRequestID: String) {
         print("✅ Created payment request with id \(paymentRequestID)")
+        DispatchQueue.main.async {
+            (self.childCoordinators.first as! InvoicesListCoordinator).invoicesListViewController
+                .presentedViewController?.dismiss(animated: true)
+        }
     }
 }
 


### PR DESCRIPTION
Moves the publishing of the paymentRequestID in the "share with" case to when the user has tapped on an app in the native share sheet for the "share with" PDF. This way when clients can dismiss the Payment Review Screen on receiving the paymentRequestID safely also for the "share with" case.

The [bug ticket](https://ginis.atlassian.net/browse/IPC-289) contains more details.