### PR TITLE
Ipc 513 contrast issue

### DIFF
--- a/GiniComponents/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentInfo/PaymentInfoConfiguration.swift
+++ b/GiniComponents/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentInfo/PaymentInfoConfiguration.swift
@@ -27,6 +27,7 @@ public struct PaymentInfoConfiguration {
     let backgroundColor: UIColor
     let closeIcon: UIImage?
     let closeIconTintColor: UIColor?
+    let questionHeaderIconTintColor: UIColor
 
     public init(giniFont: UIFont,
                 answersFont: UIFont,
@@ -47,7 +48,8 @@ public struct PaymentInfoConfiguration {
                 separatorColor: UIColor,
                 backgroundColor: UIColor,
                 closeIcon: UIImage? = nil,
-                closeIconTintColor: UIColor? = nil) {
+                closeIconTintColor: UIColor? = nil,
+                questionHeaderIconTintColor: UIColor) {
         self.giniFont = giniFont
         self.answersFont = answersFont
         self.answerCellTextColor = answerCellTextColor
@@ -68,6 +70,7 @@ public struct PaymentInfoConfiguration {
         self.backgroundColor = backgroundColor
         self.closeIcon = closeIcon
         self.closeIconTintColor = closeIconTintColor
+        self.questionHeaderIconTintColor = questionHeaderIconTintColor
     }
 }
 

--- a/GiniComponents/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentInfo/PaymentInfoQuestionHeaderViewCell.swift
+++ b/GiniComponents/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentInfo/PaymentInfoQuestionHeaderViewCell.swift
@@ -67,6 +67,7 @@ final class PaymentInfoQuestionHeaderViewCell: UIView {
         titleLabel.textColor = viewModel.titleColor
         titleLabel.font = viewModel.titleFont
         extendedImageView.image = viewModel.extendedIcon
+        extendedImageView.tintColor = viewModel.iconTintColor
         accessibilityLabel = viewModel.titleText
     }
     
@@ -97,12 +98,15 @@ struct PaymentInfoQuestionHeaderViewModel {
     let titleFont: UIFont
     let titleColor: UIColor
     let extendedIcon: UIImage
+    let iconTintColor: UIColor
 
-    init(titleText: String, titleFont: UIFont, titleColor: UIColor, extendedIcon: UIImage) {
+
+    init(titleText: String, titleFont: UIFont, titleColor: UIColor, extendedIcon: UIImage, iconTintColor: UIColor) {
         self.titleText = titleText
         self.titleFont = titleFont
         self.titleColor = titleColor
-        self.extendedIcon = extendedIcon
+        self.extendedIcon = extendedIcon.withRenderingMode(.alwaysTemplate)
+        self.iconTintColor = iconTintColor
     }
 }
 

--- a/GiniComponents/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentInfo/PaymentInfoViewModel.swift
+++ b/GiniComponents/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentInfo/PaymentInfoViewModel.swift
@@ -112,7 +112,8 @@ public final class PaymentInfoViewModel {
         PaymentInfoQuestionHeaderViewModel(titleText: questions[index].title, 
                                            titleFont: configuration.questionHeaderFont,
                                            titleColor: configuration.questionHeaderTitleColor,
-                                           extendedIcon: questions[index].isExtended ? configuration.questionHeaderMinusIcon : configuration.questionHeaderPlusIcon)
+                                           extendedIcon: questions[index].isExtended ? configuration.questionHeaderMinusIcon : configuration.questionHeaderPlusIcon,
+                                           iconTintColor: configuration.questionHeaderIconTintColor)
     }
 
     func infoBankCellModel(at index: Int) -> PaymentInfoBankCollectionViewCellModel {

--- a/HealthSDK/GiniHealthSDK/Sources/GiniHealthSDK/Core/GiniHealth+PaymentComponentsConfigurationProvider.swift
+++ b/HealthSDK/GiniHealthSDK/Sources/GiniHealthSDK/Core/GiniHealth+PaymentComponentsConfigurationProvider.swift
@@ -101,7 +101,8 @@ extension GiniHealth: PaymentComponentsConfigurationProvider {
             separatorColor: GiniColor.standard5.uiColor(),
             backgroundColor: GiniColor.standard7.uiColor(),
             closeIcon: GiniHealthImage.close.preferredUIImage(),
-            closeIconTintColor: GiniColor.standard2.uiColor()
+            closeIconTintColor: GiniColor.standard2.uiColor(),
+            questionHeaderIconTintColor: GiniColor.accent1.uiColor()
         )
     }
 
@@ -136,7 +137,7 @@ extension GiniHealth: PaymentComponentsConfigurationProvider {
     public var paymentReviewConfiguration: PaymentReviewConfiguration {
         PaymentReviewConfiguration(
             loadingIndicatorStyle: UIActivityIndicatorView.Style.large,
-            loadingIndicatorColor: GiniHealthColorPalette.accent1.preferredColor(),
+            loadingIndicatorColor: GiniColor.accent1.uiColor(),
             infoBarLabelTextColor: GiniHealthColorPalette.dark7.preferredColor(),
             infoBarBackgroundColor: GiniColor.success1.uiColor(),
             mainViewBackgroundColor: GiniColor.standard7.uiColor(),

--- a/HealthSDK/GiniHealthSDK/Sources/GiniHealthSDK/Core/GiniHealthColors.swift
+++ b/HealthSDK/GiniHealthSDK/Sources/GiniHealthSDK/Core/GiniHealthColors.swift
@@ -44,6 +44,9 @@ enum GiniHealthColorPalette: String {
     case success2 = "Success02"
     case success3 = "Success03"
     case success4 = "Success04"
+    
+    case darkAccent1 = "Accent01Dark"
+    case lightAccent1 = "Accent01Light"
 }
 
 extension GiniHealthColorPalette {
@@ -69,7 +72,7 @@ extension GiniColor {
     static let standard7 = GiniColor(lightModeColorName: .dark7, darkModeColorName: .light7)
     static let standard8 = GiniColor(lightModeColorName: .dark8, darkModeColorName: .light8)
 
-    static let accent1 = GiniColor(lightModeColorName: .accent1, darkModeColorName: .accent1)
+    static let accent1 = GiniColor(lightModeColorName: .darkAccent1, darkModeColorName: .lightAccent1)
 
     static let feedback1 = GiniColor(lightModeColorName: .feedback1, darkModeColorName: .feedback1)
     

--- a/HealthSDK/GiniHealthSDK/Sources/GiniHealthSDK/Core/GiniHealthConfiguration.swift
+++ b/HealthSDK/GiniHealthSDK/Sources/GiniHealthSDK/Core/GiniHealthConfiguration.swift
@@ -95,7 +95,7 @@ public final class GiniHealthConfiguration: NSObject {
     /**
      A configuration that defines the appearance of the primary button, including its background color, border color, title color, shadow color, corner radius, border width, shadow radius, and whether to apply a blur effect. It is used for buttons on different UI elements: Payment Component View, Payment Review Screen.
      */
-    public lazy var primaryButtonConfiguration = ButtonConfiguration(backgroundColor: GiniHealthColorPalette.accent1.preferredColor().withAlphaComponent(0.4),
+    public lazy var primaryButtonConfiguration = ButtonConfiguration(backgroundColor: GiniColor.accent1.uiColor().withAlphaComponent(0.4),
                                                                      borderColor: .clear,
                                                                      titleColor: .white,
                                                                      titleFont: font(for: .button),
@@ -123,7 +123,7 @@ public final class GiniHealthConfiguration: NSObject {
      A default style configuration that defines the appearance of the text field, including its background color, border color, text color, corner radius, border width and the placeholder foreground color. It is used for input text fields on  Payment Review Screen.
      */
     public lazy var defaultStyleInputFieldConfiguration = TextFieldConfiguration(backgroundColor: GiniColor.standard6.uiColor(),
-                                                                                 borderColor: GiniColor.standard5.uiColor(),
+                                                                                 borderColor: GiniColor.standard6.uiColor(),
                                                                                  textColor: GiniColor.standard1.uiColor(),
                                                                                  textFont: font(for: .captions2),
                                                                                  cornerRadius: 12.0,

--- a/HealthSDK/GiniHealthSDK/Sources/GiniHealthSDK/Resources/GiniColors.xcassets/Accent01Dark.colorset/Contents.json
+++ b/HealthSDK/GiniHealthSDK/Sources/GiniHealthSDK/Resources/GiniColors.xcassets/Accent01Dark.colorset/Contents.json
@@ -5,8 +5,8 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0xDC",
-          "green" : "0x9E",
+          "blue" : "0xCF",
+          "green" : "0x6E",
           "red" : "0x00"
         }
       },

--- a/HealthSDK/GiniHealthSDK/Sources/GiniHealthSDK/Resources/GiniColors.xcassets/Accent01Light.colorset/Contents.json
+++ b/HealthSDK/GiniHealthSDK/Sources/GiniHealthSDK/Resources/GiniColors.xcassets/Accent01Light.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0xAD",
-          "green" : "0xAD",
-          "red" : "0xAD"
+          "blue" : "0xEE",
+          "green" : "0x7F",
+          "red" : "0x00"
         }
       },
       "idiom" : "universal"

--- a/MerchantSDK/GiniMerchantSDK/Sources/GiniMerchantSDK/Core/GiniMerchant+PaymentComponentsConfigurationProvider.swift
+++ b/MerchantSDK/GiniMerchantSDK/Sources/GiniMerchantSDK/Core/GiniMerchant+PaymentComponentsConfigurationProvider.swift
@@ -99,7 +99,8 @@ extension GiniMerchant: PaymentComponentsConfigurationProvider {
             linksFont: GiniMerchantConfiguration.shared.font(for: .linkBold),
             linksColor: GiniColor.accent1.uiColor(),
             separatorColor: GiniColor.standard5.uiColor(),
-            backgroundColor: GiniColor.standard7.uiColor()
+            backgroundColor: GiniColor.standard7.uiColor(),
+            questionHeaderIconTintColor: GiniColor.accent1.uiColor()
         )
     }
     


### PR DESCRIPTION
## Pull Request Description

<!-- Briefly explain **what** this PR does and **why**. Mention the motivation, feature, or issue it's addressing. -->
This PR consists of color-related changes across the Payment Info module. It introduces support for customizing the tint of question header icons and updates the accent01 color to adapt properly in both light and dark modes.

[IPC-513](https://ginis.atlassian.net/browse/IPC-513)<!-- Closes ticket number PP-####; Replace with JIRA ticket if relevant -->

<!--

Some description of HOW you achieved it. Perhaps give a high level description of the chnages you did. Did you need to refactor something? What tradeoffs did you take?

-->

## Notes for Reviewers
- Added tint color support for question header icons via configuration.
- Updated accent01 to use dynamic colors for light and dark appearance.
<!--

Explain how you verified the changes.
A clear testing scenario helps colleagues who may not be familiar with this part of the code quickly understand and verify the changes. Include steps they can follow to see the impact in action.

You can include: 
- Simulators/Devices you used (e.g. iPhone 13, iPad Pro) 
- iOS versions tested (e.g. 16.0, 17.5) 
- Manual checks (e.g. flow tested: onboarding, permissions, error states) 
- Unit tests added or updated 
 
 Include screenshots, screen recordings, or simulator gifs for UI changes. 
 
 - Optional: Anything that needs extra attention in review? Are there TODOs, known limitations, or follow-up work? 
 
 -->

[IPC-513]: https://ginis.atlassian.net/browse/IPC-513?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ