### PR TITLE
ci: Add checks when publish to firebase flow is triggered

### DIFF
--- a/.github/workflows/bank-api-library.build.docs.yml
+++ b/.github/workflows/bank-api-library.build.docs.yml
@@ -1,6 +1,7 @@
 name: Builds docs for Bank API Library
 
 on:
+  workflow_call:
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/bank-api-library.build.docs.yml
+++ b/.github/workflows/bank-api-library.build.docs.yml
@@ -1,10 +1,6 @@
 name: Builds docs for Bank API Library
 
 on:
-  pull_request:
-    types: [opened, reopened, synchronize, ready_for_review]
-    paths:
-      - 'BankAPILibrary/**'
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/bank-api-library.check.yml
+++ b/.github/workflows/bank-api-library.check.yml
@@ -1,10 +1,5 @@
 name: Check Bank API Library
 on:
-  pull_request:
-    types: [opened, reopened, synchronize, ready_for_review]
-    paths:
-      - 'BankAPILibrary/**'
-
   workflow_call:
     secrets:
       GINI_MOBILE_TEST_CLIENT_SECRET:

--- a/.github/workflows/bank-sdk.build.docs.yml
+++ b/.github/workflows/bank-sdk.build.docs.yml
@@ -1,10 +1,6 @@
 name: Builds docs for Bank SDK
 
 on:
-  pull_request:
-    types: [opened, reopened, synchronize, ready_for_review]
-    paths:
-      - 'BankSDK/**'
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/bank-sdk.build.docs.yml
+++ b/.github/workflows/bank-sdk.build.docs.yml
@@ -1,7 +1,9 @@
 name: Builds docs for Bank SDK
 
 on:
+  workflow_call:
   workflow_dispatch:
+
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/bank-sdk.check.yml
+++ b/.github/workflows/bank-sdk.check.yml
@@ -1,11 +1,5 @@
 name: Check Bank SDK
 on:
-  pull_request:
-    types: [opened, reopened, synchronize, ready_for_review]
-    paths:
-      - 'BankSDK/**'
-      - 'CaptureSDK/**'
-      - 'BankAPILibrary/**'
   workflow_call:
     secrets:
       GINI_MOBILE_TEST_CLIENT_SECRET:

--- a/.github/workflows/bank-sdk.publish.example.app.firebase.yml
+++ b/.github/workflows/bank-sdk.publish.example.app.firebase.yml
@@ -21,8 +21,6 @@ jobs:
   check-bank-api-libray-docs:
     needs: check-bank-api-libray
     uses: ./.github/workflows/bank-api-library.build.docs.yml
-    secrets:
-      GINI_MOBILE_TEST_CLIENT_SECRET: ${{ secrets.GINI_MOBILE_TEST_CLIENT_SECRET }}
 
   check-capture:
     needs: check-bank-api-libray-docs
@@ -33,8 +31,6 @@ jobs:
   check-capture-docs:
     needs: check-capture
     uses: ./.github/workflows/capture-sdk.build.docs.yml
-    secrets:
-      GINI_MOBILE_TEST_CLIENT_SECRET: ${{ secrets.GINI_MOBILE_TEST_CLIENT_SECRET }}
     
   check-bank:
     needs: check-capture-docs
@@ -45,12 +41,10 @@ jobs:
   check-bank-docs:
     needs: check-bank
     uses: ./.github/workflows/bank-sdk.build.docs.yml
-    secrets:
-      GINI_MOBILE_TEST_CLIENT_SECRET: ${{ secrets.GINI_MOBILE_TEST_CLIENT_SECRET }}
 
 
   upload-version:
-    needs: check-bank
+    needs: check-bank-docs
     runs-on: macos-latest    
     steps:
       - name: Checkout repository

--- a/.github/workflows/bank-sdk.publish.example.app.firebase.yml
+++ b/.github/workflows/bank-sdk.publish.example.app.firebase.yml
@@ -17,18 +17,21 @@ jobs:
     uses: ./.github/workflows/bank-api-library.check.yml
     secrets:
       GINI_MOBILE_TEST_CLIENT_SECRET: ${{ secrets.GINI_MOBILE_TEST_CLIENT_SECRET }}
-  check-bank:
-    uses: ./.github/workflows/bank-sdk.check.yml
-    secrets:
-      GINI_MOBILE_TEST_CLIENT_SECRET: ${{ secrets.GINI_MOBILE_TEST_CLIENT_SECRET }}
-
+    
   check-capture:
+    needs: check-bank-api-librray
     uses: ./.github/workflows/capture-sdk.check.yml
     secrets:
       GINI_MOBILE_TEST_CLIENT_SECRET: ${{ secrets.GINI_MOBILE_TEST_CLIENT_SECRET }}
 
+  check-bank:
+    needs: check-capture
+    uses: ./.github/workflows/bank-sdk.check.yml
+    secrets:
+      GINI_MOBILE_TEST_CLIENT_SECRET: ${{ secrets.GINI_MOBILE_TEST_CLIENT_SECRET }}
+
   upload-version:
-    needs: [check-bank-api-librray, check-bank, check-capture]
+    needs: check-bank
     runs-on: macos-latest    
     steps:
       - name: Checkout repository

--- a/.github/workflows/bank-sdk.publish.example.app.firebase.yml
+++ b/.github/workflows/bank-sdk.publish.example.app.firebase.yml
@@ -13,7 +13,22 @@ concurrency:
   cancel-in-progress: ${{ !contains(github.ref, 'refs/tags/')}}
 
 jobs:
+  check-bank-api-librray:
+    uses: ./.github/workflows/bank-api-library.check.yml
+    secrets:
+      GINI_MOBILE_TEST_CLIENT_SECRET: ${{ secrets.GINI_MOBILE_TEST_CLIENT_SECRET }}
+  check-bank:
+    uses: ./.github/workflows/bank-sdk.check.yml
+    secrets:
+      GINI_MOBILE_TEST_CLIENT_SECRET: ${{ secrets.GINI_MOBILE_TEST_CLIENT_SECRET }}
+
+  check-capture:
+    uses: ./.github/workflows/capture-sdk.check.yml
+    secrets:
+      GINI_MOBILE_TEST_CLIENT_SECRET: ${{ secrets.GINI_MOBILE_TEST_CLIENT_SECRET }}
+
   upload-version:
+    needs: [check-bank-api-librray, check-bank, check-capture]
     runs-on: macos-latest    
     steps:
       - name: Checkout repository

--- a/.github/workflows/bank-sdk.publish.example.app.firebase.yml
+++ b/.github/workflows/bank-sdk.publish.example.app.firebase.yml
@@ -13,22 +13,41 @@ concurrency:
   cancel-in-progress: ${{ !contains(github.ref, 'refs/tags/')}}
 
 jobs:
-  check-bank-api-librray:
+  check-bank-api-libray:
     uses: ./.github/workflows/bank-api-library.check.yml
     secrets:
       GINI_MOBILE_TEST_CLIENT_SECRET: ${{ secrets.GINI_MOBILE_TEST_CLIENT_SECRET }}
     
+  check-bank-api-libray-docs:
+    needs: check-bank-api-libray
+    uses: ./.github/workflows/bank-api-library.build.docs.yml
+    secrets:
+      GINI_MOBILE_TEST_CLIENT_SECRET: ${{ secrets.GINI_MOBILE_TEST_CLIENT_SECRET }}
+
   check-capture:
-    needs: check-bank-api-librray
+    needs: check-bank-api-libray-docs
     uses: ./.github/workflows/capture-sdk.check.yml
     secrets:
       GINI_MOBILE_TEST_CLIENT_SECRET: ${{ secrets.GINI_MOBILE_TEST_CLIENT_SECRET }}
 
-  check-bank:
+  check-capture-docs:
     needs: check-capture
+    uses: ./.github/workflows/capture-sdk.build.docs.yml
+    secrets:
+      GINI_MOBILE_TEST_CLIENT_SECRET: ${{ secrets.GINI_MOBILE_TEST_CLIENT_SECRET }}
+    
+  check-bank:
+    needs: check-capture-docs
     uses: ./.github/workflows/bank-sdk.check.yml
     secrets:
       GINI_MOBILE_TEST_CLIENT_SECRET: ${{ secrets.GINI_MOBILE_TEST_CLIENT_SECRET }}
+
+  check-bank-docs:
+    needs: check-bank
+    uses: ./.github/workflows/bank-sdk.build.docs.yml
+    secrets:
+      GINI_MOBILE_TEST_CLIENT_SECRET: ${{ secrets.GINI_MOBILE_TEST_CLIENT_SECRET }}
+
 
   upload-version:
     needs: check-bank

--- a/.github/workflows/capture-sdk.build.docs.yml
+++ b/.github/workflows/capture-sdk.build.docs.yml
@@ -2,10 +2,6 @@ name: Builds docs for Capture SDK
 
 on:
   workflow_dispatch:
-  pull_request:
-    types: [opened, reopened, synchronize, ready_for_review]
-    paths:
-      - 'CaptureSDK/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/capture-sdk.build.docs.yml
+++ b/.github/workflows/capture-sdk.build.docs.yml
@@ -1,6 +1,7 @@
 name: Builds docs for Capture SDK
 
 on:
+  workflow_call:
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/capture-sdk.check.yml
+++ b/.github/workflows/capture-sdk.check.yml
@@ -1,10 +1,5 @@
 name: Check Capture SDK
 on:
-  pull_request:
-    types: [opened, reopened, synchronize, ready_for_review]
-    paths:
-      - 'CaptureSDK/**'
-      - 'BankAPILibrary/**'
   workflow_call:
     secrets:
       GINI_MOBILE_TEST_CLIENT_SECRET:

--- a/BankSDK/GiniBankSDKExample/GiniBankSDKExample/DemoViewController.swift
+++ b/BankSDK/GiniBankSDKExample/GiniBankSDKExample/DemoViewController.swift
@@ -160,7 +160,9 @@ final class DemoViewController: UIViewController {
                                   dark: giniCaptureColor("Light01")).uiColor()
         transactionListButton.setTitleColor(textColor, for: .normal)
         transactionListButton.accessibilityIdentifier = MainScreenAccessibilityIdentifiers.transactionListButton.rawValue
-        transactionListButton.addTarget(self, action: #selector(transactionListButtonTapped), for: .touchUpInside)
+        transactionListButton.addTarget(self,
+                                        action: #selector(transactionListButtonTapped),
+                                        for: .touchUpInside)
     }
 
     private func configureScreenDescriptionTitle() {

--- a/BankSDK/GiniBankSDKExample/GiniBankSDKExample/DemoViewController.swift
+++ b/BankSDK/GiniBankSDKExample/GiniBankSDKExample/DemoViewController.swift
@@ -160,9 +160,7 @@ final class DemoViewController: UIViewController {
                                   dark: giniCaptureColor("Light01")).uiColor()
         transactionListButton.setTitleColor(textColor, for: .normal)
         transactionListButton.accessibilityIdentifier = MainScreenAccessibilityIdentifiers.transactionListButton.rawValue
-        transactionListButton.addTarget(self,
-                                        action: #selector(transactionListButtonTapped),
-                                        for: .touchUpInside)
+        transactionListButton.addTarget(self, action: #selector(transactionListButtonTapped), for: .touchUpInside)
     }
 
     private func configureScreenDescriptionTitle() {


### PR DESCRIPTION
Remove triggers when the pr is opened, reopened, synchronize, ready_for_review from checks, and added in the publish to the Firebase flow.