### PR TITLE
Pp 1244 skonto help screen screen bottom bar back button is too close to the edge landscape_tes

### DIFF
--- a/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/ReturnAssistant/DigitalInvoice/DigitalInvoiceViewController.swift
+++ b/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/ReturnAssistant/DigitalInvoice/DigitalInvoiceViewController.swift
@@ -52,10 +52,10 @@ final class DigitalInvoiceViewController: UIViewController {
         proceedView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
         proceedView.heightAnchor.constraint(greaterThanOrEqualToConstant: Constants.buttonContainerHeight),
         proceedView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
-        tableView.bottomAnchor.constraint(equalTo: proceedView.topAnchor),
+        tableView.bottomAnchor.constraint(equalTo: proceedView.topAnchor)
     ]
     private lazy var proceedViewTableConstraints: [NSLayoutConstraint] = [
-        tableView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+        tableView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
     ]
 
     init(viewModel: DigitalInvoiceViewModel) {
@@ -98,9 +98,14 @@ final class DigitalInvoiceViewController: UIViewController {
     }
 
     private func setupConstraints() {
-        NSLayoutConstraint.activate([
-            tableView.topAnchor.constraint(equalTo: view.topAnchor, constant: Constants.padding),
-        ] + proceedViewConstraints)
+        let tableViewTopConstraint = tableView.topAnchor.constraint(equalTo: view.topAnchor,
+                                                                    constant: Constants.padding)
+        var constraints: [NSLayoutConstraint] = []
+
+        constraints.append(tableViewTopConstraint)
+        constraints.append(contentsOf: proceedViewConstraints)
+
+        NSLayoutConstraint.activate(constraints)
 
         if UIDevice.current.isIpad {
             NSLayoutConstraint.activate([
@@ -177,7 +182,10 @@ final class DigitalInvoiceViewController: UIViewController {
                     proceedView.removeFromSuperview()
 
                     // frame is mandatory for tableview footer view, since it doesn't use autolayout, which means we have to specify size
-                    let container = UIView(frame: CGRect(x: 0, y: 0, width: view.bounds.width, height: Constants.buttonContainerHeight + Constants.padding))
+                    let container = UIView(frame: CGRect(x: 0,
+                                                         y: 0,
+                                                         width: view.bounds.width,
+                                                         height: Constants.buttonContainerHeight + Constants.padding))
                     container.addSubview(proceedView)
                     NSLayoutConstraint.activate([
                         proceedView.leadingAnchor.constraint(equalTo: container.leadingAnchor),

--- a/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/Skonto/Help/BottomNavigation/DefaultSkontoHelpNavigationBottomBar.swift
+++ b/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/Skonto/Help/BottomNavigation/DefaultSkontoHelpNavigationBottomBar.swift
@@ -39,6 +39,6 @@ final class DefaultSkontoHelpNavigationBottomBar: UIView {
 
 private extension DefaultSkontoHelpNavigationBottomBar {
     enum Constants {
-        static let horizontalPadding: CGFloat = 8
+        static let horizontalPadding: CGFloat = 16
     }
 }

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Camera/Views/CameraBottomNavigationBar.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Camera/Views/CameraBottomNavigationBar.swift
@@ -25,7 +25,8 @@ class CameraBottomNavigationBar: UIView {
 
     override func layoutSubviews() {
         super.layoutSubviews()
-        heightConstraint.constant = currentInterfaceOrientation.isLandscape ? Constants.heightLandscape : CameraBottomNavigationBar.Constants.heightPortrait
+        let isLandscape = currentInterfaceOrientation.isLandscape
+        heightConstraint.constant = isLandscape ? Constants.heightLandscape : CameraBottomNavigationBar.Constants.heightPortrait
     }
 
     func setupView() {


### PR DESCRIPTION
Fix bottom back button spacing in Skonto Help (landscape)
Adjusted the navigation bar height to include the safe area bottom inset in landscape orientation. This prevents the back button from appearing too close to the screen edge. Also, constraint handling was refactored for clarity and safety.

**Tested on the following devices:**
- iPhoneSE first gen(iOS15.0)
- iPhone 8(iOS 16.1)
- iPhone 15 Pro(iOS 17.0.3)
- iPhone 16Pro Max(iOs18.3)
- iPad Air(5th gen, iOS 18.)

