### PR TITLE
Pp 1099 transfer summary for instant payment

### DIFF
--- a/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/GiniBankConfiguration.swift
+++ b/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/GiniBankConfiguration.swift
@@ -651,18 +651,18 @@ public final class GiniBankConfiguration: NSObject {
                                           entity: "amount",
                                           value: amountToPayString,
                                           name: "amountToPay")
-        let instantPayment = Extraction(box: nil,
-                                        candidates: nil,
-                                        entity: "instantPayment",
-                                        value: instantPayment,
-                                        name: "instantPayment")
+        let instantPaymentExtraction = Extraction(box: nil,
+                                                  candidates: nil,
+                                                  entity: "instantPayment",
+                                                  value: instantPayment,
+                                                  name: "instantPayment")
         return [paymentRecipientExtraction,
                 paymentReferenceExtraction,
                 paymentPurposeExtraction,
                 ibanExtraction,
                 bicExtraction,
                 amountExtraction,
-                instantPayment]
+                instantPaymentExtraction]
     }
     // swiftlint:enable function_parameter_count
 

--- a/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/GiniBankConfiguration.swift
+++ b/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/GiniBankConfiguration.swift
@@ -537,7 +537,6 @@ public final class GiniBankConfiguration: NSObject {
      - iban: iban description
      - bic: bic description
      - amountToPay: amountToPay description
-     - instantPayment: instantPayment description
      */
 
     // swiftlint:disable line_length
@@ -550,8 +549,7 @@ public final class GiniBankConfiguration: NSObject {
                         paymentPurpose: String,
                         iban: String,
                         bic: String,
-                        amountToPay: ExtractionAmount,
-                        instantPayment: String) {
+                        amountToPay: ExtractionAmount) {
         guard let documentService = documentService else { return }
 
         let updatedExtractions = generateBasicExtractions(paymentRecipient: paymentRecipient,
@@ -559,8 +557,7 @@ public final class GiniBankConfiguration: NSObject {
                                                           paymentPurpose: paymentPurpose,
                                                           iban: iban,
                                                           bic: bic,
-                                                          amountToPayString: amountToPay.formattedString(),
-                                                          instantPayment: instantPayment)
+                                                          amountToPayString: amountToPay.formattedString())
 
         if let lineItems = lineItems {
             documentService.sendFeedback(with: updatedExtractions,
@@ -595,6 +592,7 @@ public final class GiniBankConfiguration: NSObject {
         - iban: iban description
         - bic: bic description
         - amountToPay: amountToPay description
+        - instantPayment: instantPayment description
      */
     // swiftlint:disable function_parameter_count
     public func sendTransferSummary(paymentRecipient: String,
@@ -603,7 +601,7 @@ public final class GiniBankConfiguration: NSObject {
                                     iban: String,
                                     bic: String,
                                     amountToPay: ExtractionAmount,
-                                    instantPayment: String) {
+                                    instantPayment: String? = nil) {
         let updatedExtractions = generateBasicExtractions(paymentRecipient: paymentRecipient,
                                                           paymentReference: paymentReference,
                                                           paymentPurpose: paymentPurpose,
@@ -615,12 +613,12 @@ public final class GiniBankConfiguration: NSObject {
     }
 
     internal func generateBasicExtractions(paymentRecipient: String,
-                                          paymentReference: String,
-                                          paymentPurpose: String,
-                                          iban: String,
-                                          bic: String,
-                                          amountToPayString: String,
-                                          instantPayment: String) -> [Extraction] {
+                                           paymentReference: String,
+                                           paymentPurpose: String,
+                                           iban: String,
+                                           bic: String,
+                                           amountToPayString: String,
+                                           instantPayment: String? = nil) -> [Extraction] {
         let paymentRecipientExtraction = Extraction(box: nil,
                                                     candidates: nil,
                                                     entity: "companyname",
@@ -651,18 +649,25 @@ public final class GiniBankConfiguration: NSObject {
                                           entity: "amount",
                                           value: amountToPayString,
                                           name: "amountToPay")
-        let instantPaymentExtraction = Extraction(box: nil,
-                                                  candidates: nil,
-                                                  entity: "instantPayment",
-                                                  value: instantPayment,
-                                                  name: "instantPayment")
-        return [paymentRecipientExtraction,
-                paymentReferenceExtraction,
-                paymentPurposeExtraction,
-                ibanExtraction,
-                bicExtraction,
-                amountExtraction,
-                instantPaymentExtraction]
+
+        var extractions = [paymentRecipientExtraction,
+                           paymentReferenceExtraction,
+                           paymentPurposeExtraction,
+                           ibanExtraction,
+                           bicExtraction,
+                           amountExtraction]
+
+        if let instantPayment {
+            let instantPaymentExtraction = Extraction(box: nil,
+                                                      candidates: nil,
+                                                      entity: "instantPayment",
+                                                      value: instantPayment,
+                                                      name: "instantPayment")
+
+            extractions.append(instantPaymentExtraction)
+        }
+
+        return extractions
     }
     // swiftlint:enable function_parameter_count
 

--- a/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/GiniBankConfiguration.swift
+++ b/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/GiniBankConfiguration.swift
@@ -586,13 +586,13 @@ public final class GiniBankConfiguration: NSObject {
      - Send the transfer summary after TAN verification and provide the extraction values the user has used.
 
      - Parameters:
-        - paymentRecipient: paymentRecipient description
-        - paymentReference: paymentReference description
-        - paymentPurpose: paymentPurpose description
-        - iban: iban description
-        - bic: bic description
-        - amountToPay: amountToPay description
-        - instantPayment: instantPayment description
+        - paymentRecipient: The name of the recipient to whom the payment is being made.
+        - paymentReference: A reference string used to identify the payment transaction.
+        - paymentPurpose: A brief description of the purpose of the payment.
+        - iban: The International Bank Account Number of the recipient.
+        - bic: The Bank Identifier Code associated with the recipient’s bank.
+        - amountToPay: The amount to be transferred, including currency information.
+        - instantPayment: A Boolean value indicating whether the payment should be processed as an instant payment.
      */
     // swiftlint:disable function_parameter_count
     public func sendTransferSummary(paymentRecipient: String,
@@ -601,7 +601,7 @@ public final class GiniBankConfiguration: NSObject {
                                     iban: String,
                                     bic: String,
                                     amountToPay: ExtractionAmount,
-                                    instantPayment: String? = nil) {
+                                    instantPayment: Bool? = nil) {
         let updatedExtractions = generateBasicExtractions(paymentRecipient: paymentRecipient,
                                                           paymentReference: paymentReference,
                                                           paymentPurpose: paymentPurpose,
@@ -618,7 +618,7 @@ public final class GiniBankConfiguration: NSObject {
                                            iban: String,
                                            bic: String,
                                            amountToPayString: String,
-                                           instantPayment: String? = nil) -> [Extraction] {
+                                           instantPayment: Bool? = nil) -> [Extraction] {
         let paymentRecipientExtraction = Extraction(box: nil,
                                                     candidates: nil,
                                                     entity: "companyname",
@@ -658,10 +658,11 @@ public final class GiniBankConfiguration: NSObject {
                            amountExtraction]
 
         if let instantPayment {
+            let instantPaymentString = instantPayment ? "true" : "false"
             let instantPaymentExtraction = Extraction(box: nil,
                                                       candidates: nil,
                                                       entity: "instantPayment",
-                                                      value: instantPayment,
+                                                      value: instantPaymentString,
                                                       name: "instantPayment")
 
             extractions.append(instantPaymentExtraction)

--- a/BankSDK/GiniBankSDK/Tests/GiniBankSDKTests/TransferSummary/TransferSummaryExtractionsTests.swift
+++ b/BankSDK/GiniBankSDK/Tests/GiniBankSDKTests/TransferSummary/TransferSummaryExtractionsTests.swift
@@ -66,9 +66,10 @@ class TransferSummaryExtractionsTests: XCTestCase {
 
     // MARK: - Tests
 
-    func test_generateBasicExtractions_returnsCorrectExtractions() {
+    func testGenerateBasicExtractionsReturnsCorrectExtractions() {
         let amount = ExtractionAmount(value: 99.99, currency: .EUR)
-        let input = ExtractionInput(paymentRecipient: "Test AG",
+        let paymentRecipientName = "Otto"
+        let input = ExtractionInput(paymentRecipient: paymentRecipientName,
                                     paymentReference: "REF-001",
                                     paymentPurpose: "Invoice March",
                                     iban: "DE89370400440532013000",
@@ -79,12 +80,12 @@ class TransferSummaryExtractionsTests: XCTestCase {
         let extractions = generateExtractions(from: input)
 
         XCTAssertEqual(extractions.count, 7)
-        assertExtractionExists(extractions, name: Field.paymentRecipient, value: "Test AG")
+        assertExtractionExists(extractions, name: Field.paymentRecipient, value: paymentRecipientName)
         assertExtractionExists(extractions, name: Field.amountToPay, value: amount.formattedString())
         assertExtractionExists(extractions, name: Field.instantPayment, value: "false")
     }
 
-    func test_generateBasicExtractions_withEmptyStrings() {
+    func testGenerateBasicExtractionsWithEmptyStrings() {
         let input = ExtractionInput(paymentRecipient: "",
                                     paymentReference: "",
                                     paymentPurpose: "",
@@ -99,8 +100,8 @@ class TransferSummaryExtractionsTests: XCTestCase {
         XCTAssertTrue(extractions.allSatisfy { $0.value == "" })
     }
 
-    func test_generateBasicExtractions_withInvalidIbanFormat() {
-        let input = ExtractionInput(paymentRecipient: "Acme Inc",
+    func testGenerateBasicExtractionsWithInvalidIbanFormat() {
+        let input = ExtractionInput(paymentRecipient: "Bonprix",
                                     paymentReference: "INV123",
                                     paymentPurpose: "Payment",
                                     iban: "INVALID_IBAN",
@@ -114,11 +115,11 @@ class TransferSummaryExtractionsTests: XCTestCase {
         XCTAssertFalse(input.iban.hasPrefix("DE"), "IBAN should normally start with 'DE' in Germany")
     }
 
-    func test_generateBasicExtractions_fieldCoverage() {
+    func testGenerateBasicExtractionsFieldCoverage() {
         let amount = ExtractionAmount(value: 50.00, currency: .EUR)
-        let input = ExtractionInput(paymentRecipient: "Test AG",
+        let input = ExtractionInput(paymentRecipient: "Tchibo",
                                     paymentReference: "REF-321",
-                                    paymentPurpose: "Rent",
+                                    paymentPurpose: "Payment for coffee",
                                     iban: "DE44500105175407324931",
                                     bic: "INGDDEFFXXX",
                                     amount: amount.formattedString(),
@@ -139,7 +140,7 @@ class TransferSummaryExtractionsTests: XCTestCase {
         }
     }
 
-    func test_generateBasicExtractions_valueMapping() {
+    func testGenerateBasicExtractionsValueMapping() {
         let input = ExtractionInput(paymentRecipient: "Some Company",
                                     paymentReference: "Ref-0001",
                                     paymentPurpose: "Consulting Services",

--- a/BankSDK/GiniBankSDK/Tests/GiniBankSDKTests/TransferSummary/TransferSummaryExtractionsTests.swift
+++ b/BankSDK/GiniBankSDK/Tests/GiniBankSDKTests/TransferSummary/TransferSummaryExtractionsTests.swift
@@ -1,0 +1,166 @@
+//
+//  TransferSummaryExtractionsTests.swift
+//
+//  Copyright © 2025 Gini GmbH. All rights reserved.
+//
+
+
+import XCTest
+@testable import GiniBankSDK
+@testable import GiniCaptureSDK
+@testable import GiniBankAPILibrary
+
+class TransferSummaryExtractionsTests: XCTestCase {
+
+    let config = GiniBankConfiguration.shared
+
+    struct ExtractionInput {
+        var paymentRecipient: String
+        var paymentReference: String
+        var paymentPurpose: String
+        var iban: String
+        var bic: String
+        var amount: String
+        var instantPayment: String
+    }
+
+    private func generateExtractions(from input: ExtractionInput) -> [Extraction] {
+        return config.generateBasicExtractions(paymentRecipient: input.paymentRecipient,
+                                               paymentReference: input.paymentReference,
+                                               paymentPurpose: input.paymentPurpose,
+                                               iban: input.iban,
+                                               bic: input.bic,
+                                               amountToPayString: input.amount,
+                                               instantPayment: input.instantPayment)
+    }
+
+    private func assertExtractionExists(_ extractions: [Extraction],
+                                        name: String,
+                                        value: String? = nil,
+                                        entity: String? = nil) {
+        let match = extractions.first(where: { $0.name == name && (value == nil || $0.value == value) && (entity == nil || $0.entity == entity) })
+        XCTAssertNotNil(match, "Expected extraction with name '\(name)', value '\(value ?? "*")', entity '\(entity ?? "*")' not found")
+    }
+
+    // MARK: - Field + Entity Constants
+
+    enum Field {
+        static let paymentRecipient = "paymentRecipient"
+        static let paymentReference = "paymentReference"
+        static let paymentPurpose = "paymentPurpose"
+        static let iban = "iban"
+        static let bic = "bic"
+        static let amountToPay = "amountToPay"
+        static let instantPayment = "instantPayment"
+    }
+
+    enum Entity {
+        static let companyName = "companyname"
+        static let reference = "reference"
+        static let text = "text"
+        static let iban = "iban"
+        static let bic = "bic"
+        static let amount = "amount"
+        static let instantPayment = "instantPayment"
+    }
+
+    // MARK: - Tests
+
+    func test_generateBasicExtractions_returnsCorrectExtractions() {
+        let amount = ExtractionAmount(value: 99.99, currency: .EUR)
+        let input = ExtractionInput(paymentRecipient: "Test AG",
+                                    paymentReference: "REF-001",
+                                    paymentPurpose: "Invoice March",
+                                    iban: "DE89370400440532013000",
+                                    bic: "COBADEFFXXX",
+                                    amount: amount.formattedString(),
+                                    instantPayment: "false")
+
+        let extractions = generateExtractions(from: input)
+
+        XCTAssertEqual(extractions.count, 7)
+        assertExtractionExists(extractions, name: Field.paymentRecipient, value: "Test AG")
+        assertExtractionExists(extractions, name: Field.amountToPay, value: amount.formattedString())
+        assertExtractionExists(extractions, name: Field.instantPayment, value: "false")
+    }
+
+    func test_generateBasicExtractions_withEmptyStrings() {
+        let input = ExtractionInput(paymentRecipient: "",
+                                    paymentReference: "",
+                                    paymentPurpose: "",
+                                    iban: "",
+                                    bic: "",
+                                    amount: "",
+                                    instantPayment: "")
+
+        let extractions = generateExtractions(from: input)
+
+        XCTAssertEqual(extractions.count, 7)
+        XCTAssertTrue(extractions.allSatisfy { $0.value == "" })
+    }
+
+    func test_generateBasicExtractions_withInvalidIbanFormat() {
+        let input = ExtractionInput(paymentRecipient: "Acme Inc",
+                                    paymentReference: "INV123",
+                                    paymentPurpose: "Payment",
+                                    iban: "INVALID_IBAN",
+                                    bic: "DEUTDEFF",
+                                    amount: "123.00",
+                                    instantPayment: "false")
+
+        let extractions = generateExtractions(from: input)
+
+        assertExtractionExists(extractions, name: Field.iban, value: "INVALID_IBAN")
+        XCTAssertFalse(input.iban.hasPrefix("DE"), "IBAN should normally start with 'DE' in Germany")
+    }
+
+    func test_generateBasicExtractions_fieldCoverage() {
+        let amount = ExtractionAmount(value: 50.00, currency: .EUR)
+        let input = ExtractionInput(paymentRecipient: "Test AG",
+                                    paymentReference: "REF-321",
+                                    paymentPurpose: "Rent",
+                                    iban: "DE44500105175407324931",
+                                    bic: "INGDDEFFXXX",
+                                    amount: amount.formattedString(),
+                                    instantPayment: "true")
+
+        let extractions = generateExtractions(from: input)
+
+        let expectedFields = [(Field.paymentRecipient, Entity.companyName),
+                              (Field.paymentReference, Entity.reference),
+                              (Field.paymentPurpose, Entity.text),
+                              (Field.iban, Entity.iban),
+                              (Field.bic, Entity.bic),
+                              (Field.amountToPay, Entity.amount),
+                              (Field.instantPayment, Entity.instantPayment)]
+
+        for (name, entity) in expectedFields {
+            assertExtractionExists(extractions, name: name, entity: entity)
+        }
+    }
+
+    func test_generateBasicExtractions_valueMapping() {
+        let input = ExtractionInput(paymentRecipient: "Some Company",
+                                    paymentReference: "Ref-0001",
+                                    paymentPurpose: "Consulting Services",
+                                    iban: "DE00123456780000000000",
+                                    bic: "BANKDEFFXXX",
+                                    amount: "123.45",
+                                    instantPayment: "true")
+
+        let extractions = generateExtractions(from: input)
+
+        let expectedValues = [(Field.paymentRecipient, input.paymentRecipient),
+                              (Field.paymentReference, input.paymentReference),
+                              (Field.paymentPurpose, input.paymentPurpose),
+                              (Field.iban, input.iban),
+                              (Field.bic, input.bic),
+                              (Field.amountToPay, input.amount),
+                              (Field.instantPayment, input.instantPayment)]
+
+        for (name, value) in expectedValues {
+            assertExtractionExists(extractions, name: name, value: value)
+        }
+    }
+}
+

--- a/BankSDK/GiniBankSDK/Tests/GiniBankSDKTests/TransferSummary/TransferSummaryExtractionsTests.swift
+++ b/BankSDK/GiniBankSDK/Tests/GiniBankSDKTests/TransferSummary/TransferSummaryExtractionsTests.swift
@@ -21,7 +21,7 @@ class TransferSummaryExtractionsTests: XCTestCase {
         var iban: String
         var bic: String
         var amount: String
-        var instantPayment: String
+        var instantPayment: Bool?
     }
 
     private func generateExtractions(from input: ExtractionInput) -> [Extraction] {
@@ -85,7 +85,7 @@ class TransferSummaryExtractionsTests: XCTestCase {
                                     iban: "DE89370400440532013000",
                                     bic: "COBADEFFXXX",
                                     amount: amount.formattedString(),
-                                    instantPayment: "false")
+                                    instantPayment: false)
 
         let extractions = generateExtractions(from: input)
 
@@ -101,12 +101,11 @@ class TransferSummaryExtractionsTests: XCTestCase {
                                     paymentPurpose: "",
                                     iban: "",
                                     bic: "",
-                                    amount: "",
-                                    instantPayment: "")
+                                    amount: "")
 
         let extractions = generateExtractions(from: input)
 
-        XCTAssertEqual(extractions.count, 7)
+        XCTAssertEqual(extractions.count, 6)
         XCTAssertTrue(extractions.allSatisfy { $0.value == "" })
     }
 
@@ -117,7 +116,7 @@ class TransferSummaryExtractionsTests: XCTestCase {
                                     iban: "INVALID_IBAN",
                                     bic: "DEUTDEFF",
                                     amount: "123.00",
-                                    instantPayment: "false")
+                                    instantPayment: false)
 
         let extractions = generateExtractions(from: input)
 
@@ -133,7 +132,7 @@ class TransferSummaryExtractionsTests: XCTestCase {
                                     iban: "DE44500105175407324931",
                                     bic: "INGDDEFFXXX",
                                     amount: amount.formattedString(),
-                                    instantPayment: "true")
+                                    instantPayment: true)
 
         let extractions = generateExtractions(from: input)
 
@@ -157,7 +156,7 @@ class TransferSummaryExtractionsTests: XCTestCase {
                                     iban: "DE00123456780000000000",
                                     bic: "BANKDEFFXXX",
                                     amount: "123.45",
-                                    instantPayment: "true")
+                                    instantPayment: true)
 
         let extractions = generateExtractions(from: input)
 
@@ -167,7 +166,7 @@ class TransferSummaryExtractionsTests: XCTestCase {
                               (Field.iban, input.iban),
                               (Field.bic, input.bic),
                               (Field.amountToPay, input.amount),
-                              (Field.instantPayment, input.instantPayment)]
+                              (Field.instantPayment, input.instantPayment == true ? "true" : "false")]
 
         for (name, value) in expectedValues {
             assertExtractionExists(extractions, name: name, value: value)

--- a/BankSDK/GiniBankSDK/Tests/GiniBankSDKTests/TransferSummary/TransferSummaryExtractionsTests.swift
+++ b/BankSDK/GiniBankSDK/Tests/GiniBankSDKTests/TransferSummary/TransferSummaryExtractionsTests.swift
@@ -38,8 +38,18 @@ class TransferSummaryExtractionsTests: XCTestCase {
                                         name: String,
                                         value: String? = nil,
                                         entity: String? = nil) {
-        let match = extractions.first(where: { $0.name == name && (value == nil || $0.value == value) && (entity == nil || $0.entity == entity) })
-        XCTAssertNotNil(match, "Expected extraction with name '\(name)', value '\(value ?? "*")', entity '\(entity ?? "*")' not found")
+        let match = extractions.first { extraction in
+            let nameMatches = extraction.name == name
+            let valueMatches = value == nil || extraction.value == value
+            let entityMatches = entity == nil || extraction.entity == entity
+            return nameMatches && valueMatches && entityMatches
+        }
+        let expectedMessage = """
+                              Expected extraction with name '\(name)', \
+                              value '\(value ?? "*")', \
+                              entity '\(entity ?? "*")' not found
+                              """
+        XCTAssertNotNil(match, expectedMessage)
     }
 
     // MARK: - Field + Entity Constants

--- a/BankSDK/GiniBankSDKExample/GiniBankSDKExample/Screen API/ScreenAPICoordinator.swift
+++ b/BankSDK/GiniBankSDKExample/GiniBankSDKExample/Screen API/ScreenAPICoordinator.swift
@@ -148,13 +148,15 @@ final class ScreenAPICoordinator: NSObject, Coordinator, UINavigationControllerD
         let paymentPurpose = extractedResults.first(where: { $0.name == "paymentPurpose"})?.value ?? ""
         let iban = extractedResults.first(where: { $0.name == "iban"})?.value ?? ""
         let bic = extractedResults.first(where: { $0.name == "bic"})?.value ?? ""
+        let instantPayment = extractedResults.first(where: { $0.name == "instantPayment"})?.value ?? ""
         let amoutToPay = extractionAmount
         configuration.sendTransferSummary(paymentRecipient: paymentRecipient,
                                           paymentReference: paymentReference,
                                           paymentPurpose: paymentPurpose,
                                           iban: iban,
                                           bic: bic,
-                                          amountToPay: amoutToPay)
+                                          amountToPay: amoutToPay,
+                                          instantPayment: instantPayment)
 
         // GiniBankSDK requires both `documentId` and `originalFileName`
         // to properly display attachment information in the transaction details screen.

--- a/BankSDK/GiniBankSDKExample/GiniBankSDKExample/Screen API/ScreenAPICoordinator.swift
+++ b/BankSDK/GiniBankSDKExample/GiniBankSDKExample/Screen API/ScreenAPICoordinator.swift
@@ -149,7 +149,11 @@ final class ScreenAPICoordinator: NSObject, Coordinator, UINavigationControllerD
         let paymentPurpose = extractedResults.first(where: { $0.name == "paymentPurpose"})?.value ?? ""
         let iban = extractedResults.first(where: { $0.name == "iban"})?.value ?? ""
         let bic = extractedResults.first(where: { $0.name == "bic"})?.value ?? ""
-        let instantPayment = extractedResults.first(where: { $0.name == "instantPayment"})?.value ?? ""
+
+        // `instantPayment` is currently a String, but it should be a Bool.
+        // In GiniSDK, this parameter must be a Boolean to restrict the possible values
+        // and ensure the correct data type is sent in the transfer summary to the backend.
+        let instantPaymentString = extractedResults.first(where: { $0.name == "instantPayment"})?.value ?? ""
         let amoutToPay = extractionAmount
         configuration.sendTransferSummary(paymentRecipient: paymentRecipient,
                                           paymentReference: paymentReference,
@@ -157,7 +161,7 @@ final class ScreenAPICoordinator: NSObject, Coordinator, UINavigationControllerD
                                           iban: iban,
                                           bic: bic,
                                           amountToPay: amoutToPay,
-                                          instantPayment: instantPayment)
+                                          instantPayment: instantPaymentString.lowercased() == "true")
 
         // GiniBankSDK requires both `documentId` and `originalFileName`
         // to properly display attachment information in the transaction details screen.

--- a/BankSDK/GiniBankSDKExample/Tests/IntegrationTests/Base/BaseIntegrationTest.swift
+++ b/BankSDK/GiniBankSDKExample/Tests/IntegrationTests/Base/BaseIntegrationTest.swift
@@ -137,6 +137,9 @@ class BaseIntegrationTest: XCTestCase {
                        result.extractions["bic"]?.value)
         XCTAssertEqual(fixtureContainer.extractions.first(where: { $0.name == "amountToPay" })?.value,
                        result.extractions["amountToPay"]?.value)
+        //TODO: I need to uncomment this when backend is ready
+//        XCTAssertEqual(fixtureContainer.extractions.first(where: { $0.name == "instantPayment" })?.value,
+//                       result.extractions["instantPayment"]?.value)
     }
 
     /*

--- a/BankSDK/GiniBankSDKExample/Tests/IntegrationTests/TransferSummary/BaseIntegrationTest+TransferSummary.swift
+++ b/BankSDK/GiniBankSDKExample/Tests/IntegrationTests/TransferSummary/BaseIntegrationTest+TransferSummary.swift
@@ -65,6 +65,10 @@ extension BaseIntegrationTest {
                        extractionsAfterFeedback.first(where: { $0.name == "bic" })?.value)
         XCTAssertEqual(fixtureExtractionsAfterFeedbackContainer.extractions.first(where: { $0.name == "amountToPay" })?.value,
                        extractionsAfterFeedback.first(where: { $0.name == "amountToPay" })?.value)
+        //TODO: I need to uncomment this when backend is ready
+//        XCTAssertEqual(fixtureExtractionsAfterFeedbackContainer.extractions.first(where: { $0.name == "instantPayment" })?.value,
+//                       extractionsAfterFeedback.first(where: { $0.name == "instantPayment" })?.value)
+
 
         // Validate line items if applicable
         let fixtureLineItems = fixtureExtractionsAfterFeedbackContainer.compoundExtractions?.lineItems

--- a/BankSDK/GiniBankSDKExample/Tests/IntegrationTests/TransferSummary/TransferSummaryIntegrationTest.swift
+++ b/BankSDK/GiniBankSDKExample/Tests/IntegrationTests/TransferSummary/TransferSummaryIntegrationTest.swift
@@ -41,6 +41,8 @@ class TransferSummaryIntegrationTest: BaseIntegrationTest {
         }
 
         func giniCaptureAnalysisDidFinishWith(result: AnalysisResult) {
+            let instantPaymentString = result.extractions["instantPayment"]?.value ?? ""
+            
             GiniBankConfiguration.shared.sendTransferSummary(
                 paymentRecipient: result.extractions["paymentRecipient"]?.value ?? "",
                 paymentReference: result.extractions["paymentReference"]?.value ?? "",
@@ -48,7 +50,7 @@ class TransferSummaryIntegrationTest: BaseIntegrationTest {
                 iban: result.extractions["iban"]?.value ?? "",
                 bic: result.extractions["bic"]?.value ?? "",
                 amountToPay: ExtractionAmount(value: 950.00, currency: .EUR),
-                instantPayment: result.extractions["instantPayment"]?.value ?? ""
+                instantPayment: instantPaymentString.lowercased() == "true"
             )
             
             let mockedInvoice = mockedInvoiceResultName

--- a/BankSDK/GiniBankSDKExample/Tests/IntegrationTests/TransferSummary/TransferSummaryIntegrationTest.swift
+++ b/BankSDK/GiniBankSDKExample/Tests/IntegrationTests/TransferSummary/TransferSummaryIntegrationTest.swift
@@ -47,7 +47,8 @@ class TransferSummaryIntegrationTest: BaseIntegrationTest {
                 paymentPurpose: result.extractions["paymentPurpose"]?.value ?? "",
                 iban: result.extractions["iban"]?.value ?? "",
                 bic: result.extractions["bic"]?.value ?? "",
-                amountToPay: ExtractionAmount(value: 950.00, currency: .EUR)
+                amountToPay: ExtractionAmount(value: 950.00, currency: .EUR),
+                instantPayment: result.extractions["instantPayment"]?.value ?? ""
             )
             
             let mockedInvoice = mockedInvoiceResultName

--- a/BankSDK/GiniBankSDKExample/Tests/Resources/TransferSummary/result_Gini_invoice_example_payment_reference.json
+++ b/BankSDK/GiniBankSDKExample/Tests/Resources/TransferSummary/result_Gini_invoice_example_payment_reference.json
@@ -13,6 +13,10 @@
       "entity": "text",
       "value": "true"
     },
+    "instantPayment": {
+        "entity": "text",
+        "value": "true"
+    },
     "paymentPurpose": {
       "entity": "text",
       "value": "3 941674010439",

--- a/BankSDK/GiniBankSDKExample/Tests/Resources/TransferSummary/result_Gini_invoice_example_payment_reference_after_feedback.json
+++ b/BankSDK/GiniBankSDKExample/Tests/Resources/TransferSummary/result_Gini_invoice_example_payment_reference_after_feedback.json
@@ -9,6 +9,10 @@
       "value": "KLARNA",
       "candidates": "paymentRecipients"
     },
+    "instantPayment": {
+        "entity": "text",
+        "value": "true"
+    },
     "amountsAreConsistent": {
       "entity": "text",
       "value": "true"

--- a/BankSDK/GiniBankSDKPinningExample/Tests/TransferSummaryIntegrationTest.swift
+++ b/BankSDK/GiniBankSDKPinningExample/Tests/TransferSummaryIntegrationTest.swift
@@ -102,6 +102,9 @@ class TransferSummaryIntegrationTest: XCTestCase {
                         result.extractions["bic"]?.value)
          XCTAssertEqual(fixtureExtractionsContainer.extractions.first(where: { $0.name == "amountToPay" })?.value,
                         result.extractions["amountToPay"]?.value)
+         //TODO: I need to uncomment this when backend is ready
+         //        XCTAssertEqual(fixtureContainer.extractions.first(where: { $0.name == "instantPayment" })?.value,
+         //                       result.extractions["instantPayment"]?.value)
 
          // 3. Assuming the user saw the following extractions:
          //    amountToPay, iban, bic, paymentPurpose and paymentRecipient
@@ -130,6 +133,9 @@ class TransferSummaryIntegrationTest: XCTestCase {
                                     extractionsAfterFeedback.first(where: { $0.name == "bic" })?.value)
                      XCTAssertEqual(fixtureExtractionsAfterFeedbackContainer.extractions.first(where: { $0.name == "amountToPay" })?.value,
                                     extractionsAfterFeedback.first(where: { $0.name == "amountToPay" })?.value)
+                        //TODO: I need to uncomment this when backend is ready
+                        //        XCTAssertEqual(fixtureExtractionsAfterFeedbackContainer.extractions.first(where: { $0.name == "instantPayment" })?.value,
+                        //                       extractionsAfterFeedback.first(where: { $0.name == "instantPayment" })?.value)
                      // 6. Free up resources after TAN verification
                      GiniBankConfiguration.shared.cleanup()
                      XCTAssertNil(GiniBankConfiguration.shared.documentService)
@@ -206,7 +212,8 @@ class TransferSummaryIntegrationTest: XCTestCase {
                                                                    paymentPurpose: extractions["paymentPurpose"]?.value ?? "",
                                                                    iban: extractions["iban"]?.value ?? "",
                                                                    bic: extractions["bic"]?.value ?? "",
-                                                                   amountToPay: ExtractionAmount(value: 950.00, currency: .EUR))
+                                                                   amountToPay: ExtractionAmount(value: 950.00, currency: .EUR),
+                                                                   instantPayment: extractions["instantPayment"]?.value ?? "")
                case let .failure(error):
                   XCTFail(String(describing: error))
                }

--- a/BankSDK/GiniBankSDKPinningExample/Tests/TransferSummaryIntegrationTest.swift
+++ b/BankSDK/GiniBankSDKPinningExample/Tests/TransferSummaryIntegrationTest.swift
@@ -207,13 +207,14 @@ class TransferSummaryIntegrationTest: XCTestCase {
                   delegate.giniCaptureAnalysisDidFinishWith(result: analysisResult)
                   // 4. Send transfer summary for the extractions the user saw
                   //    with the final (user confirmed or updated) extraction values
+                  let instantPaymentString = extractions["instantPayment"]?.value ?? ""
                   GiniBankConfiguration.shared.sendTransferSummary(paymentRecipient: extractions["paymentRecipient"]?.value ?? "",
                                                                    paymentReference: extractions["paymentReference"]?.value ?? "",
                                                                    paymentPurpose: extractions["paymentPurpose"]?.value ?? "",
                                                                    iban: extractions["iban"]?.value ?? "",
                                                                    bic: extractions["bic"]?.value ?? "",
                                                                    amountToPay: ExtractionAmount(value: 950.00, currency: .EUR),
-                                                                   instantPayment: extractions["instantPayment"]?.value ?? "")
+                                                                   instantPayment: instantPaymentString.lowercased() == "true")
                case let .failure(error):
                   XCTFail(String(describing: error))
                }


### PR DESCRIPTION
Transfer summary for Instant Payment:
- Add `instantPayment` property to transfer summary method
- Add unit tests for transfer summary extractions
- Adjust integration tests