### PR TITLE
Pp 1241 invoice edge case education concept

### DIFF
--- a/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/GiniBankNetworkingScreenApiCoordinator.swift
+++ b/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/GiniBankNetworkingScreenApiCoordinator.swift
@@ -368,8 +368,10 @@ private extension GiniBankNetworkingScreenApiCoordinator {
 
     private func handleSuccessfulAnalysis(with extractionResult: ExtractionResult,
                                           networkDelegate: GiniCaptureNetworkDelegate) {
-        DispatchQueue.main.async {
-            if let analysisViewController = self.screenAPINavigationController.children.last as? AnalysisViewController {
+        DispatchQueue.main.async { [weak self] in
+            guard let self else { return }
+            let lastViewControllerInNavigationStack = self.screenAPINavigationController.children.last
+            if let analysisViewController = lastViewControllerInNavigationStack as? AnalysisViewController {
                 analysisViewController.performWhenAnimationCompleted {
                     self.presentNextScreen(after: extractionResult, networkDelegate: networkDelegate)
                 }

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/EducationFlow/EducationFlowController.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/EducationFlow/EducationFlowController.swift
@@ -34,9 +34,11 @@ final class EducationFlowController {
         }
 
         let messageIndex = currentCount % configuration.numberOfMessages
-
-        configuration.setDisplayCount(currentCount + 1)
-
         return .showMessage(messageIndex: messageIndex)
+    }
+
+    func markMessageAsShown() {
+        let currentCount = configuration.getDisplayCount()
+        configuration.setDisplayCount(currentCount + 1)
     }
 }

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/EducationFlow/EducationFlowState.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/EducationFlow/EducationFlowState.swift
@@ -10,7 +10,7 @@
  specifies which message to display (e.g., 0 for first message, 1 for second message).
  - showOriginalFlow: Indicates that the original flow (e.g., spinning wheel) should be shown.
  */
-enum EducationFlowState {
+enum EducationFlowState: Equatable {
     case showMessage(messageIndex: Int)
     case showOriginalFlow
 }

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Analysis/AnalysisViewController.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Analysis/AnalysisViewController.swift
@@ -216,7 +216,8 @@ import Combine
     }
 
     private func configureLoadingIndicator() {
-        let controller = EducationFlowController.qrCodeFlowController(displayIfNeeded: !document.isImported)
+        let displayEducationFlow = !document.isImported && giniConfiguration.fileImportSupportedTypes != .none
+        let controller = EducationFlowController.qrCodeFlowController(displayIfNeeded: displayEducationFlow)
 
         let nextState = controller.nextState()
         switch nextState {

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Analysis/AnalysisViewController.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Analysis/AnalysisViewController.swift
@@ -44,6 +44,7 @@ import Combine
 
     private var animationCompletedSubject = CurrentValueSubject<Bool, Never>(false)
     private var anymationCancellables = Set<AnyCancellable>()
+    private var educationFlowController: EducationFlowController?
 
     // User interface
     private var imageView: UIImageView = {
@@ -217,13 +218,15 @@ import Combine
 
     private func configureLoadingIndicator() {
         let displayEducationFlow = !document.isImported && giniConfiguration.fileImportSupportedTypes != .none
-        let controller = EducationFlowController.qrCodeFlowController(displayIfNeeded: displayEducationFlow)
+        educationFlowController = EducationFlowController.qrCodeFlowController(displayIfNeeded: displayEducationFlow)
 
-        let nextState = controller.nextState()
+        let nextState = educationFlowController?.nextState()
         switch nextState {
         case .showMessage:
             showEducationLoadingMessage()
         case .showOriginalFlow:
+            showOriginalLoadingMessage()
+        case .none:
             showOriginalLoadingMessage()
         }
     }
@@ -290,6 +293,7 @@ import Combine
                 .filter { $0 }
                 .prefix(1)
                 .sink { _ in
+                    self.educationFlowController?.markMessageAsShown()
                     action()
                 }
                 .store(in: &anymationCancellables)

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Storage/GiniCaptureUserDefaultsStorage.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Storage/GiniCaptureUserDefaultsStorage.swift
@@ -5,7 +5,6 @@
 //
 
 import Foundation
-import GiniBankAPILibrary
 
 /**
     This is for internal use only.

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Resources/en.lproj/Localizable.strings
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Resources/en.lproj/Localizable.strings
@@ -109,7 +109,7 @@
 "ginicapture.analysis.defaultPdfDokumentTitle" = "PDF document";
 "ginicapture.analysis.education.loadingText" = "analyzing";
 "ginicapture.analysis.education.intro" = "In case you didn’t know...";
-"ginicapture.analysis.education.photo" = "Upload PDFs, images, or GIFs.";
+"ginicapture.analysis.education.photo" = "Upload PDFs, images, or GIFs";
 
 "ginicapture.help.openWithTutorial.title" = "Open documents from other apps";
 

--- a/CaptureSDK/GiniCaptureSDK/Tests/GiniCaptureSDKTests/EducationFlowControllerTests.swift
+++ b/CaptureSDK/GiniCaptureSDK/Tests/GiniCaptureSDKTests/EducationFlowControllerTests.swift
@@ -1,0 +1,135 @@
+//
+//  EducationFlowControllerTests.swift
+//
+//  Copyright © 2025 Gini GmbH. All rights reserved.
+//
+
+import XCTest
+@testable import GiniCaptureSDK
+
+final class EducationFlowControllerTests: XCTestCase {
+
+    func testNextStateReturnsShowOriginalFlowWhenShouldNotBeDisplayed() {
+        let config = EducationFlowConfiguration(
+            maxTotalDisplays: 3,
+            numberOfMessages: 2,
+            shouldBeDisplayed: { false },
+            getDisplayCount: { 0 },
+            setDisplayCount: { _ in }
+        )
+
+        let controller = EducationFlowController(configuration: config)
+        let state = controller.nextState()
+        XCTAssertEqual(state,
+                       .showOriginalFlow,
+                       "Expected .showOriginalFlow when shouldBeDisplayed is false.")
+    }
+
+    func testNextStateWithSingleMessage() {
+        let config = EducationFlowConfiguration(
+            maxTotalDisplays: 2,
+            numberOfMessages: 1,
+            shouldBeDisplayed: { true },
+            getDisplayCount: { 1 }, // 1 % 1 = 0
+            setDisplayCount: { _ in }
+        )
+
+        let controller = EducationFlowController(configuration: config)
+        let state = controller.nextState()
+
+        XCTAssertEqual(state,
+                       .showMessage(messageIndex: 0),
+                       "Expected messageIndex 0 when there's only one message.")
+    }
+
+
+    func testNextStateReturnsShowOriginalFlowWhenDisplayLimitReached() {
+        let config = EducationFlowConfiguration(
+            maxTotalDisplays: 3,
+            numberOfMessages: 2,
+            shouldBeDisplayed: { true },
+            getDisplayCount: { 3 },
+            setDisplayCount: { _ in }
+        )
+
+        let controller = EducationFlowController(configuration: config)
+        let state = controller.nextState()
+        XCTAssertEqual(state,
+                       .showOriginalFlow,
+                       "Expected .showOriginalFlow when display count reaches maxTotalDisplays.")
+    }
+
+    func testNextStateReturnsCorrectMessageIndex() {
+        let config = EducationFlowConfiguration(
+            maxTotalDisplays: 5,
+            numberOfMessages: 3,
+            shouldBeDisplayed: { true },
+            getDisplayCount: { 4 },
+            setDisplayCount: { _ in }
+        )
+
+        let controller = EducationFlowController(configuration: config)
+        let state = controller.nextState()
+        XCTAssertEqual(state,
+                       .showMessage(messageIndex: 1),
+                       "Expected .showMessage with messageIndex 1 when displayCount is 4 and numberOfMessages is 3.")
+    }
+
+    func testMarkMessageAsShownIncrementsDisplayCount() {
+        var displayCount = 2
+        let config = EducationFlowConfiguration(
+            maxTotalDisplays: 5,
+            numberOfMessages: 3,
+            shouldBeDisplayed: { true },
+            getDisplayCount: { displayCount },
+            setDisplayCount: { newCount in displayCount = newCount }
+        )
+
+        let controller = EducationFlowController(configuration: config)
+        controller.markMessageAsShown()
+
+        XCTAssertEqual(displayCount, 3, "Expected displayCount to be incremented to 3 after markMessageAsShown()")
+    }
+
+    func testNextStateReturnsShowOriginalFlowWhenDisplayCountExceedsMaxTotalDisplays() {
+        let config = EducationFlowConfiguration(
+            maxTotalDisplays: 3,
+            numberOfMessages: 2,
+            shouldBeDisplayed: { true },
+            getDisplayCount: { 5 },
+            setDisplayCount: { _ in
+                XCTFail("setDisplayCount should not be called when over maxTotalDisplays")
+            }
+        )
+
+        let controller = EducationFlowController(configuration: config)
+        let state = controller.nextState()
+
+        XCTAssertEqual(state,
+                       .showOriginalFlow,
+                       "Expected .showOriginalFlow when displayCount exceeds maxTotalDisplays.")
+    }
+
+    func testNextStateReturnsMessageWhenDisplayCountIsOneBelowLimit() {
+        var newDisplayCount: Int?
+
+        let config = EducationFlowConfiguration(
+            maxTotalDisplays: 3,
+            numberOfMessages: 2,
+            shouldBeDisplayed: { true },
+            getDisplayCount: { 2 },
+            setDisplayCount: { newDisplayCount = $0 }
+        )
+
+        let controller = EducationFlowController(configuration: config)
+        let state = controller.nextState()
+        controller.markMessageAsShown()
+
+        XCTAssertEqual(state,
+                       .showMessage(messageIndex: 0),
+                       "Expected messageIndex 0 when displayCount is 2.")
+        XCTAssertEqual(newDisplayCount,
+                       3,
+                       "Expected displayCount to be incremented to 3.")
+    }
+}


### PR DESCRIPTION
Improves education message logic based on`fileImportSupportedTypes` and error handling

- Do not show any education message when DocumentImportEnabledFileTypes is NONE; fallback to the original loading indicator.
- Show the invoice education message ("Upload PDFs, images, or GIFs") when import types are enabled.
- On capture processing error, do not delay the response to ensure education message visibility. In this case, we do not mark the education message as "seen" by the user.
- In the case of the "No results" flow, we should display the education message for the full duration (4.5 seconds) before showing the "No results" screen.