### PR TITLE
Pp 1398 make qr code education accessibility conform

### DIFF
--- a/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/GiniBankNetworkingScreenApiCoordinator.swift
+++ b/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/GiniBankNetworkingScreenApiCoordinator.swift
@@ -338,7 +338,7 @@ private extension GiniBankNetworkingScreenApiCoordinator {
         GiniAnalyticsManager.track(event: .sdkClosed,properties: properties)
     }
 
-    private func setDcoumentIdAsUserProperty() {
+    private func setDocumentIdAsUserProperty() {
         guard let documentId = documentService.document?.id else { return }
         GiniAnalyticsManager.registerSuperProperties([.documentId: documentId])
     }
@@ -354,7 +354,7 @@ private extension GiniBankNetworkingScreenApiCoordinator {
             guard let self = self else { return }
             switch result {
             case let .success(extractionResult):
-                self.setDcoumentIdAsUserProperty()
+                self.setDocumentIdAsUserProperty()
                 self.handleSuccessfulAnalysis(with: extractionResult, networkDelegate: networkDelegate)
             case let .failure(error):
                 guard error != .requestCancelled else { return }

--- a/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/GiniBankNetworkingScreenApiCoordinator.swift
+++ b/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/GiniBankNetworkingScreenApiCoordinator.swift
@@ -354,6 +354,7 @@ private extension GiniBankNetworkingScreenApiCoordinator {
             guard let self = self else { return }
             switch result {
             case let .success(extractionResult):
+                self.setDcoumentIdAsUserProperty()
                 self.handleSuccessfulAnalysis(with: extractionResult, networkDelegate: networkDelegate)
             case let .failure(error):
                 guard error != .requestCancelled else { return }

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Custom views/GiniAnimatedSuffixLabelView.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Custom views/GiniAnimatedSuffixLabelView.swift
@@ -23,7 +23,7 @@ final class GiniAnimatedSuffixLabelView: UIView {
          suffixSymbol: String = ".",
          maxSteps: Int = 3,
          animationInterval: TimeInterval = 0.4,
-         font: UIFont,
+         font: UIFont?,
          textColor: UIColor) {
 
         self.baseText = baseText
@@ -46,7 +46,7 @@ final class GiniAnimatedSuffixLabelView: UIView {
 
     // MARK: - Setup
 
-    private func setupLabels(font: UIFont, textColor: UIColor) {
+    private func setupLabels(font: UIFont?, textColor: UIColor) {
         textLabel.text = baseText
         textLabel.font = font
         textLabel.textColor = textColor
@@ -75,7 +75,8 @@ final class GiniAnimatedSuffixLabelView: UIView {
         ])
     }
 
-    private func calculateMaxSuffixWidth(font: UIFont) -> CGFloat {
+    private func calculateMaxSuffixWidth(font: UIFont?) -> CGFloat {
+        guard let font else { return 0 }
         let fullSuffix = String(repeating: suffixSymbol, count: maxSteps)
         return (fullSuffix as NSString).size(withAttributes: [.font: font]).width
     }

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/EducationFlow/Views/QRCodeEducation/QRCodeEducationLoadingView.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/EducationFlow/Views/QRCodeEducation/QRCodeEducationLoadingView.swift
@@ -12,6 +12,7 @@ final class QRCodeEducationLoadingView: UIView {
     struct Style {
         let textColor: UIColor
         let analysingTextColor: UIColor
+        let useDarkAppearance: Bool
 
         private static let defaultTextColor = GiniColor(light: .GiniCapture.dark1,
                                                         dark: .GiniCapture.light1).uiColor()
@@ -19,9 +20,11 @@ final class QRCodeEducationLoadingView: UIView {
                                                                  dark: .GiniCapture.light6).uiColor()
 
         init(textColor: UIColor = defaultTextColor,
-             analysingTextColor: UIColor = defaultAnalysingTextColor) {
+             analysingTextColor: UIColor = defaultAnalysingTextColor,
+             useDarkAppearance: Bool = false) {
             self.textColor = textColor
             self.analysingTextColor = analysingTextColor
+            self.useDarkAppearance = useDarkAppearance
         }
     }
 
@@ -64,6 +67,9 @@ final class QRCodeEducationLoadingView: UIView {
         self.viewModel = viewModel
         self.style = style
         super.init(frame: .zero)
+        if style.useDarkAppearance {
+            overrideUserInterfaceStyle = .dark
+        }
         bind()
     }
 

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/EducationFlow/Views/QRCodeEducation/QRCodeEducationLoadingView.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/EducationFlow/Views/QRCodeEducation/QRCodeEducationLoadingView.swift
@@ -34,6 +34,7 @@ final class QRCodeEducationLoadingView: UIView {
         let imageView = UIImageView()
         imageView.translatesAutoresizingMaskIntoConstraints = false
         imageView.contentMode = .scaleAspectFit
+        imageView.isAccessibilityElement = false
         return imageView
     }()
 
@@ -44,8 +45,8 @@ final class QRCodeEducationLoadingView: UIView {
         label.textColor = style.textColor
         label.adjustsFontForContentSizeCategory = true
         label.textAlignment = .center
+        label.isAccessibilityElement = false
         label.numberOfLines = 0
-        label.isAccessibilityElement = true
         return label
     }()
 
@@ -55,6 +56,7 @@ final class QRCodeEducationLoadingView: UIView {
                                                font: labelFont,
                                                textColor: style.analysingTextColor)
         view.translatesAutoresizingMaskIntoConstraints = false
+        view.isAccessibilityElement = false
         return view
     }()
 
@@ -120,7 +122,8 @@ final class QRCodeEducationLoadingView: UIView {
     private func configure(with model: QRCodeEducationLoadingItem) {
         imageView.image = model.image
         textLabel.text = model.text
-        textLabel.accessibilityLabel = model.text
+        let announcementArgument = model.text + "\n" + LocalizedStrings.loadingAccessibilityText
+        UIAccessibility.post(notification: .announcement, argument: announcementArgument)
     }
 }
 
@@ -136,5 +139,8 @@ private extension QRCodeEducationLoadingView {
     enum LocalizedStrings {
         static let loadingBaseText = NSLocalizedStringPreferredFormat("ginicapture.analysis.education.loadingText",
                                                                       comment: "analyzing")
+
+        static let loadingAccessibilityText = NSLocalizedStringPreferredFormat("ginicapture.education.loading.accessibility",
+                                                                               comment: "analyzing")
     }
 }

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/EducationFlow/Views/QRCodeEducation/QRCodeEducationLoadingView.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/EducationFlow/Views/QRCodeEducation/QRCodeEducationLoadingView.swift
@@ -50,7 +50,7 @@ final class QRCodeEducationLoadingView: UIView {
     }()
 
     private lazy var animatedSuffixLabelView: GiniAnimatedSuffixLabelView = {
-        let labelFont = giniConfiguration.textStyleFonts[.caption1] ?? .systemFont(ofSize: 17)
+        let labelFont = giniConfiguration.textStyleFonts[.caption1]
         let view = GiniAnimatedSuffixLabelView(baseText: LocalizedStrings.loadingBaseText,
                                                font: labelFont,
                                                textColor: style.analysingTextColor)

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/EducationFlow/Views/QRCodeEducation/QRCodeEducationLoadingViewModel.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/EducationFlow/Views/QRCodeEducation/QRCodeEducationLoadingViewModel.swift
@@ -6,7 +6,11 @@
 
 import Foundation
 
-final class QRCodeEducationLoadingViewModel: ObservableObject {
+/*
+ ViewModel responsible for managing the sequential display of loading items
+ during the QR code education animation.
+ */
+final class QRCodeEducationLoadingViewModel {
     @Published private(set) var currentItem: QRCodeEducationLoadingItem?
 
     private let items: [QRCodeEducationLoadingItem]
@@ -15,14 +19,26 @@ final class QRCodeEducationLoadingViewModel: ObservableObject {
         self.items = items
     }
 
-    func start() async {
-        guard !items.isEmpty else { return }
-
-        for item in items {
-            await MainActor.run {
-                self.currentItem = item
+    /*
+     Starts the animation and calls `completion` once all items are shown.
+     Each item is set on the main thread and displayed for its specified duration.
+     If no items are available, the method returns immediately.
+     */
+    func start(completion: (() -> Void)? = nil) {
+        Task {
+            guard !items.isEmpty else {
+                completion?()
+                return
             }
-            try? await Task.sleep(nanoseconds: item.durationInNanoseconds)
+
+            for item in items {
+                await MainActor.run {
+                    self.currentItem = item
+                }
+                try? await Task.sleep(nanoseconds: item.durationInNanoseconds)
+            }
+
+            completion?()
         }
     }
 }

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/EducationFlow/Views/QRCodeEducation/QRCodeEducationPresenting.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/EducationFlow/Views/QRCodeEducation/QRCodeEducationPresenting.swift
@@ -1,5 +1,5 @@
 //
-//  QRCodeEducationable.swift
+//  QRCodeEducationPresenting.swift
 //
 //  Copyright © 2025 Gini GmbH. All rights reserved.
 //

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Helpers/GiniAccessibility.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Helpers/GiniAccessibility.swift
@@ -1,0 +1,26 @@
+//
+//  GiniAccessibility.swift
+//
+//  Copyright © 2025 Gini GmbH. All rights reserved.
+//
+
+import UIKit
+
+/**
+ A utility for accessibility-related helpers.
+ */
+public enum GiniAccessibility {
+
+    /**
+     Indicates whether the user has enabled an accessibility-level font size.
+
+     Returns `true` when the current `UIContentSizeCategory` is greater than or equal to
+     `.accessibilityMedium`, which typically corresponds to a font scaling factor of around 200% or more.
+
+     Use this to adjust layouts or content spacing for users with significantly enlarged fonts.
+     */
+    public static var isFontSizeAtLeastAccessibilityMedium: Bool {
+        return UIApplication.shared.preferredContentSizeCategory >= .accessibilityMedium
+    }
+}
+

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Helpers/GiniAccessibility.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Helpers/GiniAccessibility.swift
@@ -23,4 +23,3 @@ public enum GiniAccessibility {
         return UIApplication.shared.preferredContentSizeCategory >= .accessibilityMedium
     }
 }
-

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Camera/Camera/CameraViewController.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Camera/Camera/CameraViewController.swift
@@ -447,7 +447,7 @@ final class CameraViewController: UIViewController {
     private lazy var cameraPreviewBottomContraint: NSLayoutConstraint =
     cameraPreviewViewController.view.bottomAnchor.constraint(equalTo: view.bottomAnchor)
 
-    private func configureConstraints() {
+    private func setQRCodeOverLayLayout() {
         if qrCodeScanningOnlyEnabled {
             qrCodeOverLay.layoutViews(centeringBy: cameraPreviewViewController.qrCodeFrameView,
                                       on: cameraPreviewViewController)
@@ -455,7 +455,10 @@ final class CameraViewController: UIViewController {
             qrCodeOverLay.layoutViews(centeringBy: cameraPreviewViewController.cameraFrameView,
                                       on: cameraPreviewViewController)
         }
+    }
 
+    private func configureConstraints() {
+        setQRCodeOverLayLayout()
         ibanDetectionOverLay.layoutViews(centeringBy: cameraPreviewViewController.cameraFrameView,
                                          on: cameraPreviewViewController)
 
@@ -509,6 +512,7 @@ final class CameraViewController: UIViewController {
 
         coordinator.animate(alongsideTransition: { [weak self] _ in
             self?.configureCameraPanesBasedOnOrientation()
+            self?.setQRCodeOverLayLayout()
         })
     }
 

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Camera/CameraPreviewViewController.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Camera/CameraPreviewViewController.swift
@@ -164,9 +164,10 @@ final class CameraPreviewViewController: UIViewController {
         if UIDevice.current.isIphone,
            let defaultImageView,
            let defaultImage,
-           let cgimage = defaultImage.cgImage
-        {
-            defaultImageView.image = UIImage(cgImage: cgimage, scale: 1, orientation: currentInterfaceOrientation.isLandscape ? .left : .up)
+           let cgimage = defaultImage.cgImage {
+            defaultImageView.image = UIImage(cgImage: cgimage,
+                                             scale: 1,
+                                             orientation: currentInterfaceOrientation.isLandscape ? .left : .up)
         }
     }
 
@@ -206,7 +207,8 @@ final class CameraPreviewViewController: UIViewController {
 
         if UIDevice.current.isIpad {
             NSLayoutConstraint.activate([
-                cameraFrameView.topAnchor.constraint(greaterThanOrEqualTo: view.topAnchor, constant: Constants.padding),
+                cameraFrameView.topAnchor.constraint(greaterThanOrEqualTo: view.topAnchor,
+                                                     constant: Constants.padding),
                 cameraFrameView.centerYAnchor.constraint(equalTo: view.centerYAnchor),
                 cameraFrameView.leadingAnchor.constraint(greaterThanOrEqualTo: view.leadingAnchor,
                                                          constant: Constants.padding),
@@ -215,7 +217,8 @@ final class CameraPreviewViewController: UIViewController {
                 cameraFrameViewHeightAnchorPortrait])
         } else {
             NSLayoutConstraint.activate([
-                cameraFrameView.topAnchor.constraint(equalTo: view.topAnchor, constant: Constants.padding),
+                cameraFrameView.topAnchor.constraint(equalTo: view.topAnchor,
+                                                     constant: Constants.padding),
                 cameraFrameView.leadingAnchor.constraint(greaterThanOrEqualTo: view.leadingAnchor,
                                                          constant: Constants.padding),
                 cameraFrameView.centerXAnchor.constraint(equalTo: view.centerXAnchor),
@@ -462,7 +465,9 @@ extension CameraPreviewViewController {
             defaultImageView.removeFromSuperview()
             self.defaultImageView = nil
         }
-        let defaultImage = UIImage(cgImage: defaultImageCG, scale: 1, orientation: (UIDevice.current.isIphone && currentInterfaceOrientation.isLandscape) ? .left : .up)
+        let iPhoneInLandscape = UIDevice.current.isIphone && currentInterfaceOrientation.isLandscape
+        let defaultImage = UIImage(cgImage: defaultImageCG, scale: 1,
+                                   orientation: iPhoneInLandscape ? .left : .up)
         defaultImageView = UIImageView(image: defaultImage)
         guard let defaultImageView = defaultImageView else { return }
         defaultImageView.alpha = 0.5

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Camera/Views/CameraPane.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Camera/Views/CameraPane.swift
@@ -24,9 +24,8 @@ final class CameraPane: UIView {
 
     func setupView() {
         let giniConfiguration = GiniConfiguration.shared
-        backgroundColor = GiniColor(
-            light: UIColor.GiniCapture.dark1,
-            dark: UIColor.GiniCapture.dark1).uiColor().withAlphaComponent(0.4)
+        backgroundColor = GiniColor(light: .GiniCapture.dark1,
+                                    dark: .GiniCapture.dark1).uiColor().withAlphaComponent(0.4)
         captureButton.setTitle("", for: .normal)
         captureButton.isExclusiveTouch = true
         thumbnailView.isHidden = true

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Camera/Views/IBANDetectionOverlay/IBANDetectionOverlay.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Camera/Views/IBANDetectionOverlay/IBANDetectionOverlay.swift
@@ -47,7 +47,7 @@ final class IBANDetectionOverlay: UIView {
         let title: String
         let takePhotoString = NSLocalizedStringPreferredFormat("ginicapture.ibandetection.takephoto",
                                                                comment: "IBAN Detection")
-        
+
         if IBANs.count == 1 {
             let iban = IBANs[0].split(every: 4)
             title = "\(iban)\n\n\(takePhotoString)"

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Camera/Views/QRCodeOverlay.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Camera/Views/QRCodeOverlay.swift
@@ -104,7 +104,7 @@ final class IncorrectQRCodeTextContainer: UIView {
 final class QRCodeOverlay: UIView {
     private let configuration = GiniConfiguration.shared
     private var educationViewModel: QRCodeEducationLoadingViewModel?
-    private var customLoadingView: QRCodeEducationLoadingView?
+    private var educationLoadingView: QRCodeEducationLoadingView?
     private let useCustomLoadingView: Bool = true
     private var educationTask: Task<Void, Never>?
     private var educationFlowController: EducationFlowController?
@@ -211,10 +211,10 @@ final class QRCodeOverlay: UIView {
 
         let customViewStyle = QRCodeEducationLoadingView.Style(textColor: .GiniCapture.light1,
                                                                analysingTextColor: .GiniCapture.light6)
-        let customView = QRCodeEducationLoadingView(viewModel: viewModel, style: customViewStyle)
-        customView.translatesAutoresizingMaskIntoConstraints = false
-        customLoadingView = customView
-        addSubview(customView)
+        let view = QRCodeEducationLoadingView(viewModel: viewModel, style: customViewStyle)
+        view.translatesAutoresizingMaskIntoConstraints = false
+        educationLoadingView = view
+        addSubview(view)
     }
 
     private func addOriginalLoadingView() {
@@ -267,32 +267,21 @@ final class QRCodeOverlay: UIView {
     }
 
     private func layoutLoadingIndicator(centeringBy cameraFrame: UIView) {
-        if let customLoadingView {
-            layoutCustomLoadingView(customLoadingView, cameraFrame: cameraFrame)
+        if let educationLoadingView {
+            layoutLoadingView(educationLoadingView, cameraFrame: cameraFrame)
         } else {
-            layoutOriginalLoadingContainer(cameraFrame: cameraFrame)
+            layoutLoadingView(loadingContainer, cameraFrame: cameraFrame)
         }
     }
 
-    private func layoutCustomLoadingView(_ view: UIView, cameraFrame: UIView) {
+    private func layoutLoadingView(_ view: UIView,
+                                   cameraFrame: UIView) {
+
         NSLayoutConstraint.activate([
             view.centerXAnchor.constraint(equalTo: cameraFrame.centerXAnchor),
-            view.centerYAnchor.constraint(greaterThanOrEqualTo: cameraFrame.centerYAnchor),
-            view.leadingAnchor.constraint(greaterThanOrEqualTo: cameraFrame.leadingAnchor,
-                                          constant: Constants.educationLoadingViewPadding),
-            view.trailingAnchor.constraint(lessThanOrEqualTo: cameraFrame.trailingAnchor,
-                                           constant: -Constants.educationLoadingViewPadding),
-            view.topAnchor.constraint(greaterThanOrEqualTo: correctQRFeedback.topAnchor,
-                                      constant: Constants.educationLoadingViewTopPadding)
-        ])
-    }
-
-    private func layoutOriginalLoadingContainer(cameraFrame: UIView) {
-        NSLayoutConstraint.activate([
-            loadingContainer.centerXAnchor.constraint(equalTo: cameraFrame.centerXAnchor),
-            loadingContainer.centerYAnchor.constraint(equalTo: cameraFrame.centerYAnchor),
-            loadingContainer.leadingAnchor.constraint(equalTo: cameraFrame.leadingAnchor),
-            loadingContainer.topAnchor.constraint(greaterThanOrEqualTo: cameraFrame.topAnchor)
+            view.centerYAnchor.constraint(equalTo: cameraFrame.centerYAnchor),
+            view.leadingAnchor.constraint(equalTo: cameraFrame.leadingAnchor),
+            view.topAnchor.constraint(greaterThanOrEqualTo: cameraFrame.topAnchor)
         ])
     }
 
@@ -326,7 +315,7 @@ final class QRCodeOverlay: UIView {
                 await educationViewModel.start()
                 self?.educationFlowController?.markMessageAsShown()
             }
-            customLoadingView?.isHidden = false
+            educationLoadingView?.isHidden = false
         } else {
             loadingContainer.isHidden = false
             if let loadingIndicator = configuration.customLoadingIndicator {
@@ -342,8 +331,8 @@ final class QRCodeOverlay: UIView {
      */
     public func hideAnimation() {
         checkMarkImageView.isHidden = true
-        if let customLoadingView {
-            customLoadingView.isHidden = true
+        if let educationLoadingView {
+            educationLoadingView.isHidden = true
         } else {
             loadingContainer.isHidden = true
             if let customIndicator = configuration.customLoadingIndicator {

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Camera/Views/QRCodeOverlay.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Camera/Views/QRCodeOverlay.swift
@@ -210,7 +210,7 @@ final class QRCodeOverlay: UIView {
         educationViewModel = viewModel
 
         let customViewStyle = QRCodeEducationLoadingView.Style(textColor: .GiniCapture.light1,
-                                                               analysingTextColor: .GiniCapture.light6)
+                                                               analysingTextColor: .GiniCapture.light3)
         let view = QRCodeEducationLoadingView(viewModel: viewModel, style: customViewStyle)
         view.translatesAutoresizingMaskIntoConstraints = false
         educationLoadingView = view

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Resources/de.lproj/Localizable.strings
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Resources/de.lproj/Localizable.strings
@@ -221,3 +221,5 @@
 
 "ginicapture.ibandetection.multipleibansdetected" = "IBAN erkannt";
 "ginicapture.ibandetection.takephoto" = "Machen Sie ein Foto";
+
+"ginicapture.education.loading.accessibility" = "Analyse der Rechnung läuft";

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Resources/en.lproj/Localizable.strings
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Resources/en.lproj/Localizable.strings
@@ -218,3 +218,5 @@
 
 "ginicapture.ibandetection.multipleibansdetected" = "IBAN detected";
 "ginicapture.ibandetection.takephoto" = "Take a photo";
+
+"ginicapture.education.loading.accessibility" = "Analyzing invoice in progress";


### PR DESCRIPTION
Make QR Code Education accessible:
- landscape
- voice over
- font size 200%

When VoiceOver is enabled, the image, the text beneath it , and the analyzing animated text will be read aloud as a single element. The text that should be read is the one displayed directly below the image and the accessibility text for the animated loading text. Value of the animated loading text for voice over should be:  “analyzing invoice in progress” – “analyse der Rechnung läuft”.

Font size 200% tested on iPhone SE first gen simulator just on capture invoice flow:

https://github.com/user-attachments/assets/c162923a-4b17-409d-8faa-7ea13916c5d7

https://github.com/user-attachments/assets/58565d50-2d31-46e1-8a73-e276f5d35e16

https://github.com/user-attachments/assets/5ec34c1e-923f-40ea-85df-bc1d21f826d7


