### PR TITLE
Feat(GiniMerchantSDK): Migrate to universal links

### DIFF
--- a/MerchantSDK/GiniMerchantSDKExample/GiniMerchantSDKExample.xcodeproj/project.pbxproj
+++ b/MerchantSDK/GiniMerchantSDKExample/GiniMerchantSDKExample.xcodeproj/project.pbxproj
@@ -80,6 +80,7 @@
 		507A25F72C355DAA00A7106E /* GiniMerchantSDKPinningExampleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GiniMerchantSDKPinningExampleTests.swift; sourceTree = "<group>"; };
 		507A26102C35700F00A7106E /* GiniMerchantSDKPinning */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = GiniMerchantSDKPinning; path = ../GiniMerchantSDKPinning; sourceTree = "<group>"; };
 		507A26112C35B5C200A7106E /* GiniMerchantSDKPinningExampleWrongCertificatesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GiniMerchantSDKPinningExampleWrongCertificatesTests.swift; sourceTree = "<group>"; };
+		5087AF392C46E27D008B3403 /* GiniMerchantSDKExample.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = GiniMerchantSDKExample.entitlements; sourceTree = "<group>"; };
 		50D80D542C245A8900B446A8 /* GiniMerchantSDKExample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = GiniMerchantSDKExample.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		50D80D572C245A8900B446A8 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		50D80D592C245A8900B446A8 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -201,6 +202,7 @@
 		50D80D562C245A8900B446A8 /* GiniMerchantSDKExample */ = {
 			isa = PBXGroup;
 			children = (
+				5087AF392C46E27D008B3403 /* GiniMerchantSDKExample.entitlements */,
 				50D80DC82C24788F00B446A8 /* Sources */,
 				50D80DC72C24786500B446A8 /* Resources */,
 				50D80D652C245A8A00B446A8 /* Info.plist */,
@@ -798,7 +800,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
-				CODE_SIGN_ENTITLEMENTS = "";
+				CODE_SIGN_ENTITLEMENTS = GiniMerchantSDKExample/GiniMerchantSDKExample.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = JA825X8F7Z;
@@ -832,7 +834,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
-				CODE_SIGN_ENTITLEMENTS = "";
+				CODE_SIGN_ENTITLEMENTS = GiniMerchantSDKExample/GiniMerchantSDKExample.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = JA825X8F7Z;

--- a/MerchantSDK/GiniMerchantSDKExample/GiniMerchantSDKExample/GiniMerchantSDKExample.entitlements
+++ b/MerchantSDK/GiniMerchantSDKExample/GiniMerchantSDKExample/GiniMerchantSDKExample.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.developer.associated-domains</key>
+	<array>
+		<string>applinks:beaver-d97a1.web.app</string>
+	</array>
+</dict>
+</plist>

--- a/MerchantSDK/GiniMerchantSDKExample/GiniMerchantSDKExample/Sources/AppDelegate.swift
+++ b/MerchantSDK/GiniMerchantSDKExample/GiniMerchantSDKExample/Sources/AppDelegate.swift
@@ -11,25 +11,51 @@ import UIKit
 class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
     var coordinator: AppCoordinator!
-    
+
     func application(_ application: UIApplication,
                      didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         let window = UIWindow(frame: UIScreen.main.bounds)
         coordinator = AppCoordinator(window: window)
         coordinator.start()
-        
+
         return true
     }
-    
+
     func application(_ app: UIApplication,
                      open url: URL,
                      options: [UIApplication.OpenURLOptionsKey: Any] = [:]) -> Bool {
-        
         if (url.host == "payment-requester") {
             coordinator.processBankUrl()
         } else {
             coordinator.processExternalDocument(withUrl: url, sourceApplication: options[.sourceApplication] as? String)
         }
+        return true
+    }
+
+    func application(_ application: UIApplication,
+                     continue userActivity: NSUserActivity,
+                     restorationHandler: @escaping ([any UIUserActivityRestoring]?) -> Void) -> Bool {
+        // Get URL components from the incoming user activity.
+        guard userActivity.activityType == NSUserActivityTypeBrowsingWeb,
+              let incomingURL = userActivity.webpageURL,
+              let components = NSURLComponents(url: incomingURL, resolvingAgainstBaseURL: true),
+              let path = components.path,
+              let params = components.queryItems else {
+            print("❌ can't parse URL")
+            return false
+        }
+
+        // Validate URL components
+        guard components.host == "beaver-d97a1.web.app",
+              path == "/payment-requester",
+              params.first(where: { $0.name == "paymentRequestId" }) != nil else {
+            print("❌ unsupported URL")
+            return false
+        }
+
+        // Process URL
+        coordinator.processBankUrl()
+        print("✅ Successfully proceed with URL: \(incomingURL.absoluteString)")
         return true
     }
 }


### PR DESCRIPTION
EC-89 migrate from URL Scheme to Universal Links 

Highlights:
- need to deploy AASA file (for development needs https://beaver-d97a1.web.app/.well-known/apple-app-site-association) docs https://developer.apple.com/documentation/xcode/supporting-associated-domains
- still have to support URL Scheme for detecting clients/banking apps
- possible collision URLSheme implemented (app installed, and we suppose to open it), but Universal links not implemented (will be redirect to fallback URL, our flow breaks)
- harder to implement for clients
- potential risk (note from apple: Universal links offer a potential attack vector into your app, so make sure to validate all URL parameters and discard any malformed URLs. In addition, limit the available actions to those that don’t risk the user’s data. For example, don’t allow universal links to directly delete content or access sensitive information about the user. When testing your URL-handling code, make sure your test cases include improperly formatted URLs.) docs https://developer.apple.com/documentation/xcode/supporting-universal-links-in-your-app?language=objc 
+ can be used across platforms
+ not deprecated