### PR TITLE
fix(GiniHealthSDK): fixing voice over issue when user taps on label

### DIFF
--- a/GiniComponents/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/InstallApp/InstallAppBottomView.swift
+++ b/GiniComponents/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/InstallApp/InstallAppBottomView.swift
@@ -178,7 +178,7 @@ public final class InstallAppBottomView: GiniBottomSheetViewController {
     }
 
     private func setupAccessibility() {
-        accessibilityElements = [
+        view.accessibilityElements = [
             titleLabel,
             bankIconImageView,
             moreInformationLabel,

--- a/GiniComponents/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/ShareInvoice/ShareInvoiceBottomView.swift
+++ b/GiniComponents/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/ShareInvoice/ShareInvoiceBottomView.swift
@@ -159,7 +159,7 @@ public final class ShareInvoiceBottomView: GiniBottomSheetViewController {
     }
     
     private func setupAccessibility() {
-        accessibilityElements = [
+        view.accessibilityElements = [
             titleLabel,
             qrImageView,
             continueButton,

--- a/GiniComponents/GiniUtilites/Sources/GiniUtilites/Protocols/GiniBottomSheetPresentable.swift
+++ b/GiniComponents/GiniUtilites/Sources/GiniUtilites/Protocols/GiniBottomSheetPresentable.swift
@@ -98,10 +98,19 @@ public extension GiniBottomSheetPresentable where Self: UIViewController {
         /// For iOS versions prior to 15, the view controller will be presented as a standard modal sheet
         if #available(iOS 15, *),
            let presentationController = sheetPresentationController {
-            presentationController.detents = [shouldIncludeLargeDetent ? .large() : .medium()]
             presentationController.prefersGrabberVisible = shouldShowDragIndicator
             presentationController.prefersScrollingExpandsWhenScrolledToEdge = false
             presentationController.prefersEdgeAttachedInCompactHeight = !shouldShowInFullScreenInLandscapeMode
+            
+            if #available(iOS 16, *) {
+                let halfScreenDetent = UISheetPresentationController.Detent.custom { context in
+                    self.view.bounds.height / 2
+                }
+                
+                presentationController.detents = [shouldIncludeLargeDetent ? .large() : halfScreenDetent]
+            } else {
+                presentationController.detents = [shouldIncludeLargeDetent ? .large() : .medium()]
+            }
         }
     }
     
@@ -116,6 +125,7 @@ public extension GiniBottomSheetPresentable where Self: UIViewController {
                 return height
             }
             
+            presentationController.prefersGrabberVisible = shouldShowDragIndicator
             presentationController.detents = [customDetent]
             presentationController.selectedDetentIdentifier = identifier
         }


### PR DESCRIPTION
IPC-540

## Pull Request Description

<!-- Briefly explain **what** this PR does and **why**. Mention the motivation, feature, or issue it's addressing. -->

Fixed issue when user tap on sub view and it wont say anything

[IPC-540](https://ginis.atlassian.net/browse/IPC-540)<!-- Closes ticket number PP-####; Replace with JIRA ticket if relevant -->

<!--

Some description of HOW you achieved it. Perhaps give a high level description of the chnages you did. Did you need to refactor something? What tradeoffs did you take?

-->

## Notes for Reviewers
Updated setupAccessibility() to set accessibilityElements on the view instead of the view controller itself. This make sure VoiceOver can properly focus on and read each individual element.
<!--

Explain how you verified the changes.
A clear testing scenario helps colleagues who may not be familiar with this part of the code quickly understand and verify the changes. Include steps they can follow to see the impact in action.

You can include: 
- Simulators/Devices you used (e.g. iPhone 13, iPad Pro) 
- iOS versions tested (e.g. 16.0, 17.5) 
- Manual checks (e.g. flow tested: onboarding, permissions, error states) 
- Unit tests added or updated 
 
 Include screenshots, screen recordings, or simulator gifs for UI changes. 
 
 - Optional: Anything that needs extra attention in review? Are there TODOs, known limitations, or follow-up work? 
 
 -->

[IPC-540]: https://ginis.atlassian.net/browse/IPC-540?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ