### PR TITLE
fix(GiniBankSDK): Improve VoiceOver support for non-editable input vi…

### DIFF
--- a/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/Skonto/Views/SkontoAmountToPayView.swift
+++ b/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/Skonto/Views/SkontoAmountToPayView.swift
@@ -197,13 +197,18 @@ class SkontoAmountToPayView: UIView {
         if isEditable {
             textField.text = price.localizedStringWithoutCurrencyCode ?? ""
             containerView.accessibilityHint = Strings.accessibilityHint
+            // Marks the element as editable and frequently updated for VoiceOver
+            containerView.accessibilityTraits = [.updatesFrequently]
         } else {
             textField.text = price.localizedStringWithCurrencyCode ?? ""
             containerView.accessibilityHint = nil
+            // Marks the element as static and disabled for VoiceOver
+            containerView.accessibilityTraits = [.staticText, .notEnabled]
         }
         self.isEditable = isEditable
         containerView.layer.borderWidth = isEditable ? 1 : 0
         containerView.accessibilityValue = accessibilityValue
+
         textField.isUserInteractionEnabled = isEditable
         currencyLabel.isHidden = !isEditable
     }

--- a/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/Skonto/Views/SkontoExpiryDateView.swift
+++ b/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/Skonto/Views/SkontoExpiryDateView.swift
@@ -165,11 +165,18 @@ class SkontoExpiryDateView: UIView, GiniInputAccessoryViewPresentable {
         textField.isUserInteractionEnabled = isSkontoApplied
         calendarImageView.isHidden = !isSkontoApplied
         textField.text = dueDateString
+        configureAccessibility(isSkontoApplied)
+    }
 
+    private func configureAccessibility(_ isSkontoApplied: Bool) {
         if isSkontoApplied {
             accessibilityHint = Strings.accessibilityHint
+            // Marks the element as editable and frequently updated for VoiceOver
+            accessibilityTraits = [.updatesFrequently]
         } else {
             accessibilityHint = nil
+            // Marks the element as static and disabled for VoiceOver
+            accessibilityTraits = [.staticText, .notEnabled]
         }
     }
 


### PR DESCRIPTION
## Pull Request Description
Improves VoiceOver traits for input fields in Skonto when Skonto is not applied.

[PP-1376](https://ginis.atlassian.net/browse/PP-1376)

This PR adjusts the accessibilityTraits of the container view representing the input field. When Skonto is not applied, the field becomes non-editable, and the traits are updated accordingly to improve VoiceOver announcements.

When editable: `accessibilityTraits` is set to` .updatesFrequently`

When non-editable: `accessibilityTraits` is set to `[.staticText, .notEnabled]` to clearly indicate the field is disabled

This change ensures a more accurate and accessible experience for VoiceOver users.

## Notes for Reviewers
N/A

[PP-1376]: https://ginis.atlassian.net/browse/PP-1376?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ