### PR TITLE
fix(GiniCaptureSDK):  Add `optional` to `topConstraint` to avoid the …

### DIFF
--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Onboarding/Views/OnboardingPageCell.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Onboarding/Views/OnboardingPageCell.swift
@@ -13,7 +13,7 @@ class OnboardingPageCell: UICollectionViewCell {
     @IBOutlet weak var descriptionLabel: UILabel!
 
     @IBOutlet private weak var iconBottomConstraint: NSLayoutConstraint!
-    @IBOutlet private weak var topConstraint: NSLayoutConstraint!
+    @IBOutlet private weak var topConstraint: NSLayoutConstraint?
 
     override func awakeFromNib() {
         super.awakeFromNib()
@@ -49,14 +49,14 @@ class OnboardingPageCell: UICollectionViewCell {
     override func layoutSubviews() {
         if UIDevice.current.isIpad {
             if UIWindow.orientation.isLandscape {
-                topConstraint.constant = Constants.compactTopPadding
+                topConstraint?.constant = Constants.compactTopPadding
                 iconBottomConstraint.constant = calculateIconMargin()
             } else {
-                topConstraint.constant = Constants.regularTopPadding
+                topConstraint?.constant = Constants.regularTopPadding
                 iconBottomConstraint.constant = Constants.maxIconPadding
             }
         } else if currentInterfaceOrientation.isPortrait {
-            topConstraint.constant = Constants.compactTopPadding
+            topConstraint?.constant = Constants.compactTopPadding
             iconBottomConstraint.constant = calculateIconMargin()
         }
         super.layoutSubviews()


### PR DESCRIPTION
Fix the crash related to changing from portrait to landscape on Capture SDK onboarding

- Use optional constraint instead of force unwrap since there are `xibs` that doesn't use this reference.

PP-1383