### PR TITLE
fix(GiniBankSDKExample): Fix button overlap on main screen for specific small-screen devices

### DIFF
--- a/BankSDK/GiniBankSDKExample/GiniBankSDKExample/Utils/Device.swift
+++ b/BankSDK/GiniBankSDKExample/GiniBankSDKExample/Utils/Device.swift
@@ -9,6 +9,7 @@ import UIKit
 
 class Device {
     static var small: Bool {
-        return UIScreen.main.bounds.width <= 320
+        let screenHeight = UIScreen.main.bounds.height
+        return screenHeight <= 667 // Targets iPhone SE 1st Gen, 6/7/8, SE 2nd Gen
     }
 }


### PR DESCRIPTION
- Adjust layout to prevent the Transaction list button from overlapping with the `Photopayment` button on small-screen devices (e.g., iPhone SE, 6/7/8) PP-1057