### PR TITLE
Ipc 727 forward to installed app

### DIFF
--- a/HealthSDK/GiniHealthSDKExample/GiniHealthSDKExample/Info.plist
+++ b/HealthSDK/GiniHealthSDKExample/GiniHealthSDKExample/Info.plist
@@ -57,6 +57,26 @@
 	</array>
 	<key>LSApplicationQueriesSchemes</key>
 	<array>
+		<string>ginipay-DDsmpHs93puLf</string>
+		<string>ginipay-ptYzZrNmlgWsW</string>
+		<string>ginipay-za5wWqjtY5cWu</string>
+		<string>ginipay-m6BnyhqnMm72p</string>
+		<string>ginipay-Jdl5QfQ9THAiW</string>
+		<string>ginipay-CDNzcNw9krqiR</string>
+		<string>ginipay-5H2aVOlpoN4Rz</string>
+		<string>ginipay-b7rI96et3Z18P</string>
+		<string>ginipay-bnwH3OMawKL6j</string>
+		<string>ginipay-FalLmit8eStZb</string>
+		<string>ginipay-DrL5HACXXdOlU</string>
+		<string>ginipay-a5h6BTnIfio93</string>
+		<string>ginipay-kireHcM4F5KnF</string>
+		<string>ginipay-i0WYoJLMVzeJ3</string>
+		<string>ginipay-lnFwi5PCkySPI</string>
+		<string>ginipay-WZFeM1e49JISj</string>
+		<string>ginipay-McR1xIgY4QqKz</string>
+		<string>ginipay-eCzol0zXPebH9</string>
+		<string>ginipay-Gru1iJF31Yd0v</string>
+		<string>ginipay-3Xas3pKiFtS93</string>
 		<string>ginipay-PBJWducqgKNAR</string>
 		<string>ginipay-insurance-bank-mock</string>
 		<string>ginipay-cbwm</string>


### PR DESCRIPTION
This PR adds the scheme of the supported Gini Banks in order to be able to know if the corresponding Bank app is installed or not. 

IPC-727