### PR TITLE
PP-208 fix "qr code detected" getting cut off

### DIFF
--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Extensions/UILabel.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Extensions/UILabel.swift
@@ -20,4 +20,10 @@ extension UILabel {
                                  attributes: [NSAttributedString.Key.font: font],
                                  context: nil).size.height
     }
+
+    func enableScaling() {
+        adjustsFontSizeToFitWidth = true
+        minimumScaleFactor = 10 / font.pointSize
+        adjustsFontForContentSizeCategory = true
+    }
 }

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Camera/Views/QRCodeOverlay.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Camera/Views/QRCodeOverlay.swift
@@ -54,6 +54,9 @@ final class IncorrectQRCodeTextContainer: UIView {
         label.textColor = .GiniCapture.dark1
         label.text = NSLocalizedStringPreferredFormat("ginicapture.QRscanning.incorrect.title",
                                                       comment: "Unknown QR")
+        label.adjustsFontSizeToFitWidth = true
+        label.minimumScaleFactor = 10 / label.font.pointSize
+        label.adjustsFontForContentSizeCategory = true
         label.numberOfLines = 0
         return label
     }()
@@ -65,6 +68,9 @@ final class IncorrectQRCodeTextContainer: UIView {
         label.numberOfLines = 0
         label.text = NSLocalizedStringPreferredFormat("ginicapture.QRscanning.incorrect.description",
                                                       comment: "No content")
+        label.adjustsFontSizeToFitWidth = true
+        label.minimumScaleFactor = 10 / label.font.pointSize
+        label.adjustsFontForContentSizeCategory = true
         return label
     }()
 

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Camera/Views/QRCodeOverlay.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Camera/Views/QRCodeOverlay.swift
@@ -19,6 +19,8 @@ final class CorrectQRCodeTextContainer: UIView {
         label.text = NSLocalizedStringPreferredFormat("ginicapture.QRscanning.correct",
                                                       comment: "QR Detected")
         label.adjustsFontForContentSizeCategory = true
+        label.adjustsFontSizeToFitWidth = true
+        label.minimumScaleFactor = 10 / label.font.pointSize
         return label
     }()
 

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Camera/Views/QRCodeOverlay.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Camera/Views/QRCodeOverlay.swift
@@ -18,9 +18,7 @@ final class CorrectQRCodeTextContainer: UIView {
         label.textColor = .GiniCapture.light1
         label.text = NSLocalizedStringPreferredFormat("ginicapture.QRscanning.correct",
                                                       comment: "QR Detected")
-        label.adjustsFontForContentSizeCategory = true
-        label.adjustsFontSizeToFitWidth = true
-        label.minimumScaleFactor = 10 / label.font.pointSize
+        label.enableScaling()
         return label
     }()
 
@@ -54,9 +52,7 @@ final class IncorrectQRCodeTextContainer: UIView {
         label.textColor = .GiniCapture.dark1
         label.text = NSLocalizedStringPreferredFormat("ginicapture.QRscanning.incorrect.title",
                                                       comment: "Unknown QR")
-        label.adjustsFontSizeToFitWidth = true
-        label.minimumScaleFactor = 10 / label.font.pointSize
-        label.adjustsFontForContentSizeCategory = true
+        label.enableScaling()
         label.numberOfLines = 0
         return label
     }()
@@ -68,9 +64,7 @@ final class IncorrectQRCodeTextContainer: UIView {
         label.numberOfLines = 0
         label.text = NSLocalizedStringPreferredFormat("ginicapture.QRscanning.incorrect.description",
                                                       comment: "No content")
-        label.adjustsFontSizeToFitWidth = true
-        label.minimumScaleFactor = 10 / label.font.pointSize
-        label.adjustsFontForContentSizeCategory = true
+        label.enableScaling()
         return label
     }()
 


### PR DESCRIPTION
I managed to replicate the issue on iPhone 6s iOS 15.8.2, but only with "QR code detected", with "Scan invoice or QR code" at the bottom everything is fine, and it already has minimumScaleFactor and adjustsFontSizeToFitWidth set up to it