### PR TITLE
fix(GiniBankSDK):  fix layout issue for devices with home button

### DIFF
--- a/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/Skonto/SkontoViewController.swift
+++ b/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/Skonto/SkontoViewController.swift
@@ -146,7 +146,19 @@ final class SkontoViewController: UIViewController {
         sendAnalyticsScreenShown()
     }
 
-    // Called when the view's safe area insets change
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+
+        // On devices without a notch (i.e., no safe area insets at the top),
+        // viewSafeAreaInsetsDidChange() does not called on first appearance.
+        // So we manually trigger the layout adjustment here as a fallback.
+        if firstAppearance && !UIDevice.current.hasNotch {
+            adjustPhoneLayoutForCurrentOrientation()
+        }
+    }
+
+    // This is reliably called on devices that does have a notch
+    // (i.e., have safe area insets)
     override func viewSafeAreaInsetsDidChange() {
         super.viewSafeAreaInsetsDidChange()
         if firstAppearance {


### PR DESCRIPTION
PP-1515

## Pull Request Description

<!-- Briefly explain **what** this PR does and **why**. Mention the motivation, feature, or issue it's addressing. -->

[PP-1515](https://ginis.atlassian.net/browse/PP-1515)<!-- Closes ticket number PP-####; Replace with JIRA ticket if relevant -->

This PR ensures that adjustPhoneLayoutForCurrentOrientation() is reliably called during the first appearance of the view, even on devices without a notch (i.e., no safe area insets).
<!--


Some description of HOW you achieved it. Perhaps give a high level description of the chnages you did. Did you need to refactor something? What tradeoffs did you take?

-->

## Notes for Reviewers
- viewSafeAreaInsetsDidChange() is only called if safe area insets change.
- On notch-less devices, insets may already be zero and static, so this method won’t be triggered.
- By explicitly checking UIDevice.current.hasNotch, we ensure layout adjustment works consistently across all iOS devices.

<!--

Explain how you verified the changes.
A clear testing scenario helps colleagues who may not be familiar with this part of the code quickly understand and verify the changes. Include steps they can follow to see the impact in action.

You can include: 
- Simulators/Devices you used (e.g. iPhone 13, iPad Pro) 
- iOS versions tested (e.g. 16.0, 17.5) 
- Manual checks (e.g. flow tested: onboarding, permissions, error states) 
- Unit tests added or updated 
 
 Include screenshots, screen recordings, or simulator gifs for UI changes. 
 
 - Optional: Anything that needs extra attention in review? Are there TODOs, known limitations, or follow-up work? 
 
 -->