### PR TITLE
Pp 636 handle UI for small devices and i pads in skonto

### DIFF
--- a/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/Skonto/BottomNavigation/DefaultSkontoBottomNavigationBar.swift
+++ b/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/Skonto/BottomNavigation/DefaultSkontoBottomNavigationBar.swift
@@ -160,6 +160,11 @@ final class DefaultSkontoBottomNavigationBar: UIView {
     }
 
     private func setupConstraints() {
+        var horizontalPadding: CGFloat = Constants.padding
+        if UIDevice.current.isIpad {
+            horizontalPadding += UIScreen.main.bounds.width * (1 - Constants.tabletWidthMultiplier) / 2
+        }
+
         NSLayoutConstraint.activate([
             dividerView.topAnchor.constraint(equalTo: topAnchor),
             dividerView.leadingAnchor.constraint(equalTo: leadingAnchor),
@@ -167,11 +172,13 @@ final class DefaultSkontoBottomNavigationBar: UIView {
             dividerView.heightAnchor.constraint(equalToConstant: Constants.dividerViewHeight),
 
             totalLabel.topAnchor.constraint(equalTo: dividerView.bottomAnchor, constant: Constants.padding),
-            totalLabel.leadingAnchor.constraint(equalTo: leadingAnchor, constant: Constants.padding),
+            totalLabel.leadingAnchor.constraint(equalTo: leadingAnchor,
+                                                constant: horizontalPadding),
 
             totalValueLabel.topAnchor.constraint(equalTo: totalLabel.bottomAnchor,
                                                  constant: Constants.totalValueLabelTopPadding),
-            totalValueLabel.leadingAnchor.constraint(equalTo: leadingAnchor, constant: Constants.padding),
+            totalValueLabel.leadingAnchor.constraint(equalTo: leadingAnchor,
+                                                     constant: horizontalPadding),
 
             savingsAmountLabel.topAnchor.constraint(equalTo: totalValueLabel.bottomAnchor,
                                                   constant: Constants.savingsAmountLabelTopPadding),
@@ -179,7 +186,7 @@ final class DefaultSkontoBottomNavigationBar: UIView {
 
             skontoBadgeView.centerYAnchor.constraint(equalTo: totalLabel.centerYAnchor),
             skontoBadgeView.trailingAnchor.constraint(equalTo: trailingAnchor,
-                                                     constant: -Constants.padding),
+                                                      constant: -horizontalPadding),
 
             skontoBadgeLabel.topAnchor.constraint(equalTo: skontoBadgeView.topAnchor,
                                                   constant: Constants.badgeVerticalPadding),
@@ -190,7 +197,8 @@ final class DefaultSkontoBottomNavigationBar: UIView {
             skontoBadgeLabel.trailingAnchor.constraint(equalTo: skontoBadgeView.trailingAnchor,
                                                        constant: -Constants.badgeHorizontalPadding),
 
-            backButton.buttonView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: Constants.padding),
+            backButton.buttonView.leadingAnchor.constraint(equalTo: leadingAnchor,
+                                                           constant: horizontalPadding),
             backButton.buttonView.centerYAnchor.constraint(equalTo: proceedButton.centerYAnchor),
 
             proceedButton.topAnchor.constraint(equalTo: savingsAmountLabel.bottomAnchor,
@@ -230,5 +238,6 @@ extension DefaultSkontoBottomNavigationBar {
         static let cornerRadius: CGFloat = 4
         static let totalValueLabelTopPadding: CGFloat = 4
         static let savingsAmountLabelTopPadding: CGFloat = 2
+        static let tabletWidthMultiplier: CGFloat = 0.7
     }
 }

--- a/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/Skonto/BottomNavigation/DefaultSkontoBottomNavigationBar.swift
+++ b/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/Skonto/BottomNavigation/DefaultSkontoBottomNavigationBar.swift
@@ -50,7 +50,6 @@ final class DefaultSkontoBottomNavigationBar: UIView {
         label.font = configuration.textStyleFonts[.subheadline]
         label.textColor = .giniColorScheme().text.primary.uiColor()
         label.adjustsFontForContentSizeCategory = true
-        label.setContentHuggingPriority(.required, for: .vertical)
         let text = NSLocalizedStringPreferredGiniBankFormat("ginibank.skonto.total.title",
                                                             comment: "Total")
         label.text = text
@@ -61,10 +60,12 @@ final class DefaultSkontoBottomNavigationBar: UIView {
     private lazy var totalValueLabel: UILabel = {
         let label = UILabel()
         label.translatesAutoresizingMaskIntoConstraints = false
-        label.adjustsFontForContentSizeCategory = true
         label.font = configuration.textStyleFonts[.title2Bold]
         label.textColor = .giniColorScheme().text.primary.uiColor()
-        label.setContentHuggingPriority(.required, for: .vertical)
+        label.adjustsFontForContentSizeCategory = true
+        label.adjustsFontSizeToFitWidth = true
+        label.setContentHuggingPriority(.defaultHigh, for: .horizontal)
+        label.setContentCompressionResistancePriority(.defaultHigh, for: .horizontal)
         return label
     }()
 
@@ -73,8 +74,10 @@ final class DefaultSkontoBottomNavigationBar: UIView {
         label.translatesAutoresizingMaskIntoConstraints = false
         label.font = configuration.textStyleFonts[.footnoteBold]
         label.textColor = .giniColorScheme().chips.textSuggestionEnabled.uiColor()
-        label.numberOfLines = 0
         label.adjustsFontForContentSizeCategory = true
+        label.adjustsFontSizeToFitWidth = true
+        label.setContentHuggingPriority(.defaultLow, for: .horizontal)
+        label.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
         return label
     }()
 
@@ -93,8 +96,8 @@ final class DefaultSkontoBottomNavigationBar: UIView {
         label.translatesAutoresizingMaskIntoConstraints = false
         label.font = configuration.textStyleFonts[.footnoteBold]
         label.textColor = .giniColorScheme().chips.suggestionEnabled.uiColor()
-        label.numberOfLines = 0
         label.adjustsFontForContentSizeCategory = true
+        label.adjustsFontSizeToFitWidth = true
         return label
     }()
 
@@ -174,15 +177,21 @@ final class DefaultSkontoBottomNavigationBar: UIView {
             totalLabel.topAnchor.constraint(equalTo: dividerView.bottomAnchor, constant: Constants.padding),
             totalLabel.leadingAnchor.constraint(equalTo: leadingAnchor,
                                                 constant: horizontalPadding),
+            totalLabel.trailingAnchor.constraint(lessThanOrEqualTo: skontoBadgeView.leadingAnchor,
+                                                 constant: -Constants.badgeHorizontalPadding),
 
             totalValueLabel.topAnchor.constraint(equalTo: totalLabel.bottomAnchor,
                                                  constant: Constants.totalValueLabelTopPadding),
             totalValueLabel.leadingAnchor.constraint(equalTo: leadingAnchor,
                                                      constant: horizontalPadding),
+            totalValueLabel.trailingAnchor.constraint(lessThanOrEqualTo: trailingAnchor,
+                                                      constant: -horizontalPadding),
 
             savingsAmountLabel.topAnchor.constraint(equalTo: totalValueLabel.bottomAnchor,
                                                   constant: Constants.savingsAmountLabelTopPadding),
             savingsAmountLabel.leadingAnchor.constraint(equalTo: totalValueLabel.leadingAnchor),
+            savingsAmountLabel.trailingAnchor.constraint(lessThanOrEqualTo: trailingAnchor,
+                                                         constant: -horizontalPadding),
 
             skontoBadgeView.centerYAnchor.constraint(equalTo: totalLabel.centerYAnchor),
             skontoBadgeView.trailingAnchor.constraint(equalTo: trailingAnchor,

--- a/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/Skonto/SkontoViewController.swift
+++ b/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/Skonto/SkontoViewController.swift
@@ -151,10 +151,15 @@ public class SkontoViewController: UIViewController {
     }
 
     private func setupScrollViewConstraints() {
+        var horizontalPadding: CGFloat = Constants.scrollViewSideInset
+        if UIDevice.current.isIpad {
+            horizontalPadding += UIScreen.main.bounds.width * (1 - Constants.tabletWidthMultiplier) / 2
+        }
+
         NSLayoutConstraint.activate([
             scrollView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
-            scrollView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            scrollView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            scrollView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: horizontalPadding),
+            scrollView.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -horizontalPadding),
             scrollView.bottomAnchor.constraint(equalTo: proceedView.topAnchor)
         ])
     }
@@ -207,13 +212,6 @@ public class SkontoViewController: UIViewController {
 
     private func setupNotAppliedGroupViewConstraints() {
         NSLayoutConstraint.activate([
-            notAppliedGroupView.topAnchor.constraint(equalTo: appliedGroupView.bottomAnchor,
-                                                     constant: Constants.containerPadding),
-            notAppliedGroupView.leadingAnchor.constraint(equalTo: view.leadingAnchor,
-                                                         constant: Constants.containerPadding),
-            notAppliedGroupView.trailingAnchor.constraint(equalTo: view.trailingAnchor,
-                                                          constant: -Constants.containerPadding),
-
             notAppliedView.topAnchor.constraint(equalTo: notAppliedGroupView.topAnchor),
             notAppliedView.leadingAnchor.constraint(equalTo: notAppliedGroupView.leadingAnchor,
                                                     constant: Constants.horizontalPadding),
@@ -371,5 +369,6 @@ private extension SkontoViewController {
         static let scrollViewSideInset: CGFloat = 0
         static let groupCornerRadius: CGFloat = 8
         static let scrollIndicatorInset: CGFloat = 0
+        static let tabletWidthMultiplier: CGFloat = 0.7
     }
 }

--- a/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/Skonto/Views/SkontoAmountView.swift
+++ b/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/Skonto/Views/SkontoAmountView.swift
@@ -54,7 +54,7 @@ class SkontoAmountView: UIView {
         let stackView = UIStackView(arrangedSubviews: [textField, currencyLabel])
         stackView.axis = .horizontal
         stackView.alignment = .center
-        stackView.spacing = Constants.stackviewSpacing
+        stackView.spacing = Constants.stackViewSpacing
         stackView.translatesAutoresizingMaskIntoConstraints = false
         return stackView
     }()
@@ -153,7 +153,7 @@ extension SkontoAmountView: PriceTextFieldDelegate {
 private extension SkontoAmountView {
     enum Constants {
         static let padding: CGFloat = 12
-        static let stackviewSpacing: CGFloat = 4
+        static let stackViewSpacing: CGFloat = 4
         static let cornerRadius: CGFloat = 8
     }
 }

--- a/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/Skonto/Views/SkontoAmountView.swift
+++ b/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/Skonto/Views/SkontoAmountView.swift
@@ -31,6 +31,7 @@ class SkontoAmountView: UIView {
         textField.keyboardType = .numberPad
         textField.isUserInteractionEnabled = isEditable
         textField.adjustsFontForContentSizeCategory = true
+        textField.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
         textField.translatesAutoresizingMaskIntoConstraints = false
         return textField
     }()
@@ -41,8 +42,19 @@ class SkontoAmountView: UIView {
         label.textColor = .giniColorScheme().text.secondary.uiColor()
         label.font = configuration.textStyleFonts[.body]
         label.adjustsFontForContentSizeCategory = true
+        label.setContentHuggingPriority(.defaultHigh, for: .horizontal)
+        label.setContentCompressionResistancePriority(.defaultHigh, for: .horizontal)
         label.translatesAutoresizingMaskIntoConstraints = false
         return label
+    }()
+
+    private lazy var stackView: UIStackView = {
+        let stackView = UIStackView(arrangedSubviews: [textField, currencyLabel])
+        stackView.axis = .horizontal
+        stackView.alignment = .center
+        stackView.spacing = Constants.stackviewSpacing
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        return stackView
     }()
 
     private lazy var containerView: UIView = {
@@ -81,16 +93,12 @@ class SkontoAmountView: UIView {
         backgroundColor = .giniColorScheme().bg.inputUnfocused.uiColor()
         addSubview(containerView)
         containerView.addSubview(titleLabel)
-        containerView.addSubview(textField)
-        containerView.addSubview(currencyLabel)
+        containerView.addSubview(stackView)
         setupConstraints()
         addTapGestureRecognizer()
     }
 
     private func setupConstraints() {
-        currencyLabel.setContentHuggingPriority(.defaultHigh, for: .horizontal)
-        currencyLabel.setContentCompressionResistancePriority(.required, for: .horizontal)
-
         NSLayoutConstraint.activate([
             containerView.topAnchor.constraint(equalTo: topAnchor),
             containerView.leadingAnchor.constraint(equalTo: leadingAnchor),
@@ -101,14 +109,13 @@ class SkontoAmountView: UIView {
             titleLabel.leadingAnchor.constraint(equalTo: containerView.leadingAnchor, constant: Constants.padding),
             titleLabel.trailingAnchor.constraint(equalTo: containerView.trailingAnchor, constant: -Constants.padding),
 
-            textField.topAnchor.constraint(equalTo: titleLabel.bottomAnchor),
-            textField.leadingAnchor.constraint(equalTo: containerView.leadingAnchor, constant: Constants.padding),
-            textField.bottomAnchor.constraint(equalTo: containerView.bottomAnchor, constant: -Constants.padding),
-
-            currencyLabel.centerYAnchor.constraint(equalTo: textField.centerYAnchor),
-            currencyLabel.leadingAnchor.constraint(equalTo: textField.trailingAnchor,
-                                                   constant: Constants.currencyLabelHorizontalPadding),
-            currencyLabel.trailingAnchor.constraint(equalTo: containerView.trailingAnchor, constant: -Constants.padding)
+            stackView.topAnchor.constraint(equalTo: titleLabel.bottomAnchor, constant: Constants.padding),
+            stackView.leadingAnchor.constraint(equalTo: containerView.leadingAnchor,
+                                                        constant: Constants.padding),
+            stackView.trailingAnchor.constraint(equalTo: containerView.trailingAnchor,
+                                                         constant: -Constants.padding),
+            stackView.bottomAnchor.constraint(equalTo: containerView.bottomAnchor,
+                                                       constant: -Constants.padding)
         ])
     }
 
@@ -144,7 +151,7 @@ extension SkontoAmountView: PriceTextFieldDelegate {
 private extension SkontoAmountView {
     enum Constants {
         static let padding: CGFloat = 12
-        static let currencyLabelHorizontalPadding: CGFloat = 10
+        static let stackviewSpacing: CGFloat = 4
         static let cornerRadius: CGFloat = 8
     }
 }

--- a/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/Skonto/Views/SkontoAmountView.swift
+++ b/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/Skonto/Views/SkontoAmountView.swift
@@ -31,6 +31,8 @@ class SkontoAmountView: UIView {
         textField.keyboardType = .numberPad
         textField.isUserInteractionEnabled = isEditable
         textField.adjustsFontForContentSizeCategory = true
+        textField.adjustsFontSizeToFitWidth = true
+        textField.setContentHuggingPriority(.defaultLow, for: .horizontal)
         textField.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
         textField.translatesAutoresizingMaskIntoConstraints = false
         return textField

--- a/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/Skonto/Views/SkontoAppliedDateView.swift
+++ b/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/Skonto/Views/SkontoAppliedDateView.swift
@@ -27,6 +27,7 @@ class SkontoAppliedDateView: UIView {
         textField.font = configuration.textStyleFonts[.body]
         textField.borderStyle = .none
         textField.adjustsFontForContentSizeCategory = true
+        textField.adjustsFontSizeToFitWidth = true
         textField.translatesAutoresizingMaskIntoConstraints = false
         return textField
     }()

--- a/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/Skonto/Views/SkontoAppliedHeaderView.swift
+++ b/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/Skonto/Views/SkontoAppliedHeaderView.swift
@@ -51,7 +51,7 @@ class SkontoAppliedHeaderView: UIView {
         let stackView = UIStackView(arrangedSubviews: [titleLabel, statusLabel])
         stackView.axis = .horizontal
         stackView.alignment = .center
-        stackView.spacing = Constants.stackviewSpacing
+        stackView.spacing = Constants.stackViewSpacing
         stackView.translatesAutoresizingMaskIntoConstraints = false
         return stackView
     }()
@@ -83,7 +83,7 @@ class SkontoAppliedHeaderView: UIView {
         NSLayoutConstraint.activate([
             stackView.leadingAnchor.constraint(equalTo: leadingAnchor),
             stackView.topAnchor.constraint(greaterThanOrEqualTo: topAnchor,
-                                           constant: Constants.stackviewVerticalPadding),
+                                           constant: Constants.stackViewVerticalPadding),
             stackView.bottomAnchor.constraint(lessThanOrEqualTo: bottomAnchor),
 
             discountSwitch.topAnchor.constraint(greaterThanOrEqualTo: topAnchor,
@@ -117,8 +117,8 @@ class SkontoAppliedHeaderView: UIView {
 
 private extension SkontoAppliedHeaderView {
     enum Constants {
-        static let stackviewSpacing: CGFloat = 4
-        static let stackviewVerticalPadding: CGFloat = 16
+        static let stackViewSpacing: CGFloat = 4
+        static let stackViewVerticalPadding: CGFloat = 16
         static let discountSwitchLeadingPadding: CGFloat = 4
         static let discountSwitchTopPadding: CGFloat = 12
     }

--- a/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/Skonto/Views/SkontoAppliedHeaderView.swift
+++ b/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/Skonto/Views/SkontoAppliedHeaderView.swift
@@ -16,6 +16,9 @@ class SkontoAppliedHeaderView: UIView {
         label.textColor = .giniColorScheme().text.primary.uiColor()
         label.font = configuration.textStyleFonts[.bodyBold]
         label.adjustsFontForContentSizeCategory = true
+        label.numberOfLines = 0
+        label.setContentHuggingPriority(.defaultLow, for: .horizontal)
+        label.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
         label.translatesAutoresizingMaskIntoConstraints = false
         return label
     }()
@@ -29,6 +32,8 @@ class SkontoAppliedHeaderView: UIView {
         label.font = configuration.textStyleFonts[.footnoteBold]
         label.textColor = UIColor.giniColorScheme().text.status.uiColor()
         label.adjustsFontForContentSizeCategory = true
+        label.setContentHuggingPriority(.required, for: .horizontal)
+        label.setContentCompressionResistancePriority(.required, for: .horizontal)
         label.translatesAutoresizingMaskIntoConstraints = false
         return label
     }()
@@ -40,6 +45,15 @@ class SkontoAppliedHeaderView: UIView {
         discountSwitch.addTarget(self, action: #selector(discountSwitchToggled(_:)), for: .valueChanged)
         discountSwitch.translatesAutoresizingMaskIntoConstraints = false
         return discountSwitch
+    }()
+
+    private lazy var stackView: UIStackView = {
+        let stackView = UIStackView(arrangedSubviews: [titleLabel, statusLabel])
+        stackView.axis = .horizontal
+        stackView.alignment = .center
+        stackView.spacing = Constants.stackviewSpacing
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        return stackView
     }()
 
     private let configuration = GiniBankConfiguration.shared
@@ -59,8 +73,7 @@ class SkontoAppliedHeaderView: UIView {
     private func setupView() {
         translatesAutoresizingMaskIntoConstraints = false
         backgroundColor = .giniColorScheme().bg.surface.uiColor()
-        addSubview(titleLabel)
-        addSubview(statusLabel)
+        addSubview(stackView)
         addSubview(discountSwitch)
         setupConstraints()
         bindViewModel()
@@ -68,17 +81,18 @@ class SkontoAppliedHeaderView: UIView {
 
     private func setupConstraints() {
         NSLayoutConstraint.activate([
-            titleLabel.leadingAnchor.constraint(equalTo: leadingAnchor),
+            stackView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            stackView.topAnchor.constraint(greaterThanOrEqualTo: topAnchor,
+                                           constant: Constants.stackviewVerticalPadding),
+            stackView.bottomAnchor.constraint(lessThanOrEqualTo: bottomAnchor),
 
-            statusLabel.centerYAnchor.constraint(equalTo: titleLabel.centerYAnchor),
-            statusLabel.leadingAnchor.constraint(equalTo: titleLabel.trailingAnchor,
-                                                 constant: Constants.statusLabelHorizontalPadding),
-
-            discountSwitch.topAnchor.constraint(equalTo: topAnchor,
+            discountSwitch.topAnchor.constraint(greaterThanOrEqualTo: topAnchor,
                                                 constant: Constants.discountSwitchTopPadding),
-            discountSwitch.bottomAnchor.constraint(equalTo: bottomAnchor),
-            discountSwitch.centerYAnchor.constraint(equalTo: titleLabel.centerYAnchor),
-            discountSwitch.trailingAnchor.constraint(equalTo: trailingAnchor)
+            discountSwitch.centerYAnchor.constraint(equalTo: stackView.centerYAnchor),
+            discountSwitch.trailingAnchor.constraint(equalTo: trailingAnchor),
+            discountSwitch.leadingAnchor.constraint(greaterThanOrEqualTo: stackView.trailingAnchor,
+                                                    constant: Constants.discountSwitchLeadingPadding),
+            discountSwitch.bottomAnchor.constraint(lessThanOrEqualTo: bottomAnchor)
         ])
     }
 
@@ -103,7 +117,9 @@ class SkontoAppliedHeaderView: UIView {
 
 private extension SkontoAppliedHeaderView {
     enum Constants {
-        static let statusLabelHorizontalPadding: CGFloat = 4
+        static let stackviewSpacing: CGFloat = 4
+        static let stackviewVerticalPadding: CGFloat = 16
+        static let discountSwitchLeadingPadding: CGFloat = 4
         static let discountSwitchTopPadding: CGFloat = 12
     }
 }

--- a/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/Skonto/Views/SkontoNotAppliedView.swift
+++ b/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/Skonto/Views/SkontoNotAppliedView.swift
@@ -16,6 +16,9 @@ class SkontoNotAppliedView: UIView {
         label.textColor = .giniColorScheme().text.primary.uiColor()
         label.font = configuration.textStyleFonts[.bodyBold]
         label.adjustsFontForContentSizeCategory = true
+        label.numberOfLines = 0
+        label.setContentHuggingPriority(.defaultLow, for: .horizontal)
+        label.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
         label.translatesAutoresizingMaskIntoConstraints = false
         return label
     }()
@@ -29,12 +32,23 @@ class SkontoNotAppliedView: UIView {
         label.font = configuration.textStyleFonts[.footnoteBold]
         label.textColor = UIColor.giniColorScheme().text.status.uiColor()
         label.adjustsFontForContentSizeCategory = true
+        label.setContentHuggingPriority(.required, for: .horizontal)
+        label.setContentCompressionResistancePriority(.required, for: .horizontal)
         label.translatesAutoresizingMaskIntoConstraints = false
         return label
     }()
 
     private lazy var amountView: SkontoNotAppliedAmountView = {
         return SkontoNotAppliedAmountView(viewModel: viewModel)
+    }()
+
+    private lazy var stackView: UIStackView = {
+        let stackView = UIStackView(arrangedSubviews: [titleLabel, statusLabel])
+        stackView.axis = .horizontal
+        stackView.alignment = .center
+        stackView.spacing = Constants.stackviewSpacing
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        return stackView
     }()
 
     private let configuration = GiniBankConfiguration.shared
@@ -54,8 +68,7 @@ class SkontoNotAppliedView: UIView {
     private func setupView() {
         translatesAutoresizingMaskIntoConstraints = false
         backgroundColor = .giniColorScheme().bg.surface.uiColor()
-        addSubview(titleLabel)
-        addSubview(statusLabel)
+        addSubview(stackView)
         addSubview(amountView)
         setupConstraints()
         bindViewModel()
@@ -63,14 +76,11 @@ class SkontoNotAppliedView: UIView {
 
     private func setupConstraints() {
         NSLayoutConstraint.activate([
-            titleLabel.topAnchor.constraint(equalTo: topAnchor, constant: Constants.verticalPadding),
-            titleLabel.leadingAnchor.constraint(equalTo: leadingAnchor),
+            stackView.topAnchor.constraint(equalTo: topAnchor, constant: Constants.verticalPadding),
+            stackView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            stackView.trailingAnchor.constraint(lessThanOrEqualTo: trailingAnchor),
 
-            statusLabel.centerYAnchor.constraint(equalTo: titleLabel.centerYAnchor),
-            statusLabel.leadingAnchor.constraint(equalTo: titleLabel.trailingAnchor,
-                                                 constant: Constants.statusLabelHorizontalPadding),
-
-            amountView.topAnchor.constraint(equalTo: titleLabel.bottomAnchor, constant: Constants.verticalPadding),
+            amountView.topAnchor.constraint(equalTo: stackView.bottomAnchor, constant: Constants.verticalPadding),
             amountView.bottomAnchor.constraint(equalTo: bottomAnchor),
             amountView.leadingAnchor.constraint(equalTo: leadingAnchor),
             amountView.trailingAnchor.constraint(equalTo: trailingAnchor)
@@ -92,7 +102,7 @@ class SkontoNotAppliedView: UIView {
 
 private extension SkontoNotAppliedView {
     enum Constants {
-        static let statusLabelHorizontalPadding: CGFloat = 4
+        static let stackviewSpacing: CGFloat = 4
         static let verticalPadding: CGFloat = 12
     }
 }

--- a/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/Skonto/Views/SkontoNotAppliedView.swift
+++ b/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/Skonto/Views/SkontoNotAppliedView.swift
@@ -46,7 +46,7 @@ class SkontoNotAppliedView: UIView {
         let stackView = UIStackView(arrangedSubviews: [titleLabel, statusLabel])
         stackView.axis = .horizontal
         stackView.alignment = .center
-        stackView.spacing = Constants.stackviewSpacing
+        stackView.spacing = Constants.stackViewSpacing
         stackView.translatesAutoresizingMaskIntoConstraints = false
         return stackView
     }()
@@ -102,7 +102,7 @@ class SkontoNotAppliedView: UIView {
 
 private extension SkontoNotAppliedView {
     enum Constants {
-        static let stackviewSpacing: CGFloat = 4
+        static let stackViewSpacing: CGFloat = 4
         static let verticalPadding: CGFloat = 12
     }
 }

--- a/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/Skonto/Views/SkontoProceedView.swift
+++ b/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/Skonto/Views/SkontoProceedView.swift
@@ -147,7 +147,8 @@ class SkontoProceedView: UIView {
             totalValueLabel.topAnchor.constraint(equalTo: totalLabel.bottomAnchor,
                                                  constant: Constants.totalValueLabelTopPadding),
             totalValueLabel.leadingAnchor.constraint(equalTo: leadingAnchor, constant: horizontalPadding),
-            totalValueLabel.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -horizontalPadding),
+            totalValueLabel.trailingAnchor.constraint(lessThanOrEqualTo: trailingAnchor,
+                                                      constant: -horizontalPadding),
 
             savingsAmountLabel.topAnchor.constraint(equalTo: totalValueLabel.bottomAnchor,
                                                     constant: Constants.savingsAmountLabelTopPadding),

--- a/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/Skonto/Views/SkontoProceedView.swift
+++ b/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/Skonto/Views/SkontoProceedView.swift
@@ -43,6 +43,7 @@ class SkontoProceedView: UIView {
         label.text = labelText
         label.accessibilityValue = labelText
         label.adjustsFontForContentSizeCategory = true
+        label.adjustsFontSizeToFitWidth = true
         return label
     }()
 
@@ -136,6 +137,7 @@ class SkontoProceedView: UIView {
             totalValueLabel.topAnchor.constraint(equalTo: totalLabel.bottomAnchor,
                                                  constant: Constants.totalValueLabelTopPadding),
             totalValueLabel.leadingAnchor.constraint(equalTo: leadingAnchor, constant: Constants.padding),
+            totalValueLabel.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -Constants.padding),
 
             savingsAmountLabel.topAnchor.constraint(equalTo: totalValueLabel.bottomAnchor,
                                                   constant: Constants.savingsAmountLabelTopPadding),

--- a/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/Skonto/Views/SkontoProceedView.swift
+++ b/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/Skonto/Views/SkontoProceedView.swift
@@ -124,6 +124,11 @@ class SkontoProceedView: UIView {
     }
 
     private func setupConstraints() {
+        var horizontalPadding: CGFloat = Constants.padding
+        if UIDevice.current.isIpad {
+            horizontalPadding += UIScreen.main.bounds.width * (1 - Constants.tabletWidthMultiplier) / 2
+        }
+
         NSLayoutConstraint.activate([
             dividerView.topAnchor.constraint(equalTo: topAnchor),
             dividerView.leadingAnchor.constraint(equalTo: leadingAnchor),
@@ -131,21 +136,20 @@ class SkontoProceedView: UIView {
             dividerView.heightAnchor.constraint(equalToConstant: Constants.dividerViewHeight),
 
             totalLabel.topAnchor.constraint(equalTo: dividerView.bottomAnchor, constant: Constants.padding),
-            totalLabel.leadingAnchor.constraint(equalTo: leadingAnchor, constant: Constants.padding),
-            totalLabel.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -Constants.padding),
+            totalLabel.leadingAnchor.constraint(equalTo: leadingAnchor, constant: horizontalPadding),
+            totalLabel.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -horizontalPadding),
 
             totalValueLabel.topAnchor.constraint(equalTo: totalLabel.bottomAnchor,
                                                  constant: Constants.totalValueLabelTopPadding),
-            totalValueLabel.leadingAnchor.constraint(equalTo: leadingAnchor, constant: Constants.padding),
-            totalValueLabel.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -Constants.padding),
+            totalValueLabel.leadingAnchor.constraint(equalTo: leadingAnchor, constant: horizontalPadding),
+            totalValueLabel.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -horizontalPadding),
 
             savingsAmountLabel.topAnchor.constraint(equalTo: totalValueLabel.bottomAnchor,
-                                                  constant: Constants.savingsAmountLabelTopPadding),
+                                                    constant: Constants.savingsAmountLabelTopPadding),
             savingsAmountLabel.leadingAnchor.constraint(equalTo: totalValueLabel.leadingAnchor),
 
             skontoBadgeView.centerYAnchor.constraint(equalTo: totalLabel.centerYAnchor),
-            skontoBadgeView.trailingAnchor.constraint(equalTo: trailingAnchor,
-                                                     constant: -Constants.padding),
+            skontoBadgeView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -horizontalPadding),
 
             skontoBadgeLabel.topAnchor.constraint(equalTo: skontoBadgeView.topAnchor,
                                                   constant: Constants.badgeVerticalPadding),
@@ -159,9 +163,9 @@ class SkontoProceedView: UIView {
             proceedButton.topAnchor.constraint(equalTo: savingsAmountLabel.bottomAnchor,
                                                constant: Constants.verticalPadding),
             proceedButton.bottomAnchor.constraint(equalTo: safeAreaLayoutGuide.bottomAnchor,
-                                              constant: -Constants.verticalPadding),
+                                                  constant: -Constants.verticalPadding),
             proceedButton.centerXAnchor.constraint(equalTo: centerXAnchor),
-            proceedButton.leadingAnchor.constraint(equalTo: leadingAnchor, constant: Constants.padding),
+            proceedButton.leadingAnchor.constraint(equalTo: leadingAnchor, constant: horizontalPadding),
             proceedButton.heightAnchor.constraint(greaterThanOrEqualToConstant: Constants.proceedButtonHeight)
         ])
     }
@@ -203,5 +207,6 @@ private extension SkontoProceedView {
         static let cornerRadius: CGFloat = 4
         static let totalValueLabelTopPadding: CGFloat = 4
         static let savingsAmountLabelTopPadding: CGFloat = 2
+        static let tabletWidthMultiplier: CGFloat = 0.7
     }
 }

--- a/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/Skonto/Views/SkontoProceedView.swift
+++ b/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/Skonto/Views/SkontoProceedView.swift
@@ -44,6 +44,8 @@ class SkontoProceedView: UIView {
         label.accessibilityValue = labelText
         label.adjustsFontForContentSizeCategory = true
         label.adjustsFontSizeToFitWidth = true
+        label.setContentHuggingPriority(.defaultHigh, for: .horizontal)
+        label.setContentCompressionResistancePriority(.defaultHigh, for: .horizontal)
         return label
     }()
 
@@ -55,9 +57,11 @@ class SkontoProceedView: UIView {
         let labelText = String.localizedStringWithFormat(skontoTitle,
                                                          viewModel.formattedPercentageDiscounted)
         label.text = labelText
-        label.numberOfLines = 0
         label.accessibilityValue = labelText
         label.adjustsFontForContentSizeCategory = true
+        label.adjustsFontSizeToFitWidth = true
+        label.setContentHuggingPriority(.defaultLow, for: .horizontal)
+        label.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
         return label
     }()
 
@@ -78,9 +82,9 @@ class SkontoProceedView: UIView {
         label.textColor = .giniColorScheme().chips.suggestionEnabled.uiColor()
         let labelText = viewModel.savingsAmountString
         label.text = labelText
-        label.numberOfLines = 0
         label.accessibilityValue = labelText
         label.adjustsFontForContentSizeCategory = true
+        label.adjustsFontSizeToFitWidth = true
         return label
     }()
 
@@ -137,7 +141,8 @@ class SkontoProceedView: UIView {
 
             totalLabel.topAnchor.constraint(equalTo: dividerView.bottomAnchor, constant: Constants.padding),
             totalLabel.leadingAnchor.constraint(equalTo: leadingAnchor, constant: horizontalPadding),
-            totalLabel.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -horizontalPadding),
+            totalLabel.trailingAnchor.constraint(lessThanOrEqualTo: skontoBadgeView.leadingAnchor,
+                                                 constant: -Constants.badgeHorizontalPadding),
 
             totalValueLabel.topAnchor.constraint(equalTo: totalLabel.bottomAnchor,
                                                  constant: Constants.totalValueLabelTopPadding),
@@ -147,6 +152,8 @@ class SkontoProceedView: UIView {
             savingsAmountLabel.topAnchor.constraint(equalTo: totalValueLabel.bottomAnchor,
                                                     constant: Constants.savingsAmountLabelTopPadding),
             savingsAmountLabel.leadingAnchor.constraint(equalTo: totalValueLabel.leadingAnchor),
+            savingsAmountLabel.trailingAnchor.constraint(lessThanOrEqualTo: trailingAnchor,
+                                                         constant: -horizontalPadding),
 
             skontoBadgeView.centerYAnchor.constraint(equalTo: totalLabel.centerYAnchor),
             skontoBadgeView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -horizontalPadding),


### PR DESCRIPTION
Add updated iPad layout to be consistent with RA:
![Simulator Screenshot - iPad Pro (11-inch) (4th generation) - 2024-07-31 at 15 29 57](https://github.com/user-attachments/assets/227d6f61-fca2-4c51-ad1d-490178f351db)
![Simulator Screenshot - iPad Pro (11-inch) (4th generation) - 2024-07-31 at 15 30 04](https://github.com/user-attachments/assets/7c6c838e-9d4a-4266-9ef7-db459c9f038f)
Update layout to support small devices