### PR TITLE
PP-1239-Disable-bottom-tips-when-the-QR-code-education-message-is-displayed-on-the-Analysis-screen

### DIFF
--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/EducationFlow/Views/QRCodeEducation/QRCodeEducationLoadingViewModel.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/EducationFlow/Views/QRCodeEducation/QRCodeEducationLoadingViewModel.swift
@@ -19,26 +19,26 @@ final class QRCodeEducationLoadingViewModel {
         self.items = items
     }
 
-    /*
-     Starts the animation and calls `completion` once all items are shown.
-     Each item is set on the main thread and displayed for its specified duration.
-     If no items are available, the method returns immediately.
+    /**
+     Starts the sequential display of all educational animation items.
+
+     - Ensures each item is presented on the main thread by assigning it to `currentItem`.
+     - Waits asynchronously for the specified duration of each item before proceeding to the next.
+     - If no items are available, the method exits immediately without performing any actions.
+
+     This method is `async` and can be awaited. It is intended to be called inside an `async` context,
+     such as a `Task` block, to manage the lifecycle of the animation flow.
      */
-    func start(completion: (() -> Void)? = nil) {
-        Task {
-            guard !items.isEmpty else {
-                completion?()
-                return
-            }
+    func start() async {
+        guard !items.isEmpty else {
+            return
+        }
 
-            for item in items {
-                await MainActor.run {
-                    self.currentItem = item
-                }
-                try? await Task.sleep(nanoseconds: item.durationInNanoseconds)
+        for item in items {
+            await MainActor.run {
+                self.currentItem = item
             }
-
-            completion?()
+            try? await Task.sleep(nanoseconds: item.durationInNanoseconds)
         }
     }
 }

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Analysis/AnalysisViewController.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Analysis/AnalysisViewController.swift
@@ -43,6 +43,7 @@ import UIKit
 
     private var animationCompletionContinuations: [CheckedContinuation<Void, Never>] = []
     private var educationFlowController: EducationFlowController?
+    private var educationAnimationFinished: Bool = false
     private var shouldShowOriginalFlow: Bool {
         guard let state = educationFlowController?.nextState() else {
             return false
@@ -281,19 +282,25 @@ import UIKit
                                                         constant: -Constants.educationLoadingViewPadding)
         ])
 
-        /// Starts the loading animation and handles post-animation cleanup.
-        ///
-        /// The animation is triggered via `viewModel.start(completion:)`, which plays
-        /// all loading items sequentially. Once completed, this block resumes any
-        /// suspended tasks in `waitUntilAnimationCompleted()`, clears them, and notifies
-        /// the flow controller that the message has been shown.
-        viewModel.start { [weak self] in
-            guard let self else { return }
-            self.animationCompletionContinuations.forEach { $0.resume() }
-            self.animationCompletionContinuations.removeAll()
-            self.loadingViewModel = nil
-            self.educationFlowController?.markMessageAsShown()
+        Task {
+            await finalizeEducationAnimation(viewModel)
         }
+    }
+
+    /**
+     Handles the finalization of the education animation sequence:
+     - Starts the view model lifecycle.
+     - Resumes all pending animation completion continuations.
+     - Clears the continuation list to avoid memory leaks or duplicate calls.
+     - Flags the animation as finished to update UI state.
+     - Marks the educational message as shown to prevent it from appearing again.
+     */
+    private func finalizeEducationAnimation(_ viewModel: QRCodeEducationLoadingViewModel) async {
+        await viewModel.start()
+        animationCompletionContinuations.forEach { $0.resume() }
+        animationCompletionContinuations.removeAll()
+        educationAnimationFinished = true
+        educationFlowController?.markMessageAsShown()
     }
 
     /**
@@ -304,8 +311,12 @@ import UIKit
      */
     public func waitUntilAnimationCompleted() async {
         await withCheckedContinuation { continuation in
-            // If no loadingViewModel or no pending animation, return immediately
-            if loadingViewModel == nil || animationCompletionContinuations.isEmpty {
+            guard loadingViewModel != nil else {
+                continuation.resume()
+                return
+            }
+
+            if educationAnimationFinished {
                 continuation.resume()
             } else {
                 animationCompletionContinuations.append(continuation)


### PR DESCRIPTION
When the QR code education message is displayed, the bottom screen tips should not be displayed. In case the request is slow, in landscape mode these tips are hidding the qrcode education message.