### PR TITLE
PP-1097 Make `instantPayment` extraction editable in `TransactionSummary` screen

### DIFF
--- a/BankSDK/GiniBankSDKExample/GiniBankSDKExample/Screen API/ScreenAPICoordinator.swift
+++ b/BankSDK/GiniBankSDKExample/GiniBankSDKExample/Screen API/ScreenAPICoordinator.swift
@@ -57,7 +57,8 @@ final class ScreenAPICoordinator: NSObject, Coordinator, UINavigationControllerD
 											   "paymentPurpose" : "text",
 											   "iban" : "iban",
 											   "bic" : "bic",
-											   "amountToPay" : "amount"]
+											   "amountToPay" : "amount",
+                                               "instantPayment" : "instantPayment"]
 
     private let apiEnvironment: APIEnvironment
 


### PR DESCRIPTION
- The value of instant payment needs to be editable in the extractions screen of the demo app.
- Possible values should be "true" / "false".