### PR TITLE
fix(GiniCaptureSDK, GiniBankSDK): Use subheadline style for the description labels on the onboarding screens

### DIFF
--- a/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/ReturnAssistant/Onboarding/DigitalInvoiceOnboardingViewController.swift
+++ b/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/ReturnAssistant/Onboarding/DigitalInvoiceOnboardingViewController.swift
@@ -93,7 +93,7 @@ final class DigitalInvoiceOnboardingViewController: UIViewController {
         firstLabel.adjustsFontForContentSizeCategory = true
 
         secondLabel.text = secondLabelText
-        secondLabel.font = configuration.textStyleFonts[.headline]
+        secondLabel.font = configuration.textStyleFonts[.subheadline]
         secondLabel.textColor = GiniColor(light: .GiniBank.dark6, dark: .GiniBank.dark7).uiColor()
         secondLabel.adjustsFontForContentSizeCategory = true
 

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Onboarding/Views/OnboardingPageCell.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Onboarding/Views/OnboardingPageCell.swift
@@ -29,7 +29,7 @@ class OnboardingPageCell: UICollectionViewCell {
 
         descriptionLabel.textColor = GiniColor(light: UIColor.GiniCapture.dark6,
                                                dark: UIColor.GiniCapture.dark7).uiColor()
-        descriptionLabel.font = GiniConfiguration.shared.textStyleFonts[.title2Bold]
+        descriptionLabel.font = GiniConfiguration.shared.textStyleFonts[.subheadline]
         descriptionLabel.isAccessibilityElement = true
 
     }


### PR DESCRIPTION
Use `subheadline` style for the description labels on the onboarding screens

`We will need to update the customization guide (at least for Bank RA onboarding screen)`

PP-577, PP-468