### PR TITLE
Pp 1441 ra voice over in iPad unable to select the toggle using swipe gesture

### DIFF
--- a/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/ReturnAssistant/DigitalInvoice/Components/DigitalLineItemTableViewCell.swift
+++ b/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/ReturnAssistant/DigitalInvoice/Components/DigitalLineItemTableViewCell.swift
@@ -123,6 +123,12 @@ class DigitalLineItemTableViewCell: UITableViewCell {
         nameLabel.font = configuration.textStyleFonts[.body]
         unitPriceLabel.font = configuration.textStyleFonts[.body]
         editButton.titleLabel?.font = configuration.textStyleFonts[.body]
+
+        accessibilityElements = [nameLabel,
+                                 modeSwitch,
+                                 unitPriceLabel,
+                                 priceLabel,
+                                 editButton].compactMap { $0 }
     }
 
     private func setTextWithLimit(for label: UILabel, text: String, maxCharacters: Int) {

--- a/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Resources/DigitalLineItemTableViewCell.xib
+++ b/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Resources/DigitalLineItemTableViewCell.xib
@@ -21,6 +21,13 @@
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="utZ-Ul-3Ih">
                             <rect key="frame" x="0.0" y="0.0" width="414" height="155"/>
                             <subviews>
+                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="6LC-kT-CZp" userLabel="Separator View">
+                                    <rect key="frame" x="0.0" y="0.0" width="349" height="1"/>
+                                    <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                    <constraints>
+                                        <constraint firstAttribute="height" constant="1" id="w1f-up-Wj9"/>
+                                    </constraints>
+                                </view>
                                 <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="CUJ-3d-daD">
                                     <rect key="frame" x="349" y="17" width="51" height="31"/>
                                     <constraints>
@@ -33,20 +40,22 @@
                                     <nil key="textColor"/>
                                     <nil key="highlightedColor"/>
                                 </label>
+                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="1000" text="76 per unit" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gxv-Uq-3b2" userLabel="Unit Price Label">
+                                    <rect key="frame" x="16" y="63.5" width="82" height="20.5"/>
+                                    <constraints>
+                                        <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="50" id="DjP-a3-oEv"/>
+                                    </constraints>
+                                    <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                                    <nil key="textColor"/>
+                                    <nil key="highlightedColor"/>
+                                </label>
                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="252" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" text="€76" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="GOU-G0-cKp">
                                     <rect key="frame" x="16" y="88" width="30" height="20.5"/>
                                     <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                     <nil key="textColor"/>
                                     <nil key="highlightedColor"/>
                                 </label>
-                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="6LC-kT-CZp" userLabel="Separator View">
-                                    <rect key="frame" x="0.0" y="0.0" width="349" height="1"/>
-                                    <color key="backgroundColor" systemColor="systemBackgroundColor"/>
-                                    <constraints>
-                                        <constraint firstAttribute="height" constant="1" id="w1f-up-Wj9"/>
-                                    </constraints>
-                                </view>
-                                <button opaque="NO" contentMode="scaleToFill" semanticContentAttribute="forceRightToLeft" horizontalHuggingPriority="1000" verticalCompressionResistancePriority="749" contentHorizontalAlignment="leading" contentVerticalAlignment="center" lineBreakMode="tailTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ogc-mD-pz6">
+                                <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="1000" verticalCompressionResistancePriority="749" contentHorizontalAlignment="leading" contentVerticalAlignment="center" lineBreakMode="tailTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ogc-mD-pz6">
                                     <rect key="frame" x="16" y="116.5" width="80" height="30.5"/>
                                     <constraints>
                                         <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="80" id="kYO-Wq-hMQ"/>
@@ -60,15 +69,6 @@
                                         <action selector="editButtonTapped:" destination="iN0-l3-epB" eventType="touchUpInside" id="Rmo-hw-Kdk"/>
                                     </connections>
                                 </button>
-                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="1000" text="76 per unit" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gxv-Uq-3b2" userLabel="Unit Price Label">
-                                    <rect key="frame" x="16" y="63.5" width="82" height="20.5"/>
-                                    <constraints>
-                                        <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="50" id="DjP-a3-oEv"/>
-                                    </constraints>
-                                    <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
-                                    <nil key="textColor"/>
-                                    <nil key="highlightedColor"/>
-                                </label>
                             </subviews>
                             <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                             <constraints>
@@ -112,7 +112,7 @@
             <nil key="simulatedBottomBarMetrics"/>
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
             <connections>
-                <outlet property="backgroundContainerView" destination="utZ-Ul-3Ih" id="0b3-Ve-xGB"/>
+                <outlet property="backgroundContainerView" destination="utZ-Ul-3Ih" id="nwB-P5-C0l"/>
                 <outlet property="editButton" destination="ogc-mD-pz6" id="oiL-SO-VZw"/>
                 <outlet property="leadingConstraint" destination="Gbt-6K-DwO" id="HSk-PA-gFy"/>
                 <outlet property="modeSwitch" destination="CUJ-3d-daD" id="fEz-kD-dRR"/>
@@ -133,7 +133,7 @@
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>
         <systemColor name="systemOrangeColor">
-            <color red="1" green="0.58431372549019611" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <color red="1" green="0.58431372550000005" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
     </resources>
 </document>

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Review/ReviewCollectionCell.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Review/ReviewCollectionCell.swift
@@ -21,8 +21,7 @@ final class ReviewCollectionCell: UICollectionViewCell {
         imageView.clipsToBounds = true
         imageView.isAccessibilityElement = true
         imageView.accessibilityTraits = .button
-        imageView.accessibilityLabel = NSLocalizedStringPreferredFormat("ginicapture.review.documentImageTitle",
-                                                                        comment: "Document")
+        imageView.accessibilityLabel = Strings.imageViewAccessibilityLabel
         imageView.backgroundColor = GiniColor(light: UIColor.GiniCapture.light1,
                                               dark: UIColor.GiniCapture.dark1).uiColor()
         return imageView
@@ -38,7 +37,7 @@ final class ReviewCollectionCell: UICollectionViewCell {
         button.isExclusiveTouch = true
         button.isHidden = true
         button.isAccessibilityElement = true
-        button.accessibilityLabel = NSLocalizedStringPreferredFormat("ginicapture.review.delete", comment: "Delete")
+        button.accessibilityLabel = Strings.deleteButtonAccessibilityLabel
         return button
     }()
 
@@ -110,5 +109,12 @@ extension ReviewCollectionCell {
         static let deleteButtonWidth: CGFloat = 44
         static let deleteButtonWidthInset: CGFloat = 16
         static let documentBorderWidth: CGFloat = 2
+    }
+
+    private struct Strings {
+        static let imageViewAccessibilityLabel = NSLocalizedStringPreferredFormat("ginicapture.review.documentImageTitle",
+                                                                                  comment: "Document")
+        static let deleteButtonAccessibilityLabel = NSLocalizedStringPreferredFormat("ginicapture.review.delete",
+                                                                                     comment: "Delete")
     }
 }


### PR DESCRIPTION
## Pull Request Description

Fix VoiceOver navigation issues in DigitalLineItemTableViewCell on iOS 15.

[PP-1441](https://ginis.atlassian.net/browse/PP-1441)

This PR addresses circular navigation issues with VoiceOver accessibility on iOS 15 in the DigitalLineItemTableViewCell. Users were unable to navigate from the edit button to the next table view cell, instead getting trapped in a loop between the edit button and price label. Or the switch button couldn't be reached while swiping when VoiceOver was enabled.

**Changes made:**
1. **Removed incorrect RTL semantic attribute**: Eliminated `semanticContentAttribute="forceRightToLeft"` from the edit button in XIB, which was causing VoiceOver navigation conflicts on iOS 15
2. **Added explicit accessibility element ordering**: Implemented `accessibilityElements` array to ensure consistent VoiceOver navigation sequence: nameLabel → modeSwitch → unitPriceLabel → priceLabel → editButton

The RTL semantic attribute was incorrectly applied. 

iOS 15 VoiceOver became more strict about respecting semantic attributes, causing the navigation loop, while iOS 17+ has better fallback handling for such conflicts.


## Notes for Reviewers

**Testing performed:**
- **Devices tested**: iPad Pro(12.9 inch, iOS: 15.7), iPhone 6s Plus(iOS 15.8.3) and iPhone 15 Pro(iOs 17.0.3)
- **Accessibility testing**: Verified VoiceOver navigation flow with swipe gestures

**Testing steps to verify:**
1. Navigate to RA screen
2. Enable VoiceOver in Settings → Accessibility → VoiceOver
3. Swipe right through all elements in a cell: name → switch → unit price → total price → edit button
4. Continue swiping right from edit button - should move to first element of next cell (not loop back to price label)
5. Test on both iOS 15 and iOS 17+ devices if available

**Notes:**
- Changes affect XIB configuration and accessibility setup only
- No visual or functional changes to the UI
- Fix is specific to iOS 15 VoiceOver behavior but maintains compatibility with all iOS versions

[PP-1441]: https://ginis.atlassian.net/browse/PP-1441?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ