### PR TITLE
GitHub action workflows improvements

### DIFF
--- a/.github/workflows/bank-api-library.build.docs.yml
+++ b/.github/workflows/bank-api-library.build.docs.yml
@@ -1,15 +1,11 @@
 name: Builds docs for Bank API Library
 
 on:
-  push:
+  pull_request:
+    types: [opened, reopened, synchronize, ready_for_review]
     paths:
       - 'BankAPILibrary/**'
   workflow_dispatch:
-    tags-ignore:
-      - '**'
-  pull_request:
-    paths:
-      - 'BankAPILibrary/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/bank-api-library.check.yml
+++ b/.github/workflows/bank-api-library.check.yml
@@ -1,7 +1,7 @@
 name: Check Bank API Library
 on:
   pull_request:
-    types: [opened, edited, reopened, synchronize]
+    types: [opened, reopened, synchronize, ready_for_review]
     paths:
       - 'BankAPILibrary/**'
 

--- a/.github/workflows/bank-sdk.build.docs.yml
+++ b/.github/workflows/bank-sdk.build.docs.yml
@@ -2,7 +2,7 @@ name: Builds docs for Bank SDK
 
 on:
   pull_request:
-    types: [opened, edited, reopened, synchronize]
+    types: [opened, reopened, synchronize, ready_for_review]
     paths:
       - 'BankSDK/**'
   workflow_dispatch:

--- a/.github/workflows/bank-sdk.build.docs.yml
+++ b/.github/workflows/bank-sdk.build.docs.yml
@@ -1,15 +1,11 @@
 name: Builds docs for Bank SDK
 
 on:
-  push:
+  pull_request:
+    types: [opened, edited, reopened, synchronize]
     paths:
       - 'BankSDK/**'
   workflow_dispatch:
-    tags-ignore:
-      - '**'
-  pull_request:
-    paths:
-      - 'BankSDK/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/bank-sdk.check.yml
+++ b/.github/workflows/bank-sdk.check.yml
@@ -1,7 +1,7 @@
 name: Check Bank SDK
 on:
   pull_request:
-    types: [opened, edited, reopened, synchronize]
+    types: [opened, reopened, synchronize, ready_for_review]
     paths:
       - 'BankSDK/**'
       - 'CaptureSDK/**'

--- a/.github/workflows/capture-sdk.build.docs.yml
+++ b/.github/workflows/capture-sdk.build.docs.yml
@@ -2,8 +2,6 @@ name: Builds docs for Capture SDK
 
 on:
   workflow_dispatch:
-    tags-ignore:
-      - '**'
   pull_request:
     types: [opened, edited, reopened, synchronize]
     paths:

--- a/.github/workflows/capture-sdk.build.docs.yml
+++ b/.github/workflows/capture-sdk.build.docs.yml
@@ -3,7 +3,7 @@ name: Builds docs for Capture SDK
 on:
   workflow_dispatch:
   pull_request:
-    types: [opened, edited, reopened, synchronize]
+    types: [opened, reopened, synchronize, ready_for_review]
     paths:
       - 'CaptureSDK/**'
 

--- a/.github/workflows/capture-sdk.check.yml
+++ b/.github/workflows/capture-sdk.check.yml
@@ -1,7 +1,7 @@
 name: Check Capture SDK
 on:
   pull_request:
-    types: [opened, edited, reopened, synchronize]
+    types: [opened, reopened, synchronize, ready_for_review]
     paths:
       - 'CaptureSDK/**'
       - 'BankAPILibrary/**'

--- a/.github/workflows/health-api-library.build.docs.yml
+++ b/.github/workflows/health-api-library.build.docs.yml
@@ -1,13 +1,11 @@
 name: Builds docs for Health API Library
 
 on:
-  workflow_dispatch:
-    tags-ignore:
-      - '**'
   pull_request:
-    types: [opened, edited, reopened, synchronize]
+    types: [opened, reopened, synchronize, ready_for_review]
     paths:
       - 'HealthAPILibrary/**'
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/health-api-library.check.yml
+++ b/.github/workflows/health-api-library.check.yml
@@ -1,7 +1,7 @@
 name: Check Health API Library
 on:
   pull_request:
-   types: [opened, edited, reopened, synchronize]
+   types: [opened, reopened, synchronize, ready_for_review]
    paths:
       - 'HealthAPILibrary/**'
   workflow_call:

--- a/.github/workflows/health-sdk.build.docs.yml
+++ b/.github/workflows/health-sdk.build.docs.yml
@@ -1,13 +1,11 @@
 name: Builds docs for Health SDK
 
 on:
-  workflow_dispatch:
-    tags-ignore:
-      - '**'
   pull_request:
-    types: [opened, edited, reopened, synchronize]
+    types: [opened, reopened, synchronize, ready_for_review]
     paths:
       - 'HealthSDK/**'
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/health-sdk.check.yml
+++ b/.github/workflows/health-sdk.check.yml
@@ -1,7 +1,7 @@
 name: Check Health SDK
 on:
   pull_request:
-    types: [opened, edited, reopened, synchronize]
+    types: [opened, reopened, synchronize, ready_for_review]
     paths:
       - 'HealthSDK/**'
       - 'HealthAPILibrary/**'

--- a/.github/workflows/internal-payment-sdk.check.yml
+++ b/.github/workflows/internal-payment-sdk.check.yml
@@ -1,10 +1,9 @@
 name: Check Gini Internal Payment SDK
 on:
-  push:
+  pull_request:
+   types: [opened, reopened, synchronize, ready_for_review]
    paths:
       - 'GiniComponents/GiniInternalPaymentSDK/**'
-   tags-ignore:
-      - '**'
   workflow_call:
   workflow_dispatch:
 

--- a/.github/workflows/merchant-sdk.build.docs.yml
+++ b/.github/workflows/merchant-sdk.build.docs.yml
@@ -2,7 +2,7 @@ name: Builds docs for Merchant SDK
 
 on:
   pull_request:
-    types: [opened, edited, reopened, synchronize]
+    types: [opened, reopened, synchronize, ready_for_review]
     paths:
       - 'MerchantSDK/**'
   workflow_dispatch:

--- a/.github/workflows/merchant-sdk.check.yml
+++ b/.github/workflows/merchant-sdk.check.yml
@@ -1,7 +1,7 @@
 name: Check Merchant SDK
 on:
   pull_request:
-    types: [opened, edited, reopened, synchronize]
+    types: [opened, reopened, synchronize, ready_for_review]
     paths:
       - 'MerchantSDK/**'
   workflow_call:

--- a/.github/workflows/utilites.check.yml
+++ b/.github/workflows/utilites.check.yml
@@ -1,10 +1,9 @@
 name: Check Gini Utilites
 on:
-  push:
+  pull_request:
+   types: [opened, reopened, synchronize, ready_for_review]
    paths:
       - 'GiniComponents/GiniUtilites/**'
-   tags-ignore:
-      - '**'
   workflow_call:
   workflow_dispatch:
 


### PR DESCRIPTION
- the `edited` type was removed because we don't want to trigger the flows when the pr title or description is modified.
- `tags-ignore` does not apply to `workflow_dispatch` or `pull_request`