### PR TITLE
Ipc 747 inline error messages not displayed landscape

### DIFF
--- a/GiniComponents/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReviewContainer/PaymentReviewContainerView.swift
+++ b/GiniComponents/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReviewContainer/PaymentReviewContainerView.swift
@@ -994,7 +994,7 @@ private class ErrorBottomSheet: GiniBottomSheetViewController {
         super.viewDidLoad()
         
         view.backgroundColor = .systemBackground
-        addSCrollView()
+        addScrollView()
         bindToSizeUpdates()
         addErrorLabel()
         configureBottomSheet(shouldIncludeLargeDetent: true)
@@ -1003,7 +1003,7 @@ private class ErrorBottomSheet: GiniBottomSheetViewController {
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         
-        startTimer()
+        startErrorDismiss()
     }
     
     func configure(errorMessage: String, font: UIFont) {
@@ -1012,7 +1012,7 @@ private class ErrorBottomSheet: GiniBottomSheetViewController {
     }
     
     
-    func addSCrollView() {
+    func addScrollView() {
         view.addSubview(scrollView)
         
         NSLayoutConstraint.activate([
@@ -1042,8 +1042,8 @@ private class ErrorBottomSheet: GiniBottomSheetViewController {
             }.store(in: &cancellables)
     }
     
-    func startTimer() {
-        Timer.scheduledTimer(withTimeInterval: 2, repeats: false) { [weak self] _ in
+    func startErrorDismiss() {
+        DispatchQueue.main.asyncAfter(deadline: .now() + 2) { [weak self] in
             self?.dismiss(animated: true)
         }
     }

--- a/GiniComponents/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PoweredByGini/PoweredByGiniView.swift
+++ b/GiniComponents/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PoweredByGini/PoweredByGiniView.swift
@@ -11,7 +11,7 @@ import GiniUtilites
 
 public final class PoweredByGiniView: UIView {
     private let viewModel: PoweredByGiniViewModel
-    private let mainContainer = EmptyView()
+    private let mainContainer = AccessibleView()
 
     private lazy var poweredByGiniLabel: UILabel = {
         let label = UILabel()
@@ -21,6 +21,7 @@ public final class PoweredByGiniView: UIView {
         label.font = viewModel.configuration.poweredByGiniLabelFont
         label.numberOfLines = Constants.textNumberOfLines
         label.adjustsFontSizeToFitWidth = true
+        label.isAccessibilityElement = false
         label.textAlignment = .right
         return label
     }()
@@ -37,6 +38,7 @@ public final class PoweredByGiniView: UIView {
         self.viewModel = viewModel
         super.init(frame: .zero)
         setupView()
+        setupAccessibility()
     }
     
     required init?(coder: NSCoder) {
@@ -63,6 +65,12 @@ public final class PoweredByGiniView: UIView {
             giniImageView.widthAnchor.constraint(equalToConstant: giniImageView.frame.width),
             giniImageView.centerYAnchor.constraint(equalTo: mainContainer.centerYAnchor)
         ])
+    }
+    
+    private func setupAccessibility() {
+        mainContainer.isAccessibilityElement = true
+        mainContainer.accessibilityLabel = viewModel.strings.poweredByGiniText + "Gini"
+        mainContainer.accessibilityElements = [poweredByGiniLabel, giniImageView]
     }
 }
 

--- a/GiniComponents/GiniUtilites/Sources/GiniUtilites/Extensions/UIResponder+Extensions.swift
+++ b/GiniComponents/GiniUtilites/Sources/GiniUtilites/Extensions/UIResponder+Extensions.swift
@@ -1,0 +1,39 @@
+//
+//  UIResponder+Extensions.swift
+//
+//  Copyright © 2025 Gini GmbH. All rights reserved.
+//
+
+import UIKit
+
+public extension UIResponder {
+    
+    /// Recursively searches up the responder chain to find the parent view controller.
+    ///
+    /// This computed property traverses the responder chain starting from the current
+    /// UIResponder instance and returns the first UIViewController found in the chain.
+    /// It's particularly useful when you need to access the parent view controller
+    /// from a UIView or any other UIResponder subclass.
+    ///
+    /// - Returns: The parent UIViewController if found in the responder chain, nil otherwise.
+    ///
+    /// - Note: This property uses recursive traversal through the `next` property
+    ///         of the responder chain until it finds a UIViewController or reaches
+    ///         the end of the chain.
+    ///
+    /// Example usage:
+    /// ```swift
+    /// // From within a UIView
+    /// if let parentVC = self.parentViewController {
+    ///     parentVC.present(alertController, animated: true)
+    /// }
+    ///
+    /// // From a UIButton action
+    /// @IBAction func buttonTapped(_ sender: UIButton) {
+    ///     sender.parentViewController?.navigationController?.popViewController(animated: true)
+    /// }
+    ///```
+    var parentViewController: UIViewController? {
+        next as? UIViewController ?? next?.parentViewController
+    }
+}


### PR DESCRIPTION
## Pull Request Description

This PR fixes the issue related to inline errors not being displayed on `landscape mode` for `PaymentReviewScreen`

[IPC-747]

<!--

- An `scrollView` was added to the `containerView` in order to allow the content to grow while the inline errors are displayed. 

-->

## Notes for Reviewers

<!--

- To test you need to go from `portrait` to `landscape` on `PaymentReviewScreen` also in `200%` font size. 
 
 - There are some minor UI glitches caused by how to screen is built. If you can take a look and provide ideas on how to resolve them are welcome. 
 
 -->

[IPC-747]: https://ginis.atlassian.net/browse/IPC-747?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ