### PR TITLE
PP-1442 E- invoice open with support in demo app

### DIFF
--- a/BankSDK/GiniBankSDKExample/GiniBankSDKExample/Info.plist
+++ b/BankSDK/GiniBankSDKExample/GiniBankSDKExample/Info.plist
@@ -10,6 +10,18 @@
 	<array>
 		<dict>
 			<key>CFBundleTypeName</key>
+			<string>XML</string>
+			<key>CFBundleTypeRole</key>
+			<string>Viewer</string>
+			<key>LSHandlerRank</key>
+			<string>Alternate</string>
+			<key>LSItemContentTypes</key>
+			<array>
+				<string>public.xml</string>
+			</array>
+		</dict>
+		<dict>
+			<key>CFBundleTypeName</key>
 			<string>PDF</string>
 			<key>CFBundleTypeRole</key>
 			<string>Editor</string>


### PR DESCRIPTION
Support opening XML files in app document types.
Adds `public.xml` to `CFBundleDocumentTypes` to enable XML file support.