### PR TITLE
fix(GiniCaptureSDK): Use unexpected error for 404 upload failure

### DIFF
--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Error/ErrorType.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Error/ErrorType.swift
@@ -44,11 +44,10 @@ import GiniBankAPILibrary
             self = .authentication
         case .noInternetConnection:
             self = .connection
-        case .noResponse:
+        case .noResponse, .notFound:
             self = .unexpected
         case .notAcceptable, .tooManyRequests,
-             .parseError, .badRequest,
-             .notFound:
+             .parseError, .badRequest:
             self = .request
         case .server:
             self = .serverError


### PR DESCRIPTION
When a 404 error occurs on the invoice preview screen, the error message displayed is misleading. It does not correctly convey that the document is unavailable, which may cause confusion for users.
- decision: Use unexpected error for 404 upload failure
- 
PP-998