### PR TITLE
fix(GiniBankSDKExample): Fix integration test for instant payment feature when the default value is false

### DIFF
--- a/BankSDK/GiniBankSDKExample/Tests/IntegrationTests/TransferSummary/TransferSummaryIntegrationTest.swift
+++ b/BankSDK/GiniBankSDKExample/Tests/IntegrationTests/TransferSummary/TransferSummaryIntegrationTest.swift
@@ -75,7 +75,8 @@ class TransferSummaryIntegrationTest: BaseIntegrationTest {
             // Call the updateAndVerifyTransferSummary method to handle the transfer summary update
             testCase.updateAndVerifyTransferSummary(result: result,
                                                     mockedInvoiceUpdatedResultName: mockedInvoiceResultAfterFeedbackName,
-                                                    expect: expect)
+                                                    expect: expect,
+                                                    verifyInstantPayment: verifyInstantPayment)
         }
 
         private func sentTransferSummery(result: AnalysisResult, verifyInstantPayment: Bool?) {

--- a/BankSDK/GiniBankSDKPinningExample/Tests/TransferSummaryIntegrationTest.swift
+++ b/BankSDK/GiniBankSDKPinningExample/Tests/TransferSummaryIntegrationTest.swift
@@ -102,8 +102,6 @@ class TransferSummaryIntegrationTest: XCTestCase {
                         result.extractions["bic"]?.value)
          XCTAssertEqual(fixtureExtractionsContainer.extractions.first(where: { $0.name == "amountToPay" })?.value,
                         result.extractions["amountToPay"]?.value)
-         XCTAssertEqual(fixtureExtractionsContainer.extractions.first(where: { $0.name == "instantPayment" })?.value,
-                        result.extractions["instantPayment"]?.value)
 
          // 3. Assuming the user saw the following extractions:
          //    amountToPay, iban, bic, paymentPurpose and paymentRecipient
@@ -132,8 +130,6 @@ class TransferSummaryIntegrationTest: XCTestCase {
                                     extractionsAfterFeedback.first(where: { $0.name == "bic" })?.value)
                      XCTAssertEqual(fixtureExtractionsAfterFeedbackContainer.extractions.first(where: { $0.name == "amountToPay" })?.value,
                                     extractionsAfterFeedback.first(where: { $0.name == "amountToPay" })?.value)
-                        XCTAssertEqual(fixtureExtractionsAfterFeedbackContainer.extractions.first(where: { $0.name == "instantPayment" })?.value,
-                                       extractionsAfterFeedback.first(where: { $0.name == "instantPayment" })?.value)
                      // 6. Free up resources after TAN verification
                      GiniBankConfiguration.shared.cleanup()
                      XCTAssertNil(GiniBankConfiguration.shared.documentService)


### PR DESCRIPTION
Add a missing condition for the default value of instant payment.
For now, for every case that is not instant payment detected on the invoice or is on the invoice but not check marked, we receive from CVIE it as false