### PR TITLE
Pp 1450 voice over skonto issue

### DIFF
--- a/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/ReturnAssistant/Onboarding/DigitalInvoiceOnboardingHorizontalItem.swift
+++ b/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/ReturnAssistant/Onboarding/DigitalInvoiceOnboardingHorizontalItem.swift
@@ -39,9 +39,11 @@ class DigitalInvoiceOnboardingHorizontalItem: UIView {
 
         stack.translatesAutoresizingMaskIntoConstraints = false
         doneButton.translatesAutoresizingMaskIntoConstraints = false
-        
-        let widthConstraint = doneButton.widthAnchor.constraint(greaterThanOrEqualToConstant: Constants.doneButtonMinWidth)
-            widthConstraint.priority = .defaultHigh
+
+        let widthConstraint = doneButton.widthAnchor
+            .constraint(greaterThanOrEqualToConstant: Constants.doneButtonMinWidth)
+
+        widthConstraint.priority = .defaultHigh
 
         NSLayoutConstraint.activate([
             widthConstraint,
@@ -157,8 +159,10 @@ class DigitalInvoiceOnboardingHorizontalItem: UIView {
             // Constraints for the scroll view itself
             rightStackViewContainerScrollable.topAnchor.constraint(equalTo: topImageView.topAnchor),
             rightStackViewContainerScrollable.bottomAnchor.constraint(equalTo: bottomAnchor),
-            rightStackViewContainerScrollable.leadingAnchor.constraint(equalTo: topImageView.trailingAnchor,
-                                                                       constant: Constants.horizontalSpacingBetweenImageViewAndText),
+            rightStackViewContainerScrollable.leadingAnchor.constraint(
+                equalTo: topImageView.trailingAnchor,
+                constant: Constants.horizontalSpacingBetweenImageViewAndText
+            ),
             rightStackViewContainerScrollable.trailingAnchor.constraint(equalTo: safeAreaLayoutGuide.trailingAnchor)
         ])
     }

--- a/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/ReturnAssistant/Onboarding/DigitalInvoiceOnboardingHorizontalItem.swift
+++ b/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/ReturnAssistant/Onboarding/DigitalInvoiceOnboardingHorizontalItem.swift
@@ -39,9 +39,12 @@ class DigitalInvoiceOnboardingHorizontalItem: UIView {
 
         stack.translatesAutoresizingMaskIntoConstraints = false
         doneButton.translatesAutoresizingMaskIntoConstraints = false
+        
+        let widthConstraint = doneButton.widthAnchor.constraint(greaterThanOrEqualToConstant: Constants.doneButtonMinWidth)
+            widthConstraint.priority = .defaultHigh
+
         NSLayoutConstraint.activate([
-            stack.widthAnchor.constraint(equalToConstant: Constants.stackViewWidth),
-            doneButton.widthAnchor.constraint(greaterThanOrEqualToConstant: Constants.doneButtonMinWidth),
+            widthConstraint,
             doneButton.heightAnchor.constraint(equalToConstant: Constants.doneButtonHeight)
         ])
         return stack
@@ -149,7 +152,7 @@ class DigitalInvoiceOnboardingHorizontalItem: UIView {
             topImageView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -Constants.paddingLarge),
             topImageView.leadingAnchor.constraint(equalTo: safeAreaLayoutGuide.leadingAnchor,
                                                   constant: Constants.paddingLarge),
-            topImageView.widthAnchor.constraint(equalToConstant: 220),
+            topImageView.widthAnchor.constraint(lessThanOrEqualToConstant: Constants.imageWidth),
 
             // Constraints for the scroll view itself
             rightStackViewContainerScrollable.topAnchor.constraint(equalTo: topImageView.topAnchor),
@@ -173,6 +176,7 @@ private extension DigitalInvoiceOnboardingHorizontalItem {
         static let stackViewItemSpacing: CGFloat = 40
         static let doneButtonMinWidth: CGFloat = 170
         static let doneButtonHeight: CGFloat = 50
+        static let imageWidth: CGFloat = 220
     }
 
     func shouldHideButton() -> Bool {

--- a/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/ReturnAssistant/Onboarding/DigitalInvoiceOnboardingViewController.swift
+++ b/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/ReturnAssistant/Onboarding/DigitalInvoiceOnboardingViewController.swift
@@ -206,6 +206,8 @@ final class DigitalInvoiceOnboardingViewController: UIViewController {
         if GiniBankConfiguration.shared.bottomNavigationBarEnabled {
             navigationBarHeightConstraint.constant = getBottomBarHeight()
         }
+        updateAccessibilityElements()
+
         guard UIDevice.current.isIpad else { return }
         coordinator.animate(alongsideTransition: { [weak self] _ in
             guard let self = self else { return }
@@ -216,6 +218,15 @@ final class DigitalInvoiceOnboardingViewController: UIViewController {
                                                                                 multiplier: self.widthMultiplier)
             self.scrollViewWidthAnchor.isActive = true
         })
+    }
+
+    private func updateAccessibilityElements() {
+        let isLandscape = UIDevice.current.isLandscape
+        if isLandscape {
+            view.accessibilityElements = [horizontalItem]
+        } else {
+            view.accessibilityElements = [topImageView as Any, firstLabel as Any, secondLabel as Any, doneButton as Any]
+        }
     }
 
     @objc func doneAction(_ sender: UIButton!) {

--- a/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/ReturnAssistant/Onboarding/DigitalInvoiceOnboardingViewController.swift
+++ b/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/ReturnAssistant/Onboarding/DigitalInvoiceOnboardingViewController.swift
@@ -226,7 +226,7 @@ final class DigitalInvoiceOnboardingViewController: UIViewController {
         if isLandscape {
             view.accessibilityElements = [horizontalItem]
         } else {
-            view.accessibilityElements = [topImageView as Any, firstLabel as Any, secondLabel as Any, doneButton as Any]
+            view.accessibilityElements = [topImageView, firstLabel, secondLabel, doneButton].compactMap { $0 }
         }
     }
 

--- a/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/ReturnAssistant/Onboarding/DigitalInvoiceOnboardingViewController.swift
+++ b/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/ReturnAssistant/Onboarding/DigitalInvoiceOnboardingViewController.swift
@@ -21,7 +21,7 @@ final class DigitalInvoiceOnboardingViewController: UIViewController {
     @IBOutlet private weak var scrollViewTopConstraint: NSLayoutConstraint!
     @IBOutlet private weak var scrollViewBottomAnchor: NSLayoutConstraint!
     private var navigationBarHeightConstraint: NSLayoutConstraint!
-    private lazy var horizontalItem = DigitalInvoiceOnboardingHorizontalItem() { [weak self] in
+    private lazy var horizontalItem = DigitalInvoiceOnboardingHorizontalItem { [weak self] in
         self?.doneAction(nil)
     }
     weak var delegate: DigitalInvoiceOnboardingViewControllerDelegate?
@@ -175,7 +175,8 @@ final class DigitalInvoiceOnboardingViewController: UIViewController {
                 view.addSubview(navigationBar)
 
                 navigationBar.translatesAutoresizingMaskIntoConstraints = false
-                navigationBarHeightConstraint = navigationBar.heightAnchor.constraint(equalToConstant: getBottomBarHeight())
+                navigationBarHeightConstraint = navigationBar.heightAnchor
+                    .constraint(equalToConstant: getBottomBarHeight())
 
                 NSLayoutConstraint.activate([
                     navigationBar.leadingAnchor.constraint(equalTo: view.leadingAnchor),
@@ -256,7 +257,7 @@ extension DigitalInvoiceOnboardingViewController {
     }
 
     private func getBottomAnchorForLandscapeView() -> NSLayoutYAxisAnchor {
-        if let _ = GiniBankConfiguration.shared.digitalInvoiceOnboardingNavigationBarBottomAdapter {
+        if GiniBankConfiguration.shared.digitalInvoiceOnboardingNavigationBarBottomAdapter != nil {
             return bottomNavigationBar?.topAnchor ?? view.bottomAnchor
         } else {
             return view.bottomAnchor


### PR DESCRIPTION
## Pull Request Description

This addresses an accessibility issue on the onboarding screen for RA + Skonto. When using VoiceOver in landscape mode, the screen content is read out as if the app is still in portrait mode, causing confusion for users relying on accessibility support.
<!-- Briefly explain **what** this PR does and **why**. Mention the motivation, feature, or issue it's addressing. -->

[PP-1450](https://ginis.atlassian.net/browse/PP-1450)<!-- Closes ticket number PP-####; Replace with JIRA ticket if relevant -->

<!--

Some description of HOW you achieved it. Perhaps give a high level description of the chnages you did. Did you need to refactor something? What tradeoffs did you take?

-->

## Notes for Reviewers
- Set accessibility elements based on orientation
- Fixed layout constraint breaking logs seen during orientation changes (visible in debug output)
- Removed SwiftLint warnings from the relevant classes
<!--

Explain how you verified the changes.
A clear testing scenario helps colleagues who may not be familiar with this part of the code quickly understand and verify the changes. Include steps they can follow to see the impact in action.

You can include: 
- Simulators/Devices you used (e.g. iPhone 13, iPad Pro) 
- iOS versions tested (e.g. 16.0, 17.5) 
- Manual checks (e.g. flow tested: onboarding, permissions, error states) 
- Unit tests added or updated 
 
 Include screenshots, screen recordings, or simulator gifs for UI changes. 
 
 - Optional: Anything that needs extra attention in review? Are there TODOs, known limitations, or follow-up work? 
 
 -->

[PP-1450]: https://ginis.atlassian.net/browse/PP-1450?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ