### PR TITLE
Pp 1151 implement configuration flag qr code education message

### DIFF
--- a/BankAPILibrary/GiniBankAPILibrary/Sources/GiniBankAPILibrary/Documents/Configuration/ClientConfiguration.swift
+++ b/BankAPILibrary/GiniBankAPILibrary/Sources/GiniBankAPILibrary/Documents/Configuration/ClientConfiguration.swift
@@ -11,36 +11,44 @@ import Foundation
  A struct representing configuration settings.
  
  This struct holds various configuration options that can be used to customize the behavior and features.
+
+ Note: This configuration is intended for internal use with Gini SDKs only.
  */
 public struct ClientConfiguration: Codable {
-    /**
-     Creates a new `ClientConfiguration` instance.
 
-     - parameter clientID: A unique identifier for the client.
-     - parameter userJourneyAnalyticsEnabled: A flag indicating whether user journey analytics is enabled.
-     - parameter skontoEnabled: A flag indicating whether Skonto is enabled.
-     - parameter returnAssistantEnabled: A flag indicating whether the return assistant feature is enabled.
-     - parameter transactionDocsEnabled: A flag indicating whether TransactionDocs feature is enabled.
-     - parameter instantPaymentEnabled: A flag indicating whether Instant Payment feature is enabled.
-     */
-    public init(clientID: String,
-                userJourneyAnalyticsEnabled: Bool,
-                skontoEnabled: Bool,
-                returnAssistantEnabled: Bool,
-                transactionDocsEnabled: Bool,
-                instantPaymentEnabled: Bool) {
-        self.clientID = clientID
-        self.userJourneyAnalyticsEnabled = userJourneyAnalyticsEnabled
-        self.skontoEnabled = skontoEnabled
-        self.returnAssistantEnabled = returnAssistantEnabled
-        self.transactionDocsEnabled = transactionDocsEnabled
-        self.instantPaymentEnabled = instantPaymentEnabled
-    }
-    
     public let clientID: String
     public let userJourneyAnalyticsEnabled: Bool
     public let skontoEnabled: Bool
     public let returnAssistantEnabled: Bool
     public let transactionDocsEnabled: Bool
     public let instantPaymentEnabled: Bool
+    public let qrCodeEducationEnabled: Bool
+
+    /**
+     Creates a new `ClientConfiguration` instance.
+
+     - Parameters:
+        - clientID: A unique identifier for the client.
+        - userJourneyAnalyticsEnabled: A flag indicating whether user journey analytics is enabled.
+        - skontoEnabled: A flag indicating whether Skonto is enabled.
+        - returnAssistantEnabled: A flag indicating whether the return assistant feature is enabled.
+        - transactionDocsEnabled: A flag indicating whether TransactionDocs feature is enabled.
+        - instantPaymentEnabled: A flag indicating whether Instant Payment feature is enabled.
+        - qrCodeEducationEnabled: A flag indicating whether QR code education is enabled.
+     */
+    public init(clientID: String,
+                userJourneyAnalyticsEnabled: Bool,
+                skontoEnabled: Bool,
+                returnAssistantEnabled: Bool,
+                transactionDocsEnabled: Bool,
+                instantPaymentEnabled: Bool,
+                qrCodeEducationEnabled: Bool) {
+        self.clientID = clientID
+        self.userJourneyAnalyticsEnabled = userJourneyAnalyticsEnabled
+        self.skontoEnabled = skontoEnabled
+        self.returnAssistantEnabled = returnAssistantEnabled
+        self.transactionDocsEnabled = transactionDocsEnabled
+        self.instantPaymentEnabled = instantPaymentEnabled
+        self.qrCodeEducationEnabled = qrCodeEducationEnabled
+    }
 }

--- a/BankAPILibrary/GiniBankAPILibrary/Sources/GiniBankAPILibrary/Documents/Configuration/ClientConfiguration.swift
+++ b/BankAPILibrary/GiniBankAPILibrary/Sources/GiniBankAPILibrary/Documents/Configuration/ClientConfiguration.swift
@@ -12,7 +12,7 @@ import Foundation
  
  This struct holds various configuration options that can be used to customize the behavior and features.
 
- Note: This configuration is intended for internal use with Gini SDKs only.
+ Note: This configuration is intended for internal use in Gini SDKs only.
  */
 public struct ClientConfiguration: Codable {
 

--- a/BankAPILibrary/GiniBankAPILibrary/Tests/GiniBankAPILibraryTests/ClientConfigurationTests.swift
+++ b/BankAPILibrary/GiniBankAPILibrary/Tests/GiniBankAPILibraryTests/ClientConfigurationTests.swift
@@ -19,7 +19,8 @@ final class ClientConfigurationTests: XCTestCase {
                                          skontoEnabled: true,
                                          returnAssistantEnabled: true,
                                          transactionDocsEnabled: true,
-                                         instantPaymentEnabled: true)
+                                         instantPaymentEnabled: true,
+                                         qrCodeEducationEnabled: true)
 
         XCTAssertEqual(config.clientID, testClientID)
         XCTAssertTrue(config.userJourneyAnalyticsEnabled)
@@ -27,6 +28,7 @@ final class ClientConfigurationTests: XCTestCase {
         XCTAssertTrue(config.returnAssistantEnabled)
         XCTAssertTrue(config.transactionDocsEnabled)
         XCTAssertTrue(config.instantPaymentEnabled)
+        XCTAssertTrue(config.qrCodeEducationEnabled)
     }
 
     func testDecodingFromValidJSON() throws {
@@ -40,10 +42,12 @@ final class ClientConfigurationTests: XCTestCase {
         XCTAssertTrue(config.returnAssistantEnabled)
         XCTAssertFalse(config.transactionDocsEnabled)
         XCTAssertFalse(config.instantPaymentEnabled)
+        XCTAssertFalse(config.qrCodeEducationEnabled)
     }
 
     func testDecodingFailsWhenMissingRequiredField() {
-        XCTAssertThrowsError(try JSONDecoder().decode(ClientConfiguration.self, from: clientConfigurationMissingJson)) { error in
+        XCTAssertThrowsError(try JSONDecoder().decode(ClientConfiguration.self,
+                                                      from: clientConfigurationMissingJson)) { error in
             print("Expected decoding error: \(error)")
         }
     }

--- a/BankAPILibrary/GiniBankAPILibrary/Tests/GiniBankAPILibraryTests/Resources/clientConfiguration.json
+++ b/BankAPILibrary/GiniBankAPILibrary/Tests/GiniBankAPILibraryTests/Resources/clientConfiguration.json
@@ -4,5 +4,6 @@
     "skontoEnabled": true,
     "returnAssistantEnabled": true,
     "transactionDocsEnabled": false,
-    "instantPaymentEnabled": false
+    "instantPaymentEnabled": false,
+    "qrCodeEducationEnabled": false
 }

--- a/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/GiniBankNetworkingScreenApiCoordinator.swift
+++ b/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/GiniBankNetworkingScreenApiCoordinator.swift
@@ -272,7 +272,7 @@ open class GiniBankNetworkingScreenApiCoordinator: GiniScreenAPICoordinator, Gin
     public func startSDK(withDocuments documents: [GiniCaptureDocument]?, animated: Bool = false) -> UIViewController {
         Self.currentCoordinator = self
         setupAnalytics(withDocuments: documents)
-        configurationService?.fetchConfigurations(completion: { result in
+        configurationService?.fetchConfigurations { result in
             switch result {
             case .success(let configuration):
                 DispatchQueue.main.async {
@@ -285,8 +285,8 @@ open class GiniBankNetworkingScreenApiCoordinator: GiniScreenAPICoordinator, Gin
                 // We will not implement any caching mechanism on our side if the request is too slow.
                 // In case of a failure, the UJ analytics will remain disabled for that session.
             }
-        })
-        return self.start(withDocuments: documents, animated: animated)
+        }
+        return start(withDocuments: documents, animated: animated)
     }
 
     public static func closeSDK() {
@@ -334,7 +334,7 @@ private extension GiniBankNetworkingScreenApiCoordinator {
 
     private func sendAnalyticsEventSDKClose() {
         GiniAnalyticsManager.track(event: .sdkClosed,
-                                   properties: [GiniAnalyticsProperty(key: .status, 
+                                   properties: [GiniAnalyticsProperty(key: .status,
                                                                       value: "successful")])
     }
 

--- a/BankSDK/GiniBankSDKExample/Tests/IntegrationTests/ClientConfiguration/ClientConfigurationTests.swift
+++ b/BankSDK/GiniBankSDKExample/Tests/IntegrationTests/ClientConfiguration/ClientConfigurationTests.swift
@@ -93,5 +93,6 @@ class ClientConfigurationTests: BaseIntegrationTest {
         XCTAssertNotNil(configuration.returnAssistantEnabled, "returnAssistantEnabled should be present")
         XCTAssertNotNil(configuration.transactionDocsEnabled, "transactionDocsEnabled should be present")
         XCTAssertNotNil(configuration.instantPaymentEnabled, "instantPaymentEnabled should be present")
+        XCTAssertNotNil(configuration.qrCodeEducationEnabled, "qrCodeEducationEnabled should be present")
     }
 }


### PR DESCRIPTION
This pull request introduces a new boolean flag in the `ClientConfiguration` object. The flag allows us to control whether the QR code education message should be displayed.

The flag value is retrieved via the `/configurations` API endpoint.