### PR TITLE
Pp 1263 skonto screen text can be resized to 200 without loss of content or function

### DIFF
--- a/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/DocumentPagesPreview/Views/DocumentPagesFooterView.swift
+++ b/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/DocumentPagesPreview/Views/DocumentPagesFooterView.swift
@@ -53,6 +53,7 @@ final class DocumentPagesFooterView: UIView {
         for item in items {
             let label = UILabel()
             label.text = item
+            label.numberOfLines = 0
             label.font = configuration.textStyleFonts[.footnote]
             label.textColor = .GiniBank.light1
             label.translatesAutoresizingMaskIntoConstraints = false

--- a/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/Skonto/Views/SkontoAmountToPayView.swift
+++ b/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/Skonto/Views/SkontoAmountToPayView.swift
@@ -5,6 +5,7 @@
 //
 
 import UIKit
+import GiniCaptureSDK
 
 protocol SkontoAmountViewDelegate: AnyObject {
     func textFieldPriceChanged(editedText: String)
@@ -15,6 +16,8 @@ class SkontoAmountToPayView: UIView {
     private lazy var titleLabel: UILabel = {
         let label = UILabel()
         label.text = titleLabelText
+        label.numberOfLines = 1
+        label.enableScaling()
         label.font = configuration.textStyleFonts[.footnote]
         label.textColor = .giniColorScheme().text.secondary.uiColor()
         label.adjustsFontForContentSizeCategory = true

--- a/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/Skonto/Views/SkontoDocumentPreviewView.swift
+++ b/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/Skonto/Views/SkontoDocumentPreviewView.swift
@@ -46,6 +46,7 @@ class SkontoDocumentPreviewView: UIView {
         let title = NSLocalizedStringPreferredGiniBankFormat("ginibank.skonto.invoice.subtitle",
                                                              comment: "Tap to view")
         label.text = title
+        label.numberOfLines = 0
         label.textColor = .giniColorScheme().text.secondary.uiColor()
         label.font = configuration.textStyleFonts[.footnote]
         label.adjustsFontForContentSizeCategory = true

--- a/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/Skonto/Views/SkontoExpiryDateView.swift
+++ b/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/Skonto/Views/SkontoExpiryDateView.swift
@@ -15,6 +15,8 @@ class SkontoExpiryDateView: UIView {
     private lazy var titleLabel: UILabel = {
         let label = UILabel()
         label.text = title
+        label.numberOfLines = 1
+        label.enableScaling()
         label.font = configuration.textStyleFonts[.footnote]
         label.textColor = .giniColorScheme().text.secondary.uiColor()
         label.adjustsFontForContentSizeCategory = true

--- a/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/Skonto/Views/SkontoProceedContainerView.swift
+++ b/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/Skonto/Views/SkontoProceedContainerView.swift
@@ -141,6 +141,7 @@ class SkontoProceedContainerView: UIView {
 
     private func setupConstraints() {
         let multiplier: CGFloat = UIDevice.current.isIpad ? Constants.tabletWidthMultiplier : 1.0
+        let contentViewTrailingAnchor = contentView.safeAreaLayoutGuide.trailingAnchor
 
         NSLayoutConstraint.activate([
             contentView.centerXAnchor.constraint(equalTo: centerXAnchor),
@@ -154,14 +155,15 @@ class SkontoProceedContainerView: UIView {
             dividerView.heightAnchor.constraint(equalToConstant: Constants.dividerViewHeight),
 
             totalAmountStackView.topAnchor.constraint(equalTo: contentView.topAnchor, constant: Constants.padding),
-            totalAmountStackView.leadingAnchor.constraint(equalTo: contentView.safeAreaLayoutGuide.leadingAnchor, constant: Constants.padding),
+            totalAmountStackView.leadingAnchor.constraint(equalTo: contentView.safeAreaLayoutGuide.leadingAnchor,
+                                                          constant: Constants.padding),
             totalAmountStackView.trailingAnchor.constraint(lessThanOrEqualTo: skontoBadgeView.leadingAnchor,
                                                            constant: -Constants.badgeHorizontalPadding),
 
             savingsAmountLabel.topAnchor.constraint(equalTo: finalAmountToPayLabel.bottomAnchor,
                                                     constant: Constants.savingsAmountLabelTopPadding),
             savingsAmountLabel.leadingAnchor.constraint(equalTo: finalAmountToPayLabel.leadingAnchor),
-            savingsAmountLabel.trailingAnchor.constraint(lessThanOrEqualTo: contentView.safeAreaLayoutGuide.trailingAnchor,
+            savingsAmountLabel.trailingAnchor.constraint(lessThanOrEqualTo: contentViewTrailingAnchor,
                                                          constant: -Constants.padding),
 
             skontoBadgeView.centerYAnchor.constraint(equalTo: totalStringLabel.centerYAnchor),

--- a/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/Skonto/Views/SkontoProceedContainerView.swift
+++ b/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/Skonto/Views/SkontoProceedContainerView.swift
@@ -30,12 +30,14 @@ class SkontoProceedContainerView: UIView {
     private lazy var totalStringLabel: UILabel = {
         let label = UILabel()
         label.translatesAutoresizingMaskIntoConstraints = false
-        label.adjustsFontForContentSizeCategory = true
         label.font = configuration.textStyleFonts[.subheadline]
         label.textColor = .giniColorScheme().text.primary.uiColor()
         let labelText = NSLocalizedStringPreferredGiniBankFormat("ginibank.skonto.total.title",
                                                                   comment: "Total")
         label.text = labelText
+        label.numberOfLines = 1
+        label.lineBreakMode = .byTruncatingTail
+        label.enableScaling(minimumScaleFactor: 15)
         return label
     }()
 
@@ -46,8 +48,8 @@ class SkontoProceedContainerView: UIView {
         label.textColor = .giniColorScheme().text.primary.uiColor()
         let labelText = viewModel.finalAmountToPay.localizedStringWithCurrencyCode
         label.text = labelText
-        label.adjustsFontForContentSizeCategory = true
-        label.adjustsFontSizeToFitWidth = true
+        label.numberOfLines = 1
+        label.enableScaling(minimumScaleFactor: 15)
         label.setContentHuggingPriority(.defaultHigh, for: .horizontal)
         label.setContentCompressionResistancePriority(.defaultHigh, for: .horizontal)
         return label
@@ -71,8 +73,8 @@ class SkontoProceedContainerView: UIView {
         let labelText = String.localizedStringWithFormat(skontoTitle,
                                                          viewModel.formattedPercentageDiscounted)
         label.text = labelText
-        label.adjustsFontForContentSizeCategory = true
-        label.adjustsFontSizeToFitWidth = true
+        label.numberOfLines = 1
+        label.enableScaling()
         label.setContentHuggingPriority(.defaultLow, for: .horizontal)
         label.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
         return label
@@ -114,6 +116,10 @@ class SkontoProceedContainerView: UIView {
     private let skontoTitle = NSLocalizedStringPreferredGiniBankFormat("ginibank.skonto.total.skontopercentage",
                                                                       comment: "%@ Skonto discount")
 
+    private var skontoBadgeCompactLeadingConstraint: NSLayoutConstraint?
+    private var totalAmountStackViewDefultLeadingConstraint: NSLayoutConstraint?
+    private var skontoBadgeMinWidthConstraint: NSLayoutConstraint?
+
     init(viewModel: SkontoViewModel) {
         self.viewModel = viewModel
         super.init(frame: .zero)
@@ -137,11 +143,26 @@ class SkontoProceedContainerView: UIView {
 
         setupConstraints()
         bindViewModel()
+        adjustLayoutForAccessibility()
+    }
+
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+        adjustLayoutForAccessibility()
     }
 
     private func setupConstraints() {
         let multiplier: CGFloat = UIDevice.current.isIpad ? Constants.tabletWidthMultiplier : 1.0
         let contentViewTrailingAnchor = contentView.safeAreaLayoutGuide.trailingAnchor
+
+        let skontoCompactLeadinConstraint = Constants.skontoBadgeCompactLeadingConstraint
+        skontoBadgeCompactLeadingConstraint = skontoBadgeView.leadingAnchor
+            .constraint(equalTo: totalStringLabel.trailingAnchor,
+                        constant: skontoCompactLeadinConstraint)
+
+        totalAmountStackViewDefultLeadingConstraint = totalAmountStackView.trailingAnchor
+            .constraint(lessThanOrEqualTo: skontoBadgeView.leadingAnchor,
+                        constant: -Constants.badgeHorizontalPadding)
 
         NSLayoutConstraint.activate([
             contentView.centerXAnchor.constraint(equalTo: centerXAnchor),
@@ -157,8 +178,6 @@ class SkontoProceedContainerView: UIView {
             totalAmountStackView.topAnchor.constraint(equalTo: contentView.topAnchor, constant: Constants.padding),
             totalAmountStackView.leadingAnchor.constraint(equalTo: contentView.safeAreaLayoutGuide.leadingAnchor,
                                                           constant: Constants.padding),
-            totalAmountStackView.trailingAnchor.constraint(lessThanOrEqualTo: skontoBadgeView.leadingAnchor,
-                                                           constant: -Constants.badgeHorizontalPadding),
 
             savingsAmountLabel.topAnchor.constraint(equalTo: finalAmountToPayLabel.bottomAnchor,
                                                     constant: Constants.savingsAmountLabelTopPadding),
@@ -188,6 +207,38 @@ class SkontoProceedContainerView: UIView {
                                                    constant: Constants.padding),
             proceedButton.heightAnchor.constraint(greaterThanOrEqualToConstant: Constants.proceedButtonHeight)
         ])
+    }
+
+    private func adjustLayoutForAccessibility() {
+        guard !UIDevice.current.isIpad else { return }
+
+        let isAccessibilityCategory = UIApplication.shared.preferredContentSizeCategory >= .accessibilityMedium
+        // Later this will be factor and use the generic methods that are inside UIDevice extension
+        let isSmallDevice = UIDevice.current.userInterfaceIdiom == .phone &&
+            UIScreen.main.bounds.size.width <= 375 // iPhone SE and smaller
+        let shouldUseCompactLayout = isAccessibilityCategory && isSmallDevice
+
+        let horizontalPriority: UILayoutPriority = isAccessibilityCategory ? .defaultHigh : .defaultLow
+        skontoPercentageLabel.setContentHuggingPriority(horizontalPriority,
+                                                        for: .horizontal)
+        skontoPercentageLabel.setContentCompressionResistancePriority(horizontalPriority,
+                                                                      for: .horizontal)
+
+        if shouldUseCompactLayout {
+            let skontoBadgeWidth = Constants.skontoBadgeMinWidthCompactLayout
+            skontoBadgeMinWidthConstraint = skontoBadgeView.widthAnchor
+                .constraint(greaterThanOrEqualToConstant: skontoBadgeWidth)
+            skontoBadgeMinWidthConstraint?.isActive = true
+            skontoBadgeCompactLeadingConstraint?.isActive = true
+            totalAmountStackViewDefultLeadingConstraint?.isActive = false
+
+        } else {
+            skontoBadgeMinWidthConstraint?.isActive = false
+            skontoBadgeCompactLeadingConstraint?.isActive = false
+            totalAmountStackViewDefultLeadingConstraint?.isActive = true
+        }
+
+        layoutIfNeeded()
     }
 
     private func bindViewModel() {
@@ -228,5 +279,8 @@ private extension SkontoProceedContainerView {
         static let totalValueLabelTopPadding: CGFloat = 4
         static let savingsAmountLabelTopPadding: CGFloat = 2
         static let tabletWidthMultiplier: CGFloat = 0.7
+        static let skontoBadgeTopPadding: CGFloat = 8
+        static let skontoBadgeMinWidthCompactLayout: CGFloat = 100
+        static let skontoBadgeCompactLeadingConstraint: CGFloat = 8
     }
 }

--- a/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/Skonto/Views/SkontoWithDiscountHeaderView.swift
+++ b/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/Skonto/Views/SkontoWithDiscountHeaderView.swift
@@ -87,6 +87,7 @@ class SkontoWithDiscountHeaderView: UIView {
         addSubview(discountSwitch)
         setupConstraints()
         bindViewModel()
+        adjustStackViewLayout()
     }
 
     private func setupConstraints() {

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Extensions/UILabel.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Extensions/UILabel.swift
@@ -32,9 +32,9 @@ extension UILabel {
      - Ensures the font never shrinks below 10pt.
      - Supports Dynamic Type for accessibility.
      */
-    public func enableScaling() {
+    public func enableScaling(minimumScaleFactor: CGFloat = 10) {
         adjustsFontSizeToFitWidth = true
-        minimumScaleFactor = 10 / font.pointSize
+        self.minimumScaleFactor = minimumScaleFactor / font.pointSize
         adjustsFontForContentSizeCategory = true
     }
 }

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Extensions/UILabel.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Extensions/UILabel.swift
@@ -21,7 +21,18 @@ extension UILabel {
                                  context: nil).size.height
     }
 
-    func enableScaling() {
+    /**
+     Enables font scaling with a minimum size of 10pt.
+
+     - Adjusts the font size to fit the label’s width.
+     - Sets the minimum scale factor to `10 / font.pointSize`.
+     For example:
+     - If font size is 20pt → minimumScaleFactor = 0.5
+     - If font size is 15pt → minimumScaleFactor ≈ 0.67
+     - Ensures the font never shrinks below 10pt.
+     - Supports Dynamic Type for accessibility.
+     */
+    public func enableScaling() {
         adjustsFontSizeToFitWidth = true
         minimumScaleFactor = 10 / font.pointSize
         adjustsFontForContentSizeCategory = true

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Camera/Camera/CameraViewController.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Camera/Camera/CameraViewController.swift
@@ -318,8 +318,9 @@ final class CameraViewController: UIViewController {
     }
 
     private func configureCameraPaneButtons() {
-        cameraPane.setupAuthorization(isHidden: UIDevice.current.isIphone && currentInterfaceOrientation.isLandscape)
-        cameraPaneHorizontal?.setupAuthorization(isHidden: !(UIDevice.current.isIphone && currentInterfaceOrientation.isLandscape))
+        let isIphoneLandscape = UIDevice.current.isIphone && currentInterfaceOrientation.isLandscape
+        cameraPane.setupAuthorization(isHidden: isIphoneLandscape)
+        cameraPaneHorizontal?.setupAuthorization(isHidden: !isIphoneLandscape)
         configureLeftButtons()
         cameraButtonsViewModel.captureAction = { [weak self] in
             self?.sendGiniAnalyticsEventCapture()
@@ -363,8 +364,10 @@ final class CameraViewController: UIViewController {
         }
         cameraButtonsViewModel.imagesUpdated = { [weak self] images in
             if let lastImage = images.last {
-                self?.cameraPane.thumbnailView.updateStackStatus(to: .filled(count: images.count, lastImage: lastImage))
-                self?.cameraPaneHorizontal?.thumbnailView.updateStackStatus(to: .filled(count: images.count, lastImage: lastImage))
+                self?.cameraPane.thumbnailView.updateStackStatus(to: .filled(count: images.count,
+                                                                             lastImage: lastImage))
+                self?.cameraPaneHorizontal?.thumbnailView.updateStackStatus(to: .filled(count: images.count,
+                                                                                        lastImage: lastImage))
             } else {
                 self?.cameraPane.thumbnailView.updateStackStatus(to: ThumbnailView.State.empty)
                 self?.cameraPaneHorizontal?.thumbnailView.updateStackStatus(to: ThumbnailView.State.empty)
@@ -717,9 +720,12 @@ extension CameraViewController: CameraPreviewViewControllerDelegate {
         cameraLensSwitcherView.isHidden = true
 
         cameraPreviewViewController.updatePreviewViewOrientation()
+        let isPortrait = currentInterfaceOrientation.isPortrait
+        let isLandscapeOniPhone = UIDevice.current.isIphone && currentInterfaceOrientation.isLandscape
+
         UIView.animate(withDuration: 1.0) {
-            self.cameraPane.setupAuthorization(isHidden: !(UIDevice.current.isIpad || self.currentInterfaceOrientation.isPortrait))
-            self.cameraPaneHorizontal?.setupAuthorization(isHidden: !(UIDevice.current.isIphone && self.currentInterfaceOrientation.isLandscape))
+            self.cameraPane.setupAuthorization(isHidden: !(UIDevice.current.isIpad || isPortrait))
+            self.cameraPaneHorizontal?.setupAuthorization(isHidden: !isLandscapeOniPhone)
             self.cameraPreviewViewController.previewView.alpha = 1
         }
     }

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Camera/Views/CameraPane.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Camera/Views/CameraPane.swift
@@ -22,10 +22,6 @@ final class CameraPane: UIView {
         setupView()
     }
 
-    override func layoutSubviews() {
-        super.layoutSubviews()
-    }
-
     func setupView() {
         let giniConfiguration = GiniConfiguration.shared
         backgroundColor = GiniColor(


### PR DESCRIPTION
Tested and working as expected without any changes:
- Skonto Help screen 
- Skont edge case native alertview

**This pr is affecting:**
1. **Invoice preview screen** -> information displayed at the bottom of the screen
2. **Main screen:**
-  `discountSwitch` from overflowing on iPhone SE (1st to 3rd gen) - Skonto screen
- amount to pay and expiry date labels
-  invoice preview view -> "tap to view" text
- Skonto discount badge 

Known issue: For Pro Max devices in English, the proceed container is not looking very well because the skonto badge text is pushing the total string and total amount too much to the  left.

**Tested on the following devices:**

iPhoneSE first gen(iOS15.0)
iPhoneSE 2nd gen(iOS17.0)
iPhoneSE 3rd gen(iOS15.5)
iPhone 7 Plus (iOS 15.5)
iPhone 8(iOS 16.1)
iPhone 15 Pro(iOS 17.0.3)
iPhone 15 Pro Max(iOS 18.0.)
iPhone 16 Pro Max(iOS 18.3)
iPhone 12 Mini (iOS 16.2)
iPhone Xr (iOS 16.4)

It should not affect iPad because the changes were done for iPhone only.
