### PR TITLE
Pp 1311 skonto screen bottom bar missing when switching from portrait to landscape

### DIFF
--- a/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/Skonto/BottomNavigation/DefaultSkontoBottomNavigationBar.swift
+++ b/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/Skonto/BottomNavigation/DefaultSkontoBottomNavigationBar.swift
@@ -419,7 +419,7 @@ final class DefaultSkontoBottomNavigationBar: UIView {
 extension DefaultSkontoBottomNavigationBar {
     private enum Constants {
         static let padding: CGFloat = 16
-        static let landscapePadding: CGFloat = 56
+        static let landscapePadding: CGFloat = UIDevice.current.isSmallIphone ? 16 : 56
         static let verticalPadding: CGFloat = 16
         static let proceedButtonTopPadding: CGFloat = 20
         static let proceedButtonHeight: CGFloat = 50

--- a/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/Skonto/BottomNavigation/DefaultSkontoBottomNavigationBar.swift
+++ b/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/Skonto/BottomNavigation/DefaultSkontoBottomNavigationBar.swift
@@ -154,7 +154,7 @@ final class DefaultSkontoBottomNavigationBar: UIView {
         self.backAction = backAction
         self.helpAction = helpAction
         super.init(frame: .zero)
-        updateLayoutForCurrentOrientation()
+        updatePhoneLayoutForCurrentOrientation()
     }
 
     required init?(coder: NSCoder) {
@@ -163,12 +163,11 @@ final class DefaultSkontoBottomNavigationBar: UIView {
 
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
-        updateLayoutForCurrentOrientation()
+        guard UIDevice.current.isIphone else { return }
+        updatePhoneLayoutForCurrentOrientation()
     }
 
-    private func updateLayoutForCurrentOrientation() {
-        guard UIDevice.current.isIphone else { return }
-
+    private func updatePhoneLayoutForCurrentOrientation() {
         let isLandscape = UIDevice.current.isLandscape
 
         subviews.forEach { $0.removeFromSuperview() }

--- a/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/Skonto/BottomNavigation/DefaultSkontoBottomNavigationBar.swift
+++ b/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/Skonto/BottomNavigation/DefaultSkontoBottomNavigationBar.swift
@@ -176,28 +176,55 @@ final class DefaultSkontoBottomNavigationBar: UIView {
     private func setupConstraints() {
         let multiplier: CGFloat = UIDevice.current.isIpad ? Constants.tabletWidthMultiplier : 1.0
 
+        setupContentViewConstraints(multiplier: multiplier)
+        setupDividerViewConstraints()
+        setupTotalAmountSectionConstraints()
+        setupSkontoBadgeConstraints()
+        setupSavingsAmountConstraints()
+        setupNavigationButtonsConstraints()
+        setupProceedButtonConstraints()
+    }
+
+    private func setupContentViewConstraints(multiplier: CGFloat) {
         NSLayoutConstraint.activate([
             contentView.centerXAnchor.constraint(equalTo: centerXAnchor),
             contentView.widthAnchor.constraint(equalTo: widthAnchor, multiplier: multiplier),
-            contentView.topAnchor.constraint(equalTo: topAnchor),
+            contentView.topAnchor.constraint(equalTo: topAnchor)
+        ])
+    }
 
+    private func setupDividerViewConstraints() {
+        NSLayoutConstraint.activate([
             dividerView.topAnchor.constraint(equalTo: contentView.topAnchor),
             dividerView.leadingAnchor.constraint(equalTo: leadingAnchor),
             dividerView.trailingAnchor.constraint(equalTo: trailingAnchor),
-            dividerView.heightAnchor.constraint(equalToConstant: Constants.dividerViewHeight),
+            dividerView.heightAnchor.constraint(equalToConstant: Constants.dividerViewHeight)
+        ])
+    }
 
+    private func setupTotalAmountSectionConstraints() {
+        NSLayoutConstraint.activate([
             totalAmountStackView.topAnchor.constraint(equalTo: contentView.topAnchor, constant: Constants.padding),
-            totalAmountStackView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: Constants.padding),
+            totalAmountStackView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor,
+                                                          constant: Constants.padding),
             totalAmountStackView.trailingAnchor.constraint(lessThanOrEqualTo: skontoBadgeView.leadingAnchor,
-                                                           constant: -Constants.badgeHorizontalPadding),
+                                                           constant: -Constants.badgeHorizontalPadding)
+        ])
+    }
 
+    private func setupSavingsAmountConstraints() {
+        NSLayoutConstraint.activate([
             savingsAmountLabel.topAnchor.constraint(equalTo: totalValueLabel.bottomAnchor,
-                                                  constant: Constants.savingsAmountLabelTopPadding),
+                                                    constant: Constants.savingsAmountLabelTopPadding),
             savingsAmountLabel.leadingAnchor.constraint(equalTo: totalValueLabel.leadingAnchor),
             savingsAmountLabel.trailingAnchor.constraint(lessThanOrEqualTo: contentView.trailingAnchor,
                                                          constant: -Constants.padding),
-            savingsAmountLabel.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
+            savingsAmountLabel.bottomAnchor.constraint(equalTo: contentView.bottomAnchor)
+        ])
+    }
 
+    private func setupSkontoBadgeConstraints() {
+        NSLayoutConstraint.activate([
             skontoBadgeView.centerYAnchor.constraint(equalTo: totalLabel.centerYAnchor),
             skontoBadgeView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor,
                                                       constant: -Constants.padding),
@@ -209,16 +236,24 @@ final class DefaultSkontoBottomNavigationBar: UIView {
             skontoBadgeLabel.leadingAnchor.constraint(equalTo: skontoBadgeView.leadingAnchor,
                                                       constant: Constants.badgeHorizontalPadding),
             skontoBadgeLabel.trailingAnchor.constraint(equalTo: skontoBadgeView.trailingAnchor,
-                                                       constant: -Constants.badgeHorizontalPadding),
+                                                       constant: -Constants.badgeHorizontalPadding)
+        ])
+    }
 
+    private func setupNavigationButtonsConstraints() {
+        NSLayoutConstraint.activate([
             backButton.buttonView.leadingAnchor.constraint(equalTo: leadingAnchor,
                                                            constant: Constants.padding),
             backButton.buttonView.centerYAnchor.constraint(equalTo: proceedButton.centerYAnchor),
 
             helpButton.buttonView.trailingAnchor.constraint(equalTo: trailingAnchor,
-                                                           constant: -Constants.padding),
-            helpButton.buttonView.centerYAnchor.constraint(equalTo: proceedButton.centerYAnchor),
+                                                            constant: -Constants.padding),
+            helpButton.buttonView.centerYAnchor.constraint(equalTo: proceedButton.centerYAnchor)
+        ])
+    }
 
+    private func setupProceedButtonConstraints() {
+        NSLayoutConstraint.activate([
             proceedButton.topAnchor.constraint(equalTo: contentView.bottomAnchor,
                                                constant: Constants.proceedButtonTopPadding),
             proceedButton.leadingAnchor.constraint(equalTo: backButton.buttonView.trailingAnchor),
@@ -230,7 +265,7 @@ final class DefaultSkontoBottomNavigationBar: UIView {
             proceedButton.heightAnchor.constraint(equalToConstant: Constants.proceedButtonHeight)
         ])
     }
-
+    
     @objc private func proceedButtonClicked() {
         proceedAction?()
     }

--- a/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/Skonto/Help/BottomNavigation/DefaultSkontoHelpNavigationBottomBar.swift
+++ b/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/Skonto/Help/BottomNavigation/DefaultSkontoHelpNavigationBottomBar.swift
@@ -33,7 +33,8 @@ final class DefaultSkontoHelpNavigationBottomBar: UIView {
             backButton.buttonView.trailingAnchor.constraint(lessThanOrEqualTo: trailingAnchor),
             backButton.buttonView.bottomAnchor.constraint(equalTo: bottomAnchor)
         ])
-        backgroundColor = GiniColor(light: UIColor.GiniBank.light1, dark: UIColor.GiniBank.dark1).uiColor()
+        backgroundColor = GiniColor(light: UIColor.GiniBank.light1,
+                                    dark: UIColor.GiniBank.dark1).uiColor()
     }
 }
 

--- a/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/Skonto/Help/SkontoHelpViewController.swift
+++ b/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/Skonto/Help/SkontoHelpViewController.swift
@@ -190,7 +190,7 @@ private extension SkontoHelpViewController {
     enum Constants {
         static let padding: CGFloat = 16
         static let spacing: CGFloat = 32
-        static let navigationBarHeightPortrait: CGFloat = 114
+        static let navigationBarHeightPortrait: CGFloat = UIDevice.current.isSmallIphone ? 72 : 114
         static let navigationBarHeightLandscape: CGFloat = UIDevice.current.isSmallIphone ? 40 : 62
     }
 }

--- a/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/Skonto/Help/Views/SkontoHelpItemView.swift
+++ b/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/Skonto/Help/Views/SkontoHelpItemView.swift
@@ -55,7 +55,7 @@ final class SkontoHelpItemView: UIView {
         isAccessibilityElement = true
         accessibilityLabel = text
     }
-    
+
     private func setupConstraints() {
         NSLayoutConstraint.activate([
             iconImageView.topAnchor.constraint(greaterThanOrEqualTo: topAnchor,

--- a/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/Skonto/SkontoViewController.swift
+++ b/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/Skonto/SkontoViewController.swift
@@ -99,10 +99,15 @@ final class SkontoViewController: UIViewController {
         proceedContainerView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
     ]
     private lazy var scrollViewBottomToViewConstraint = scrollView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
-    private lazy var scrollViewBottomToProceedViewTop = scrollView.bottomAnchor.constraint(equalTo: proceedContainerView.topAnchor)
+
+    private lazy var scrollViewBottomToProceedViewTop = scrollView.bottomAnchor
+        .constraint(equalTo: proceedContainerView.topAnchor)
     private var contentStackViewWidth: CGFloat {
-        (-2 * Constants.containerPadding) - (view.safeAreaInsets.left + view.safeAreaInsets.right) - (2*Constants.scrollViewSideInset)
+        let horizontalSafeAreaInsets = view.safeAreaInsets.left + view.safeAreaInsets.right
+        let totalPadding = 2 * Constants.containerPadding + 2 * Constants.scrollViewSideInset
+        return -totalPadding - horizontalSafeAreaInsets
     }
+
     private var scrollViewLandscapeIphoneContentInsets: UIEdgeInsets {
         UIEdgeInsets(top: Constants.containerPadding,
                      left: 0,
@@ -149,8 +154,15 @@ final class SkontoViewController: UIViewController {
         sendAnalyticsScreenShown()
     }
 
-    override func viewDidLayoutSubviews() {
-        super.viewDidLayoutSubviews()
+    override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
+        super.viewWillTransition(to: size, with: coordinator)
+
+        coordinator.animate(alongsideTransition: { _ in
+            self.adjustLayoutForCurrentOrientation()
+        }, completion: nil)
+    }
+
+    func adjustLayoutForCurrentOrientation() {
         stackViewWidthConstraint.constant = contentStackViewWidth
         if UIDevice.current.isIphone {
             let isLandscape = view.currentInterfaceOrientation.isLandscape
@@ -464,7 +476,7 @@ extension SkontoViewController {
         let contentOffsetY = max(0, targetFrameInScrollView.maxY - scrollView.bounds.height + keyboardOffsetOverProceedView)
         UIView.animate(withDuration: animationDuration) {
             self.scrollView.contentInset.bottom = keyboardHeight
-            self.scrollView.scrollIndicatorInsets.bottom = keyboardHeight
+            self.scrollView.verticalScrollIndicatorInsets.bottom = keyboardHeight
             self.scrollView.setContentOffset(CGPoint(x: 0, y: contentOffsetY), animated: true)
         }
     }
@@ -477,7 +489,7 @@ extension SkontoViewController {
 
         UIView.animate(withDuration: animationDuration) {
             self.scrollView.contentInset.bottom = Constants.containerPadding
-            self.scrollView.scrollIndicatorInsets.bottom = Constants.scrollIndicatorInset
+            self.scrollView.verticalScrollIndicatorInsets.bottom = Constants.scrollIndicatorInset
         }
     }
 }

--- a/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/Skonto/SkontoViewController.swift
+++ b/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/Skonto/SkontoViewController.swift
@@ -238,7 +238,7 @@ final class SkontoViewController: UIViewController {
         removeExistingBottomComponents()
 
         if configuration.bottomNavigationBarEnabled {
-            if let _ = bottomNavigationBar as? DefaultSkontoBottomNavigationBar {
+            if bottomNavigationBar is DefaultSkontoBottomNavigationBar {
                 setupBottomNavigationBarInLandscape()
             } else {
                 setupCustomBottomNavigationBarInLandscape()
@@ -293,17 +293,21 @@ final class SkontoViewController: UIViewController {
     }
 
     private func setupProceedContainerInLandscape() {
-        attachProceedContainerViewIfNeeded()
-
-        updateScrollViewBottomToViewConstraint(to: proceedContainerView.topAnchor)
+        guard proceedContainerView.superview != view else { return }
+        proceedContainerView.removeFromSuperview()
+        NSLayoutConstraint.deactivate(proceedContainerConstraints)
+        mainStackView.addArrangedSubview(proceedContainerView)
+        NSLayoutConstraint.activate([
+            proceedContainerView.leadingAnchor.constraint(equalTo: mainStackView.leadingAnchor),
+            proceedContainerView.trailingAnchor.constraint(equalTo: mainStackView.trailingAnchor)
+        ])
     }
 
     private func attachProceedContainerViewIfNeeded() {
         guard proceedContainerView.superview != view else { return }
 
         view.addSubview(proceedContainerView)
-        proceedContainerView.translatesAutoresizingMaskIntoConstraints = false
-        NSLayoutConstraint.activate(proceedContainerConstraints)
+        setupProceedContainerViewConstraints()
     }
 
     // MARK: - Portrait specific layout
@@ -327,6 +331,10 @@ final class SkontoViewController: UIViewController {
             pinToBottom(customBar, to: view)
             updateScrollViewBottomToViewConstraint(to: customBar.topAnchor)
         } else {
+            if mainStackView.arrangedSubviews.contains(proceedContainerView) {
+                mainStackView.removeArrangedSubview(proceedContainerView)
+                proceedContainerView.removeFromSuperview()
+            }
             attachProceedContainerViewIfNeeded()
 
             scrollViewBottomToProceedViewTop = scrollView.bottomAnchor
@@ -413,6 +421,7 @@ final class SkontoViewController: UIViewController {
     }
 
     private func setupProceedContainerViewConstraints() {
+        proceedContainerView.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate(proceedContainerConstraints)
     }
 

--- a/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/Skonto/SkontoViewController.swift
+++ b/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/Skonto/SkontoViewController.swift
@@ -69,7 +69,6 @@ final class SkontoViewController: UIViewController {
         scrollView.translatesAutoresizingMaskIntoConstraints = false
         scrollView.showsVerticalScrollIndicator = false
         scrollView.showsHorizontalScrollIndicator = false
-        scrollView.contentInset = scrollViewContentInset
         return scrollView
     }()
 
@@ -111,16 +110,6 @@ final class SkontoViewController: UIViewController {
         return -totalPadding - horizontalSafeAreaInsets
     }
 
-    private var scrollViewLandscapeIphoneContentInsets: UIEdgeInsets {
-        UIEdgeInsets(top: Constants.containerPadding,
-                     left: 0,
-                     bottom: 0,
-                     right: 0)
-    }
-    private let scrollViewContentInset = UIEdgeInsets(top: Constants.containerPadding,
-                                                      left: 0,
-                                                      bottom: Constants.containerPadding,
-                                                      right: 0)
     private let viewModel: SkontoViewModel
     private let alertFactory: SkontoAlertFactory
     private let configuration = GiniBankConfiguration.shared
@@ -157,19 +146,18 @@ final class SkontoViewController: UIViewController {
         sendAnalyticsScreenShown()
     }
 
-    override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
+    override func viewWillTransition(to size: CGSize,
+                                     with coordinator: UIViewControllerTransitionCoordinator) {
         super.viewWillTransition(to: size, with: coordinator)
+        guard UIDevice.current.isIphone else { return }
 
         coordinator.animate(alongsideTransition: { _ in
-            self.adjustLayoutForCurrentOrientation()
+            self.adjustPhoneLayoutForCurrentOrientation()
         })
     }
 
-    private func adjustLayoutForCurrentOrientation() {
+    private func adjustPhoneLayoutForCurrentOrientation() {
         stackViewWidthConstraint.constant = contentStackViewWidth
-
-        guard UIDevice.current.isIphone else { return }
-
         let isLandscape = view.currentInterfaceOrientation.isLandscape
 
         // Always deactivate both constraints before layout switch
@@ -179,13 +167,14 @@ final class SkontoViewController: UIViewController {
         if isLandscape {
             setupLandscapeLayout()
             scrollViewBottomToViewConstraint.isActive = true
+            scrollView.contentInset = Constants.scrollViewLandscapeIphoneContentInsets
+            scrollView.contentInsetAdjustmentBehavior = .never
         } else {
             setupPortraitLayout()
             scrollViewBottomToProceedViewTop.isActive = true
+            scrollView.contentInset = Constants.scrollViewDefaultContentInset
+            scrollView.contentInsetAdjustmentBehavior = .automatic
         }
-
-        scrollView.contentInset = isLandscape ? scrollViewLandscapeIphoneContentInsets : scrollViewContentInset
-        scrollView.contentInsetAdjustmentBehavior = isLandscape ? .never : .automatic
     }
 
     private func setupLandscapeLayout() {
@@ -571,5 +560,13 @@ private extension SkontoViewController {
         static let scrollIndicatorInset: CGFloat = 0
         static let tabletWidthMultiplier: CGFloat = 0.7
         static let navigationBarViewDefaultHeight: CGFloat = 62
+
+        static var scrollViewLandscapeIphoneContentInsets: UIEdgeInsets {
+            UIEdgeInsets(top: containerPadding, left: 0, bottom: 0, right: 0)
+        }
+
+        static var scrollViewDefaultContentInset: UIEdgeInsets {
+            UIEdgeInsets(top: containerPadding, left: 0, bottom: containerPadding, right: 0)
+        }
     }
 }

--- a/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/Skonto/SkontoViewController.swift
+++ b/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/Skonto/SkontoViewController.swift
@@ -224,7 +224,6 @@ final class SkontoViewController: UIViewController {
 
         if isLandscape {
             setupPhoneLandscapeLayout()
-            scrollViewBottomToViewConstraint.isActive = true
             scrollView.contentInset = Constants.scrollViewLandscapeIphoneContentInsets
             scrollView.contentInsetAdjustmentBehavior = .never
         } else {
@@ -293,14 +292,16 @@ final class SkontoViewController: UIViewController {
     }
 
     private func setupProceedContainerInLandscape() {
-        guard proceedContainerView.superview != view else { return }
         proceedContainerView.removeFromSuperview()
         NSLayoutConstraint.deactivate(proceedContainerConstraints)
+
         mainStackView.addArrangedSubview(proceedContainerView)
         NSLayoutConstraint.activate([
             proceedContainerView.leadingAnchor.constraint(equalTo: mainStackView.leadingAnchor),
             proceedContainerView.trailingAnchor.constraint(equalTo: mainStackView.trailingAnchor)
         ])
+
+        updateScrollViewBottomToViewConstraint(to: view.safeAreaLayoutGuide.bottomAnchor)
     }
 
     private func attachProceedContainerViewIfNeeded() {
@@ -365,11 +366,11 @@ final class SkontoViewController: UIViewController {
 
     private func setupStackViewConstraints() {
         NSLayoutConstraint.activate([
-            mainStackView.topAnchor.constraint(equalTo: scrollView.topAnchor),
+            mainStackView.topAnchor.constraint(equalTo: scrollView.contentLayoutGuide.topAnchor),
             mainStackView.leadingAnchor.constraint(greaterThanOrEqualTo: view.leadingAnchor),
             mainStackView.trailingAnchor.constraint(lessThanOrEqualTo: view.trailingAnchor),
             mainStackView.centerXAnchor.constraint(equalTo: scrollView.centerXAnchor),
-            mainStackView.bottomAnchor.constraint(equalTo: scrollView.bottomAnchor),
+            mainStackView.bottomAnchor.constraint(equalTo: scrollView.contentLayoutGuide.bottomAnchor),
             mainStackView.widthAnchor.constraint(equalTo: scrollView.widthAnchor),
             stackViewWidthConstraint
         ])

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Custom views/GiniBarButton.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Custom views/GiniBarButton.swift
@@ -83,6 +83,22 @@ public final class GiniBarButton {
     }
 
     /**
+     A property that gets or sets the text alignment of the button's title label.
+
+     Use `titleTextAlignment` to configure how the text inside the `titleLabel` is aligned horizontally.
+
+     - Returns: The current `NSTextAlignment` of the `titleLabel`.
+     */
+    public var titleTextAlignment: NSTextAlignment {
+        get {
+            return titleLabel.textAlignment
+        }
+        set {
+            titleLabel.textAlignment = newValue
+        }
+    }
+
+    /**
      Initializes a new `GiniBarButton` object with the specified button type.
 
      Use the `init(ofType:)` initializer to create a new `GiniBarButton` object with the specified `BarButtonType`. The `BarButtonType` parameter determines the appearance and behavior of the button.
@@ -106,6 +122,7 @@ public final class GiniBarButton {
         titleLabel.accessibilityTraits = .button
         titleLabel.isAccessibilityElement = true
         titleLabel.translatesAutoresizingMaskIntoConstraints = false
+        titleLabel.textAlignment = titleTextAlignment
 
         imageView.isAccessibilityElement = false
         titleLabel.isAccessibilityElement = false

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Extensions/UIDevice.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Extensions/UIDevice.swift
@@ -28,4 +28,14 @@ public extension UIDevice {
         let minSize: CGFloat = 350
         return smallestDimension <= minSize
     }
+
+    /// Returns true if the current device is currently in landscape orientation.
+    var isLandscape: Bool {
+        orientation.isLandscape
+    }
+
+    /// Returns true if the current device is an iPhone and is currently in landscape orientation.
+    var isIphoneAndLandscape: Bool {
+        isIphone && isLandscape
+    }
 }


### PR DESCRIPTION
Fix the bottom navigation bar in the Skonto screen in landscape.
Fix the custom bottom navigation bar in the Skonto screen in landscape

**Tested scenarios**:
- normal navigation bar(at the top of the screen)
- bottom bar navigation 
- custom bottom bar navigation

Switching from portrait to landscape and back, multiple times.

**Tested on the following devices:**

iPhoneSE first gen(iOS15.0)
iPhone 8(iOS 16.1)
iPhone 15 Pro(iOS 17.0.3)
iPad Air 11-ich (M2, iOS 18.3)