### PR TITLE
IPC-754 Tap on Pay Directly button from Invoices list screen is crashing in landscape mode

### DIFF
--- a/GiniComponents/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentComponents/PaymentComponentBottomView.swift
+++ b/GiniComponents/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentComponents/PaymentComponentBottomView.swift
@@ -62,7 +62,7 @@ public final class PaymentComponentBottomView: GiniBottomSheetViewController {
 
     private func setupView() {
         addScrollViewConstraints()
-        configureBottomSheet()
+        configureBottomSheet(shouldIncludeLargeDetent: true)
         bindToSizeUpdate()
         setContent()
         contentView.addSubview(paymentView)
@@ -86,7 +86,7 @@ public final class PaymentComponentBottomView: GiniBottomSheetViewController {
     }
     
     private func setContent() {
-        emptyScrollView.addSubview(contentView)
+        emptyScrollView.addContentSubview(contentView)
         
         NSLayoutConstraint.activate([
             contentView.topAnchor.constraint(equalTo: emptyScrollView.topAnchor,


### PR DESCRIPTION
## Pull Request Description

This PR fixes a crash related to a `BottomSheet` starting on landscape mode. Since `.medium` detent doesn't exist on landscape that was causing the app to crash because there was no available `detent` to start with. 

[IPC-754]

To be fixed, the `.large` detent is always added to the available `detents` but later the `@Publisher` is updating to only what is needed. 

## Notes for Reviewers

In order to test you need to do a fresh install of Gini Health Example app and start the flow already on `landscape` mode. 