### PR TITLE
PP-802: Fix crash in storyboard

### DIFF
--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Resources/OnboardingScreen/OnboardingViewController.xib
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Resources/OnboardingScreen/OnboardingViewController.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="21507" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="32700.99.1234" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="ipad7_9" orientation="portrait" layout="fullscreen" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21505"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22684"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -32,7 +32,7 @@
                         <inset key="sectionInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
                     </collectionViewFlowLayout>
                 </collectionView>
-                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="dqe-Kh-XtC">
+                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="dqe-Kh-XtC" customClass="MultilineTitleButton" customModule="GiniCaptureSDK">
                     <rect key="frame" x="287" y="1033" width="170" height="50"/>
                     <color key="backgroundColor" red="0.058291204270000001" green="0.61419159170000004" blue="0.86277651789999998" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                     <constraints>


### PR DESCRIPTION
The reason was that in the storyboard of that button it didn't have any custom class, just UIButton, although in the code was MultilineTitleButton, it did not crash simply because there were no additional properties before adding GiniCaptureButton.

EXC_BAD_ACCESS with code 1 usually means that the object either does not exist in memory at all (either it was never allocated or it was freed), or the address of the memory location is crooked. In this case, because the class was not defined in the storyboard (so inside uikit the memory was allocated just for UIButton), the memory for traitCollectionUpdated was not allocated, even if you put nil as default value (and Optional != nullptr).

Sometimes EXC_BAD_ACCESS also occurs because of some bugs in xcode (so far I've seen it only with v15.3.0), cleaning build folder/derived data helps in this case.