### PR TITLE
PP-639: Attempt to fix the UIDocument crash

### DIFF
--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Models/GiniCaptureDocument.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Models/GiniCaptureDocument.swift
@@ -112,13 +112,20 @@ private extension GiniCaptureDocumentBuilder {
     final class InputDocument: UIDocument {
         public var data: Data?
 
-        override public func load(fromContents contents: Any, ofType typeName: String?) throws {
+        override func load(fromContents contents: Any, ofType typeName: String?) throws {
 
             guard let data = contents as? Data else {
                 throw DocumentError.unrecognizedContent
             }
 
             self.data = data
+        }
+
+        override func writeContents(_ contents: Any, to url: URL, for saveOperation: UIDocument.SaveOperation, originalContentsURL: URL?) throws {
+            if (contents as? Data) == nil, (contents as? FileWrapper) == nil {
+                throw DocumentError.unrecognizedContent
+            }
+            try super.writeContents(contents, to: url, for: saveOperation, originalContentsURL: originalContentsURL)
         }
     }
 }


### PR DESCRIPTION
I still didn't manage to catch the crash, but judging by the error from the video, I think we should just overwrite the writeContents method and make a check, similar to what is done in `loadFromContents` in `InputDocument` (as far as I understood it is used instead of the regular `UIDocument`).