### PR TITLE
Ipc 776 sdk dismissal and duplicated bank list

### DIFF
--- a/GiniComponents/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/BanksView/BanksBottomView.swift
+++ b/GiniComponents/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/BanksView/BanksBottomView.swift
@@ -349,9 +349,7 @@ extension BanksBottomView: UITableViewDataSource, UITableViewDelegate {
     
     /// BanksBottomView event when a bank is selected from the list
     public func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        dismiss(animated: true) { [weak self] in
-            guard let self else { return }
-            viewModel.viewDelegate?.didSelectPaymentProvider(paymentProvider: viewModel.paymentProviders[indexPath.row].paymentProvider)
-        }
+        viewModel.viewDelegate?.didSelectPaymentProvider(paymentProvider: viewModel.paymentProviders[indexPath.row].paymentProvider)
+        dismiss(animated: true)
     }
 }

--- a/GiniComponents/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/BanksView/BanksBottomView.swift
+++ b/GiniComponents/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/BanksView/BanksBottomView.swift
@@ -349,7 +349,9 @@ extension BanksBottomView: UITableViewDataSource, UITableViewDelegate {
     
     /// BanksBottomView event when a bank is selected from the list
     public func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        viewModel.viewDelegate?.didSelectPaymentProvider(paymentProvider: viewModel.paymentProviders[indexPath.row].paymentProvider)
-        dismiss(animated: true)
+        dismiss(animated: true) { [weak self] in
+            guard let self else { return }
+            viewModel.viewDelegate?.didSelectPaymentProvider(paymentProvider: viewModel.paymentProviders[indexPath.row].paymentProvider)
+        }
     }
 }

--- a/GiniComponents/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentComponents/PaymentComponentBottomView.swift
+++ b/GiniComponents/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentComponents/PaymentComponentBottomView.swift
@@ -51,6 +51,12 @@ public final class PaymentComponentBottomView: GiniBottomSheetViewController {
         fatalError("init(coder:) has not been implemented")
     }
     
+    deinit {
+        if let paymentComponentView = paymentView as? PaymentComponentView {
+            paymentComponentView.viewModel.delegate?.didDismissPaymentComponent()
+        }
+    }
+    
     /// This is to notify VoiceOver that the layout changed. The delay is needed to ensure that
     /// VoiceOver has already finished processing the UI changes.
     private func notifyLayoutChanged() {

--- a/GiniComponents/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentComponents/PaymentComponentViewModel.swift
+++ b/GiniComponents/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentComponents/PaymentComponentViewModel.swift
@@ -12,6 +12,7 @@ public protocol PaymentComponentViewProtocol: AnyObject {
     func didTapOnMoreInformation(documentId: String?)
     func didTapOnBankPicker(documentId: String?)
     func didTapOnPayInvoice(documentId: String?)
+    func didDismissPaymentComponent()
 }
 
 /**

--- a/GiniMobile.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/GiniMobile.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -24,17 +24,8 @@
         "repositoryURL": "https://github.com/firebase/firebase-ios-sdk",
         "state": {
           "branch": null,
-          "revision": "b9bf3adac18e6e3059167194aeb632f15a5ba4b2",
-          "version": "12.1.0"
-        }
-      },
-      {
-        "package": "GoogleAdsOnDeviceConversion",
-        "repositoryURL": "https://github.com/googleads/google-ads-on-device-conversion-ios-sdk",
-        "state": {
-          "branch": null,
-          "revision": "e15f979c3eaf477d24e5bfec9d87f1d76fbac297",
-          "version": "2.2.0"
+          "revision": "d1f7c7e8eaa74d7e44467184dc5f592268247d33",
+          "version": "11.11.0"
         }
       },
       {
@@ -42,8 +33,8 @@
         "repositoryURL": "https://github.com/google/GoogleAppMeasurement.git",
         "state": {
           "branch": null,
-          "revision": "883305109ead4599e4ca59591754ee72e81e6b5e",
-          "version": "12.1.0"
+          "revision": "dd89fc79a77183830742a16866d87e4e54785734",
+          "version": "11.11.0"
         }
       },
       {
@@ -78,8 +69,8 @@
         "repositoryURL": "https://github.com/google/gtm-session-fetcher.git",
         "state": {
           "branch": null,
-          "revision": "fb7f2740b1570d2f7599c6bb9531bf4fad6974b7",
-          "version": "5.0.0"
+          "revision": "c756a29784521063b6a1202907e2cc47f41b667c",
+          "version": "4.5.0"
         }
       },
       {

--- a/GiniMobile.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/GiniMobile.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -2,12 +2,138 @@
   "object": {
     "pins": [
       {
+        "package": "abseil",
+        "repositoryURL": "https://github.com/google/abseil-cpp-binary.git",
+        "state": {
+          "branch": null,
+          "revision": "bbe8b69694d7873315fd3a4ad41efe043e1c07c5",
+          "version": "1.2024072200.0"
+        }
+      },
+      {
+        "package": "AppCheck",
+        "repositoryURL": "https://github.com/google/app-check.git",
+        "state": {
+          "branch": null,
+          "revision": "61b85103a1aeed8218f17c794687781505fbbef5",
+          "version": "11.2.0"
+        }
+      },
+      {
+        "package": "Firebase",
+        "repositoryURL": "https://github.com/firebase/firebase-ios-sdk",
+        "state": {
+          "branch": null,
+          "revision": "b9bf3adac18e6e3059167194aeb632f15a5ba4b2",
+          "version": "12.1.0"
+        }
+      },
+      {
+        "package": "GoogleAdsOnDeviceConversion",
+        "repositoryURL": "https://github.com/googleads/google-ads-on-device-conversion-ios-sdk",
+        "state": {
+          "branch": null,
+          "revision": "e15f979c3eaf477d24e5bfec9d87f1d76fbac297",
+          "version": "2.2.0"
+        }
+      },
+      {
+        "package": "GoogleAppMeasurement",
+        "repositoryURL": "https://github.com/google/GoogleAppMeasurement.git",
+        "state": {
+          "branch": null,
+          "revision": "883305109ead4599e4ca59591754ee72e81e6b5e",
+          "version": "12.1.0"
+        }
+      },
+      {
+        "package": "GoogleDataTransport",
+        "repositoryURL": "https://github.com/google/GoogleDataTransport.git",
+        "state": {
+          "branch": null,
+          "revision": "617af071af9aa1d6a091d59a202910ac482128f9",
+          "version": "10.1.0"
+        }
+      },
+      {
+        "package": "GoogleUtilities",
+        "repositoryURL": "https://github.com/google/GoogleUtilities.git",
+        "state": {
+          "branch": null,
+          "revision": "60da361632d0de02786f709bdc0c4df340f7613e",
+          "version": "8.1.0"
+        }
+      },
+      {
+        "package": "gRPC",
+        "repositoryURL": "https://github.com/google/grpc-binary.git",
+        "state": {
+          "branch": null,
+          "revision": "cc0001a0cf963aa40501d9c2b181e7fc9fd8ec71",
+          "version": "1.69.0"
+        }
+      },
+      {
+        "package": "GTMSessionFetcher",
+        "repositoryURL": "https://github.com/google/gtm-session-fetcher.git",
+        "state": {
+          "branch": null,
+          "revision": "fb7f2740b1570d2f7599c6bb9531bf4fad6974b7",
+          "version": "5.0.0"
+        }
+      },
+      {
+        "package": "InteropForGoogle",
+        "repositoryURL": "https://github.com/google/interop-ios-for-google-sdks.git",
+        "state": {
+          "branch": null,
+          "revision": "040d087ac2267d2ddd4cca36c757d1c6a05fdbfe",
+          "version": "101.0.0"
+        }
+      },
+      {
+        "package": "leveldb",
+        "repositoryURL": "https://github.com/firebase/leveldb.git",
+        "state": {
+          "branch": null,
+          "revision": "a0bc79961d7be727d258d33d5a6b2f1023270ba1",
+          "version": "1.22.5"
+        }
+      },
+      {
         "package": "Lottie",
         "repositoryURL": "https://github.com/airbnb/lottie-ios.git",
         "state": {
           "branch": null,
           "revision": "d6feea26a370019b4d3a85f5984cb95a2734776f",
           "version": "4.2.0"
+        }
+      },
+      {
+        "package": "nanopb",
+        "repositoryURL": "https://github.com/firebase/nanopb.git",
+        "state": {
+          "branch": null,
+          "revision": "b7e1104502eca3a213b46303391ca4d3bc8ddec1",
+          "version": "2.30910.0"
+        }
+      },
+      {
+        "package": "Promises",
+        "repositoryURL": "https://github.com/google/promises.git",
+        "state": {
+          "branch": null,
+          "revision": "540318ecedd63d883069ae7f1ed811a2df00b6ac",
+          "version": "2.4.0"
+        }
+      },
+      {
+        "package": "SwiftProtobuf",
+        "repositoryURL": "https://github.com/apple/swift-protobuf.git",
+        "state": {
+          "branch": null,
+          "revision": "102a647b573f60f73afdce5613a51d71349fe507",
+          "version": "1.30.0"
         }
       },
       {

--- a/HealthSDK/GiniHealthSDK/Sources/GiniHealthSDK/Core/GiniHealth.swift
+++ b/HealthSDK/GiniHealthSDK/Sources/GiniHealthSDK/Core/GiniHealth.swift
@@ -31,6 +31,11 @@ public protocol GiniHealthDelegate: AnyObject {
      - parameter error: error which will be handled.
      */
     func shouldHandleErrorInternally(error: GiniHealthError) -> Bool
+    
+    /**
+     Called when the Gini Health SDK has been dismissed.
+     */
+    func didDismissHealthSDK()
 }
 /**
  Errors thrown with Gini Health SDK.
@@ -668,7 +673,9 @@ extension GiniHealth: PaymentComponentsControllerProtocol {
         paymentDelegate?.didFetchedPaymentProviders()
     }
     
-    
+    public func didDismissPaymentComponents() {
+        delegate?.didDismissHealthSDK()
+    }
 }
 
 extension GiniHealth {

--- a/HealthSDK/GiniHealthSDK/Sources/GiniHealthSDK/Core/PaymentComponentsController+Helpers.swift
+++ b/HealthSDK/GiniHealthSDK/Sources/GiniHealthSDK/Core/PaymentComponentsController+Helpers.swift
@@ -149,7 +149,7 @@ extension PaymentComponentsController {
     
     private func dismissAndPresent(viewController: UIViewController, animated: Bool) {
         if let presentedViewController = navigationControllerProvided?.presentedViewController {
-            presentedViewController.dismiss(animated: true) { [weak self] in
+            presentedViewController.dismiss(animated: animated) { [weak self] in
                 /// This ensures that the view controller is presented on the topmost view controller.
                 /// For example, in a fresh install first we have the empty payment component bottom sheet, then the selected bank payment component bottom sheet.
                 /// If the user selects a bank, we need to dismiss the empty payment component bottom sheet and present the selected bank payment component bottom sheet.

--- a/HealthSDK/GiniHealthSDK/Sources/GiniHealthSDK/Core/PaymentComponentsController+Helpers.swift
+++ b/HealthSDK/GiniHealthSDK/Sources/GiniHealthSDK/Core/PaymentComponentsController+Helpers.swift
@@ -150,6 +150,9 @@ extension PaymentComponentsController {
     private func dismissAndPresent(viewController: UIViewController, animated: Bool) {
         if let presentedViewController = navigationControllerProvided?.presentedViewController {
             presentedViewController.dismiss(animated: true) { [weak self] in
+                /// This ensures that the view controller is presented on the topmost view controller.
+                /// For example, in a fresh install first we have the empty payment component bottom sheet, then the selected bank payment component bottom sheet.
+                /// If the user selects a bank, we need to dismiss the empty payment component bottom sheet and present the selected bank payment component bottom sheet.
                 self?.dismissAndPresent(viewController: viewController, animated: animated)
             }
         } else {

--- a/HealthSDK/GiniHealthSDK/Sources/GiniHealthSDK/Core/PaymentComponentsController+Helpers.swift
+++ b/HealthSDK/GiniHealthSDK/Sources/GiniHealthSDK/Core/PaymentComponentsController+Helpers.swift
@@ -360,7 +360,7 @@ extension PaymentComponentsController {
      */
     public func paymentReviewClosed(with previousPresentedView: PaymentComponentScreenType?) {
         shareInvoiceBottomSheet = nil
-        notifyThatSDKWasDismissedIfNeeded()
+        notifySDKWasDismissedIfNeeded()
     }
 
     /**
@@ -473,7 +473,11 @@ extension PaymentComponentsController {
 
         if let popoverController = activityViewController.popoverPresentationController {
             popoverController.sourceView = viewController.view
-            popoverController.sourceRect = CGRect(x: viewController.view.bounds.midX, y: viewController.view.bounds.midY, width: 0, height: 0)
+            popoverController.sourceRect = CGRect(x: viewController.view.bounds.midX,
+                                                  y: viewController.view.bounds.midY,
+                                                  width: 0,
+                                                  height: 0)
+            
             popoverController.permittedArrowDirections = []
         }
 
@@ -663,13 +667,10 @@ extension PaymentComponentsController: PaymentComponentViewProtocol {
     }
     
     public func didDismissPaymentComponent() {
-        let isNavigationControllerEmpty = navigationControllerProvided?.viewControllers.isEmpty == true
-        let isNavigationControllerNotPresenting = navigationControllerProvided?.presentedViewController == nil
-        
-        notifyThatSDKWasDismissedIfNeeded()
+        notifySDKWasDismissedIfNeeded()
     }
     
-    private func notifyThatSDKWasDismissedIfNeeded() {
+    private func notifySDKWasDismissedIfNeeded() {
         let isNavigationControllerEmpty = navigationControllerProvided?.viewControllers.isEmpty == true
         let isNavigationControllerNotPresenting = navigationControllerProvided?.presentedViewController == nil
         

--- a/HealthSDK/GiniHealthSDK/Sources/GiniHealthSDK/Core/PaymentComponentsController+Helpers.swift
+++ b/HealthSDK/GiniHealthSDK/Sources/GiniHealthSDK/Core/PaymentComponentsController+Helpers.swift
@@ -360,6 +360,7 @@ extension PaymentComponentsController {
      */
     public func paymentReviewClosed(with previousPresentedView: PaymentComponentScreenType?) {
         shareInvoiceBottomSheet = nil
+        notifyThatSDKWasDismissedIfNeeded()
     }
 
     /**
@@ -662,6 +663,13 @@ extension PaymentComponentsController: PaymentComponentViewProtocol {
     }
     
     public func didDismissPaymentComponent() {
+        let isNavigationControllerEmpty = navigationControllerProvided?.viewControllers.isEmpty == true
+        let isNavigationControllerNotPresenting = navigationControllerProvided?.presentedViewController == nil
+        
+        notifyThatSDKWasDismissedIfNeeded()
+    }
+    
+    private func notifyThatSDKWasDismissedIfNeeded() {
         let isNavigationControllerEmpty = navigationControllerProvided?.viewControllers.isEmpty == true
         let isNavigationControllerNotPresenting = navigationControllerProvided?.presentedViewController == nil
         

--- a/HealthSDK/GiniHealthSDK/Sources/GiniHealthSDK/Core/PaymentComponentsController.swift
+++ b/HealthSDK/GiniHealthSDK/Sources/GiniHealthSDK/Core/PaymentComponentsController.swift
@@ -18,6 +18,7 @@ import GiniUtilites
 public protocol PaymentComponentsControllerProtocol: AnyObject {
     func isLoadingStateChanged(isLoading: Bool) // Because we can't use Combine
     func didFetchedPaymentProviders()
+    func didDismissPaymentComponents()
 }
 
 protocol PaymentComponentsProtocol {
@@ -100,8 +101,6 @@ public final class PaymentComponentsController: BottomSheetsProviderProtocol, Gi
         }
     }
 
-    /// Previous presented view
-    var previousPresentedViews: [PaymentComponentScreenType] = []
     // Client's navigation controller provided in order to handle all HealthSDK flows
     weak var navigationControllerProvided: UINavigationController?
     // Payment Information from the invoice that contains a document or not

--- a/HealthSDK/GiniHealthSDKExample/GiniHealthSDKExample.xcodeproj/project.pbxproj
+++ b/HealthSDK/GiniHealthSDKExample/GiniHealthSDKExample.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		282DD2C32E4B6AC600A4EDCE /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 282DD2C22E4B6AC600A4EDCE /* PrivacyInfo.xcprivacy */; };
 		284A53502A86493100183EA7 /* SelectAPIViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 284A534F2A86493100183EA7 /* SelectAPIViewController.xib */; };
 		288F88502E4A5563004D7A60 /* FirebaseAnalytics in Frameworks */ = {isa = PBXBuildFile; productRef = 288F884F2E4A5563004D7A60 /* FirebaseAnalytics */; };
 		288F88522E4A5563004D7A60 /* FirebaseCrashlytics in Frameworks */ = {isa = PBXBuildFile; productRef = 288F88512E4A5563004D7A60 /* FirebaseCrashlytics */; };
@@ -75,6 +76,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		282DD2C22E4B6AC600A4EDCE /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		284A534F2A86493100183EA7 /* SelectAPIViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = SelectAPIViewController.xib; sourceTree = "<group>"; };
 		288F88552E4A6289004D7A60 /* GoogleService-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		3AC824B42CA2B16500DE37C0 /* GiniHealthSDKExampleTests.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = GiniHealthSDKExampleTests.xctestplan; sourceTree = "<group>"; };
@@ -276,6 +278,7 @@
 				8ADEE2F12C2C3C9B006D3526 /* Resources */,
 				F4EC38CC273C21E5007045DC /* LaunchScreen.storyboard */,
 				F4EC38CF273C21E5007045DC /* Info.plist */,
+				282DD2C22E4B6AC600A4EDCE /* PrivacyInfo.xcprivacy */,
 			);
 			path = GiniHealthSDKExample;
 			sourceTree = "<group>";
@@ -393,6 +396,7 @@
 				7DB661952B5687F7004537AA /* health-invoice-2.jpg in Resources */,
 				F464B17627CD2147001735B9 /* Localizable.strings in Resources */,
 				F4EC38FA273C2311007045DC /* Base.lproj in Resources */,
+				282DD2C32E4B6AC600A4EDCE /* PrivacyInfo.xcprivacy in Resources */,
 				7DD0B95E2CF75E9100C5176C /* invoice-13MB.pdf in Resources */,
 				7DB661992B5687F7004537AA /* health-invoice-5.jpg in Resources */,
 				8ADEE2FA2C2CB2E4006D3526 /* invoice-12MB.png in Resources */,

--- a/HealthSDK/GiniHealthSDKExample/GiniHealthSDKExample.xcodeproj/project.pbxproj
+++ b/HealthSDK/GiniHealthSDKExample/GiniHealthSDKExample.xcodeproj/project.pbxproj
@@ -8,6 +8,10 @@
 
 /* Begin PBXBuildFile section */
 		284A53502A86493100183EA7 /* SelectAPIViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 284A534F2A86493100183EA7 /* SelectAPIViewController.xib */; };
+		288F88502E4A5563004D7A60 /* FirebaseAnalytics in Frameworks */ = {isa = PBXBuildFile; productRef = 288F884F2E4A5563004D7A60 /* FirebaseAnalytics */; };
+		288F88522E4A5563004D7A60 /* FirebaseCrashlytics in Frameworks */ = {isa = PBXBuildFile; productRef = 288F88512E4A5563004D7A60 /* FirebaseCrashlytics */; };
+		288F88542E4A5563004D7A60 /* FirebasePerformance in Frameworks */ = {isa = PBXBuildFile; productRef = 288F88532E4A5563004D7A60 /* FirebasePerformance */; };
+		288F88562E4A6289004D7A60 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 288F88552E4A6289004D7A60 /* GoogleService-Info.plist */; };
 		504435172C5AE5D300105D0B /* GiniHealthSDKPinningExampleIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4DB6420283546960027681C /* GiniHealthSDKPinningExampleIntegrationTests.swift */; };
 		504435182C5AE5D300105D0B /* GiniHealthSDKPinningExampleWrongCertificatesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4DB642728354B2B0027681C /* GiniHealthSDKPinningExampleWrongCertificatesTests.swift */; };
 		50ED3DA52C34A16D004FC25C /* DebugMenuViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50ED3DA42C34A16D004FC25C /* DebugMenuViewController.swift */; };
@@ -72,6 +76,7 @@
 
 /* Begin PBXFileReference section */
 		284A534F2A86493100183EA7 /* SelectAPIViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = SelectAPIViewController.xib; sourceTree = "<group>"; };
+		288F88552E4A6289004D7A60 /* GoogleService-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		3AC824B42CA2B16500DE37C0 /* GiniHealthSDKExampleTests.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = GiniHealthSDKExampleTests.xctestplan; sourceTree = "<group>"; };
 		50ED3DA42C34A16D004FC25C /* DebugMenuViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugMenuViewController.swift; sourceTree = "<group>"; };
 		7D6161C52BE1327E0091000B /* test_pdf.pdf */ = {isa = PBXFileReference; lastKnownFileType = image.pdf; path = test_pdf.pdf; sourceTree = "<group>"; };
@@ -137,6 +142,9 @@
 			files = (
 				F42377262799ABB000FAC3D6 /* CloudKit.framework in Frameworks */,
 				F4206BBC2A1B9C6900E5E101 /* GiniCaptureSDK in Frameworks */,
+				288F88542E4A5563004D7A60 /* FirebasePerformance in Frameworks */,
+				288F88522E4A5563004D7A60 /* FirebaseCrashlytics in Frameworks */,
+				288F88502E4A5563004D7A60 /* FirebaseAnalytics in Frameworks */,
 				F4EC3900273C245E007045DC /* GiniHealthSDK in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -243,6 +251,7 @@
 		F4EC38C0273C21E4007045DC /* GiniHealthSDKExample */ = {
 			isa = PBXGroup;
 			children = (
+				288F88552E4A6289004D7A60 /* GoogleService-Info.plist */,
 				F4366E62273D183C0054923F /* GiniHealthSDKExample.entitlements */,
 				F4EC3912273C2B41007045DC /* Assets.xcassets */,
 				F4EC38C1273C21E4007045DC /* AppDelegate.swift */,
@@ -304,6 +313,9 @@
 			packageProductDependencies = (
 				F4EC38FF273C245E007045DC /* GiniHealthSDK */,
 				F4206BBB2A1B9C6900E5E101 /* GiniCaptureSDK */,
+				288F884F2E4A5563004D7A60 /* FirebaseAnalytics */,
+				288F88512E4A5563004D7A60 /* FirebaseCrashlytics */,
+				288F88532E4A5563004D7A60 /* FirebasePerformance */,
 			);
 			productName = GiniHealthSDKExample;
 			productReference = F4EC38BF273C21E4007045DC /* GiniHealthSDKExample.app */;
@@ -356,6 +368,9 @@
 				de,
 			);
 			mainGroup = F4C36A7F270C6EBF00CCC69C;
+			packageReferences = (
+				288F884E2E4A5563004D7A60 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */,
+			);
 			productRefGroup = F4C36A89270C6EBF00CCC69C /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -373,6 +388,7 @@
 			files = (
 				F4EC38CE273C21E5007045DC /* LaunchScreen.storyboard in Resources */,
 				7DB6618C2B554ADF004537AA /* InvoiceTableViewCell.xib in Resources */,
+				288F88562E4A6289004D7A60 /* GoogleService-Info.plist in Resources */,
 				7DB661952B5687F7004537AA /* health-invoice-2.jpg in Resources */,
 				F464B17627CD2147001735B9 /* Localizable.strings in Resources */,
 				F4EC38FA273C2311007045DC /* Base.lproj in Resources */,
@@ -773,7 +789,33 @@
 		};
 /* End XCConfigurationList section */
 
+/* Begin XCRemoteSwiftPackageReference section */
+		288F884E2E4A5563004D7A60 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/firebase/firebase-ios-sdk";
+			requirement = {
+				kind = exactVersion;
+				version = 12.1.0;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
 /* Begin XCSwiftPackageProductDependency section */
+		288F884F2E4A5563004D7A60 /* FirebaseAnalytics */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 288F884E2E4A5563004D7A60 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebaseAnalytics;
+		};
+		288F88512E4A5563004D7A60 /* FirebaseCrashlytics */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 288F884E2E4A5563004D7A60 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebaseCrashlytics;
+		};
+		288F88532E4A5563004D7A60 /* FirebasePerformance */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 288F884E2E4A5563004D7A60 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebasePerformance;
+		};
 		F4206BBB2A1B9C6900E5E101 /* GiniCaptureSDK */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = GiniCaptureSDK;

--- a/HealthSDK/GiniHealthSDKExample/GiniHealthSDKExample.xcodeproj/project.pbxproj
+++ b/HealthSDK/GiniHealthSDKExample/GiniHealthSDKExample.xcodeproj/project.pbxproj
@@ -304,6 +304,7 @@
 				F4EC38BB273C21E4007045DC /* Sources */,
 				F4EC38BC273C21E4007045DC /* Frameworks */,
 				F4EC38BD273C21E4007045DC /* Resources */,
+				282DD2C12E4B2A8100A4EDCE /* Upload DSYM */,
 			);
 			buildRules = (
 			);
@@ -412,6 +413,32 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		282DD2C12E4B2A8100A4EDCE /* Upload DSYM */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${DWARF_DSYM_FOLDER_PATH}/${DWARF_DSYM_FILE_NAME}",
+				"${DWARF_DSYM_FOLDER_PATH}/${DWARF_DSYM_FILE_NAME}/Contents/Resources/DWARF/${PRODUCT_NAME}",
+				"${DWARF_DSYM_FOLDER_PATH}/${DWARF_DSYM_FILE_NAME}/Contents/Info.plist",
+				"$(TARGET_BUILD_DIR)/$(UNLOCALIZED_RESOURCES_FOLDER_PATH)/GoogleService-Info.plist",
+				"$(TARGET_BUILD_DIR)/$(EXECUTABLE_PATH)",
+			);
+			name = "Upload DSYM";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "# Type a script or drag a script file from your workspace to insert its path.\n\"${BUILD_DIR%/Build/*}/SourcePackages/checkouts/firebase-ios-sdk/Crashlytics/run\"\n";
+		};
+/* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		F4EC38BB273C21E4007045DC /* Sources */ = {
@@ -795,7 +822,7 @@
 			repositoryURL = "https://github.com/firebase/firebase-ios-sdk";
 			requirement = {
 				kind = exactVersion;
-				version = 12.1.0;
+				version = 11.11.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/HealthSDK/GiniHealthSDKExample/GiniHealthSDKExample/AppCoordinator.swift
+++ b/HealthSDK/GiniHealthSDKExample/GiniHealthSDKExample/AppCoordinator.swift
@@ -15,7 +15,14 @@ import GiniUtilites
 
 final class AppCoordinator: Coordinator {
     
+    /**
+     * Determines whether to use the pre-existing navigation controller (`false`)
+     * or create a new `UINavigationController` for alternative navigation (`true`).
+     *
+     * Default value is `false`.
+     */
     private var shouldUseAlternativeNavigation = false
+    
     var childCoordinators: [Coordinator] = []
     fileprivate let window: UIWindow
     fileprivate var screenAPIViewController: UIViewController?

--- a/HealthSDK/GiniHealthSDKExample/GiniHealthSDKExample/AppCoordinator.swift
+++ b/HealthSDK/GiniHealthSDKExample/GiniHealthSDKExample/AppCoordinator.swift
@@ -15,6 +15,7 @@ import GiniUtilites
 
 final class AppCoordinator: Coordinator {
     
+    private var shouldUseAlternativeNavigation = false
     var childCoordinators: [Coordinator] = []
     fileprivate let window: UIWindow
     fileprivate var screenAPIViewController: UIViewController?
@@ -325,7 +326,8 @@ final class AppCoordinator: Coordinator {
             invoicesListCoordinator.start(documentService: self.health.documentService,
                                           hardcodedInvoicesController: self.hardcodedInvoicesController,
                                           health: self.health,
-                                          invoices: invoices)
+                                          invoices: invoices,
+                                          shouldUseAlternativeNavigation: self.shouldUseAlternativeNavigation)
             self.add(childCoordinator: invoicesListCoordinator)
             self.rootViewController.present(invoicesListCoordinator.rootViewController, animated: true)
         }
@@ -344,7 +346,8 @@ final class AppCoordinator: Coordinator {
         orderListCoordinator.start(documentService: health.documentService,
                                    hardcodedOrdersController: HardcodedOrdersController(),
                                    health: health,
-                                   orders: orders)
+                                   orders: orders,
+                                   shouldUseAlternativeNavigation: shouldUseAlternativeNavigation)
         add(childCoordinator: orderListCoordinator)
         rootViewController.present(orderListCoordinator.rootViewController, animated: true)
     }
@@ -400,6 +403,12 @@ extension AppCoordinator: GiniHealthDelegate {
     func didCreatePaymentRequest(paymentRequestId: String) {
         GiniUtilites.Log("Created payment request with id \(paymentRequestId)", event: .success)
     }
+    
+    func didDismissHealthSDK() {
+        if shouldUseAlternativeNavigation {
+            rootViewController.presentedViewController?.dismiss(animated: true)
+        }
+    }
 }
 
 //MARK: - DebugMenuPresenterDelegate
@@ -410,7 +419,8 @@ extension AppCoordinator: DebugMenuPresenter {
                                                               useBottomPaymentComponent: giniHealthConfiguration.useBottomPaymentComponentView,
                                                               paymentComponentConfiguration: health.paymentComponentConfiguration,
                                                               showPaymentCloseButton: giniHealthConfiguration.showPaymentReviewCloseButton,
-                                                              popupDuration: giniHealthConfiguration.popupDurationPaymentReview)
+                                                              popupDuration: giniHealthConfiguration.popupDurationPaymentReview,
+                                                              shouldUseAlternativeNavigation: shouldUseAlternativeNavigation)
         debugMenuViewController.delegate = self
         rootViewController.present(debugMenuViewController, animated: true)
     }
@@ -428,6 +438,8 @@ extension AppCoordinator: DebugMenuDelegate {
             giniHealthConfiguration.useBottomPaymentComponentView = isOn
         case .showPaymentCloseButton:
             giniHealthConfiguration.showPaymentReviewCloseButton = isOn
+        case .useAlternativeNavigation:
+            shouldUseAlternativeNavigation = isOn
         }
     }
 

--- a/HealthSDK/GiniHealthSDKExample/GiniHealthSDKExample/AppDelegate.swift
+++ b/HealthSDK/GiniHealthSDKExample/GiniHealthSDKExample/AppDelegate.swift
@@ -8,6 +8,7 @@
 import UIKit
 import GiniCaptureSDK
 import GiniHealthSDK
+import Firebase
 
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {
@@ -18,6 +19,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     func application(_ application: UIApplication,
                      didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         let window = UIWindow(frame: UIScreen.main.bounds)
+        FirebaseApp.configure()
         coordinator = AppCoordinator(window: window)
         coordinator.start()
 

--- a/HealthSDK/GiniHealthSDKExample/GiniHealthSDKExample/DebugMenuViewController.swift
+++ b/HealthSDK/GiniHealthSDKExample/GiniHealthSDKExample/DebugMenuViewController.swift
@@ -65,7 +65,10 @@ class DebugMenuViewController: UIViewController {
     private lazy var closeButtonOptionLabel: UILabel = rowTitle("Show Payment Review Close Button")
     private var closeButtonSwitch: UISwitch!
     private lazy var closeButtonRow: UIStackView = stackView(axis: .horizontal, subviews: [closeButtonOptionLabel, closeButtonSwitch])
-    private lazy var useAlternativeNavigationLabel = rowTitle("User alternative navigation")
+    
+    /// This option allows to test the navigation flow when the consumer app creates a new `UINavigationController` instance to start the payment flow. Instead of using the existing one.
+    /// by using this flow the consumer app will be listening to the new `delegate` method in the `GiniHealthSDK` to handle the navigation.
+    private lazy var useAlternativeNavigationLabel = rowTitle("Use alternative navigation")
     private var useAlternativeNavigationSwitch: UISwitch!
     private lazy var useAlternativeNavigationRow = stackView(axis: .horizontal, subviews: [useAlternativeNavigationLabel, useAlternativeNavigationSwitch])
     

--- a/HealthSDK/GiniHealthSDKExample/GiniHealthSDKExample/DebugMenuViewController.swift
+++ b/HealthSDK/GiniHealthSDKExample/GiniHealthSDKExample/DebugMenuViewController.swift
@@ -14,6 +14,7 @@ enum SwitchType {
     case showBrandedView
     case useBottomPaymentComponent
     case showPaymentCloseButton
+    case useAlternativeNavigation
 }
 
 protocol DebugMenuDelegate: AnyObject {
@@ -64,6 +65,9 @@ class DebugMenuViewController: UIViewController {
     private lazy var closeButtonOptionLabel: UILabel = rowTitle("Show Payment Review Close Button")
     private var closeButtonSwitch: UISwitch!
     private lazy var closeButtonRow: UIStackView = stackView(axis: .horizontal, subviews: [closeButtonOptionLabel, closeButtonSwitch])
+    private lazy var useAlternativeNavigationLabel = rowTitle("User alternative navigation")
+    private var useAlternativeNavigationSwitch: UISwitch!
+    private lazy var useAlternativeNavigationRow = stackView(axis: .horizontal, subviews: [useAlternativeNavigationLabel, useAlternativeNavigationSwitch])
     
     private lazy var popupDurationTitleLabel: UILabel = rowTitle("Popup Duration Time")
     
@@ -103,11 +107,13 @@ class DebugMenuViewController: UIViewController {
          useBottomPaymentComponent: Bool,
          paymentComponentConfiguration: PaymentComponentConfiguration,
          showPaymentCloseButton: Bool,
-         popupDuration: TimeInterval) {
+         popupDuration: TimeInterval,
+         shouldUseAlternativeNavigation: Bool) {
         super.init(nibName: nil, bundle: nil)
         self.reviewScreenSwitch = self.switchView(isOn: showReviewScreen)
         self.bottomPaymentComponentSwitch = self.switchView(isOn: useBottomPaymentComponent)
         self.closeButtonSwitch = self.switchView(isOn: showPaymentCloseButton)
+        self.useAlternativeNavigationSwitch = self.switchView(isOn: shouldUseAlternativeNavigation)
         self.popupDurationSlider.value = Float(popupDuration)
     }
 
@@ -168,6 +174,7 @@ class DebugMenuViewController: UIViewController {
         let spacer = UIView()
         let views = [
             titleLabel,
+            useAlternativeNavigationRow,
             localizationRow,
             reviewScreenRow,
             bottomPaymentComponentEditableRow,
@@ -190,6 +197,7 @@ class DebugMenuViewController: UIViewController {
             mainStackView.topAnchor.constraint(equalTo: contentView.topAnchor, constant: spacing),
             mainStackView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -spacing),
 
+            useAlternativeNavigationRow.heightAnchor.constraint(equalToConstant: rowHeight),
             localizationRow.heightAnchor.constraint(equalToConstant: rowHeight),
             reviewScreenRow.heightAnchor.constraint(equalToConstant: rowHeight),
             bottomPaymentComponentEditableRow.heightAnchor.constraint(equalToConstant: rowHeight),
@@ -325,14 +333,16 @@ extension DebugMenuViewController: UIPickerViewDelegate, UIPickerViewDataSource 
 private extension DebugMenuViewController {
     @objc private func switchValueChanged(_ sender: UISwitch) {
         switch sender {
-            case reviewScreenSwitch:
-                delegate?.didChangeSwitchValue(type: .showReviewScreen, isOn: sender.isOn)
-            case bottomPaymentComponentSwitch:
-                delegate?.didChangeSwitchValue(type: .useBottomPaymentComponent, isOn: sender.isOn)
-            case closeButtonSwitch:
-                delegate?.didChangeSwitchValue(type: .showPaymentCloseButton, isOn: sender.isOn)
-            default:
-                break
+        case reviewScreenSwitch:
+            delegate?.didChangeSwitchValue(type: .showReviewScreen, isOn: sender.isOn)
+        case bottomPaymentComponentSwitch:
+            delegate?.didChangeSwitchValue(type: .useBottomPaymentComponent, isOn: sender.isOn)
+        case closeButtonSwitch:
+            delegate?.didChangeSwitchValue(type: .showPaymentCloseButton, isOn: sender.isOn)
+        case useAlternativeNavigationSwitch:
+            delegate?.didChangeSwitchValue(type: .useAlternativeNavigation, isOn: sender.isOn)
+        default:
+            break
         }
     }
 }

--- a/HealthSDK/GiniHealthSDKExample/GiniHealthSDKExample/DebugMenuViewController.swift
+++ b/HealthSDK/GiniHealthSDKExample/GiniHealthSDKExample/DebugMenuViewController.swift
@@ -70,7 +70,9 @@ class DebugMenuViewController: UIViewController {
     /// by using this flow the consumer app will be listening to the new `delegate` method in the `GiniHealthSDK` to handle the navigation.
     private lazy var useAlternativeNavigationLabel = rowTitle("Use alternative navigation")
     private var useAlternativeNavigationSwitch: UISwitch!
-    private lazy var useAlternativeNavigationRow = stackView(axis: .horizontal, subviews: [useAlternativeNavigationLabel, useAlternativeNavigationSwitch])
+    private lazy var useAlternativeNavigationRow = stackView(axis: .horizontal,
+                                                             subviews: [useAlternativeNavigationLabel,
+                                                                        useAlternativeNavigationSwitch])
     
     private lazy var popupDurationTitleLabel: UILabel = rowTitle("Popup Duration Time")
     

--- a/HealthSDK/GiniHealthSDKExample/GiniHealthSDKExample/GoogleService-Info.plist
+++ b/HealthSDK/GiniHealthSDKExample/GiniHealthSDKExample/GoogleService-Info.plist
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>API_KEY</key>
+	<string>AIzaSyAqPhYmDvODxPQm0g96_6EPmAVo1NUtymU</string>
+	<key>GCM_SENDER_ID</key>
+	<string>1008447554665</string>
+	<key>PLIST_VERSION</key>
+	<string>1</string>
+	<key>BUNDLE_ID</key>
+	<string>net.gini.healthsdk.example</string>
+	<key>PROJECT_ID</key>
+	<string>ginibank-ca4f2</string>
+	<key>STORAGE_BUCKET</key>
+	<string>ginibank-ca4f2.firebasestorage.app</string>
+	<key>IS_ADS_ENABLED</key>
+	<false></false>
+	<key>IS_ANALYTICS_ENABLED</key>
+	<false></false>
+	<key>IS_APPINVITE_ENABLED</key>
+	<true></true>
+	<key>IS_GCM_ENABLED</key>
+	<true></true>
+	<key>IS_SIGNIN_ENABLED</key>
+	<true></true>
+	<key>GOOGLE_APP_ID</key>
+	<string>1:1008447554665:ios:df8972ab0adf5b3a05cef8</string>
+</dict>
+</plist>

--- a/HealthSDK/GiniHealthSDKExample/GiniHealthSDKExample/InvoicesList/InvoicesListCoordinator.swift
+++ b/HealthSDK/GiniHealthSDKExample/GiniHealthSDKExample/InvoicesList/InvoicesListCoordinator.swift
@@ -21,13 +21,15 @@ final class InvoicesListCoordinator: NSObject, Coordinator {
     func start(documentService: DefaultDocumentService,
                hardcodedInvoicesController: HardcodedInvoicesControllerProtocol,
                health: GiniHealth,
-               invoices: [DocumentWithExtractions]? = nil) {
+               invoices: [DocumentWithExtractions]? = nil,
+               shouldUseAlternativeNavigation: Bool) {
         self.invoicesListViewController = InvoicesListViewController()
         invoicesListViewController.viewModel = InvoicesListViewModel(coordinator: self,
                                                                      invoices: invoices,
                                                                      documentService: documentService,
                                                                      hardcodedInvoicesController: hardcodedInvoicesController,
-                                                                     health: health)
+                                                                     health: health,
+                                                                     shouldUseAlternativeNavigation: shouldUseAlternativeNavigation)
         invoicesListNavigationController = RootNavigationController(rootViewController: invoicesListViewController)
         let appearance = UINavigationBarAppearance()
         appearance.backgroundColor = UIColor(named: "background")

--- a/HealthSDK/GiniHealthSDKExample/GiniHealthSDKExample/InvoicesList/InvoicesListViewModel.swift
+++ b/HealthSDK/GiniHealthSDKExample/GiniHealthSDKExample/InvoicesList/InvoicesListViewModel.swift
@@ -211,16 +211,25 @@ extension InvoicesListViewModel {
     func didTapOnOpenFlow(documentId: String?) {
         documentIdToRefetch = documentId
         guard !checkDocumentForMultipleInvoices(documentID: documentId ?? "") else { return }
+        startPaymentFlow(documentId: documentId)
+    }
+    
+    private func startPaymentFlow(documentId: String?) {
+        let navigationController: UINavigationController
         
         if shouldUseAlternativeNavigation {
-            let navigationController = UINavigationController()
+            navigationController = UINavigationController()
             navigationController.setNavigationBarHidden(true, animated: false)
             navigationController.view.backgroundColor = .clear
             coordinator.invoicesListNavigationController.present(navigationController, animated: true)
-            health.startPaymentFlow(documentId: documentId, paymentInfo: obtainPaymentInfo(for: documentId), navigationController: navigationController, trackingDelegate: self)
         } else {
-            health.startPaymentFlow(documentId: documentId, paymentInfo: obtainPaymentInfo(for: documentId), navigationController: self.coordinator.invoicesListNavigationController, trackingDelegate: self)
+            navigationController = coordinator.invoicesListNavigationController
         }
+        
+        health.startPaymentFlow(documentId: documentId,
+                                paymentInfo: obtainPaymentInfo(for: documentId),
+                                navigationController: navigationController,
+                                trackingDelegate: self)
     }
 
     private func obtainPaymentInfo(for documentId: String?) -> PaymentInfo? {
@@ -256,7 +265,7 @@ extension InvoicesListViewModel: PaymentComponentsControllerProtocol {
     
     func didDismissPaymentComponents() {
         if shouldUseAlternativeNavigation {
-            coordinator.invoicesListNavigationController?.presentedViewController?.dismiss(animated: true, completion: nil)
+            coordinator.invoicesListNavigationController?.presentedViewController?.dismiss(animated: true)
         }
     }
 }

--- a/HealthSDK/GiniHealthSDKExample/GiniHealthSDKExample/OrdersList/OrderDetailViewController.swift
+++ b/HealthSDK/GiniHealthSDKExample/GiniHealthSDKExample/OrdersList/OrderDetailViewController.swift
@@ -32,6 +32,7 @@ final class OrderDetailViewController: UIViewController {
 
     private var errors: [String] = []
     private let errorTitleText = NSLocalizedString("gini.health.example.invoicesList.error", comment: "")
+    private let shouldUseAlternativeNavigation: Bool
     
     private let scrollView: UIScrollView = {
         let scrollView = UIScrollView()
@@ -75,9 +76,10 @@ final class OrderDetailViewController: UIViewController {
         contentView.widthAnchor.constraint(equalTo: scrollView.widthAnchor)]
     }
 
-    init(_ order: Order, health: GiniHealth) {
+    init(_ order: Order, health: GiniHealth, shouldUseAlternativeNavigation: Bool) {
         self.order = order
         self.health = health
+        self.shouldUseAlternativeNavigation = shouldUseAlternativeNavigation
         super.init(nibName: nil, bundle: nil)
 
         detailView.order = order
@@ -209,7 +211,15 @@ final class OrderDetailViewController: UIViewController {
         let paymentInfo = obtainPaymentInfo()
         if paymentInfo.isComplete && order.price.value != .zero {
             guard let navigationController else { return }
-            health.startPaymentFlow(documentId: nil, paymentInfo: obtainPaymentInfo(), navigationController: navigationController, trackingDelegate: self)
+            if shouldUseAlternativeNavigation {
+                let newNavigationController = UINavigationController()
+                newNavigationController.setNavigationBarHidden(true, animated: false)
+                newNavigationController.view.backgroundColor = .clear
+                navigationController.present(newNavigationController, animated: true)
+                health.startPaymentFlow(documentId: nil, paymentInfo: paymentInfo, navigationController: newNavigationController, trackingDelegate: self)
+            } else {
+                health.startPaymentFlow(documentId: nil, paymentInfo: obtainPaymentInfo(), navigationController: navigationController, trackingDelegate: self)
+            }
         } else {
             showErrorAlertView(error: NSLocalizedString("gini.health.example.order.detail.alert.field.error", comment: ""))
         }

--- a/HealthSDK/GiniHealthSDKExample/GiniHealthSDKExample/OrdersList/OrderDetailViewController.swift
+++ b/HealthSDK/GiniHealthSDKExample/GiniHealthSDKExample/OrdersList/OrderDetailViewController.swift
@@ -210,16 +210,7 @@ final class OrderDetailViewController: UIViewController {
 
         let paymentInfo = obtainPaymentInfo()
         if paymentInfo.isComplete && order.price.value != .zero {
-            guard let navigationController else { return }
-            if shouldUseAlternativeNavigation {
-                let newNavigationController = UINavigationController()
-                newNavigationController.setNavigationBarHidden(true, animated: false)
-                newNavigationController.view.backgroundColor = .clear
-                navigationController.present(newNavigationController, animated: true)
-                health.startPaymentFlow(documentId: nil, paymentInfo: paymentInfo, navigationController: newNavigationController, trackingDelegate: self)
-            } else {
-                health.startPaymentFlow(documentId: nil, paymentInfo: obtainPaymentInfo(), navigationController: navigationController, trackingDelegate: self)
-            }
+            startPaymentFlow(paymentInfo: paymentInfo)
         } else {
             showErrorAlertView(error: NSLocalizedString("gini.health.example.order.detail.alert.field.error", comment: ""))
         }
@@ -227,6 +218,25 @@ final class OrderDetailViewController: UIViewController {
 
     @objc private func didTapOnView() {
         view.endEditing(true)
+    }
+    
+    private func startPaymentFlow(paymentInfo: GiniHealthSDK.PaymentInfo) {
+        let navigationControllerToUse: UINavigationController
+        
+        if shouldUseAlternativeNavigation {
+            navigationControllerToUse = UINavigationController()
+            navigationControllerToUse.setNavigationBarHidden(true, animated: false)
+            navigationControllerToUse.view.backgroundColor = .clear
+            navigationController?.present(navigationControllerToUse, animated: true)
+        } else {
+            guard let navigationController = navigationController else { return }
+            navigationControllerToUse = navigationController
+        }
+        
+        health.startPaymentFlow(documentId: nil,
+                                paymentInfo: paymentInfo,
+                                navigationController: navigationControllerToUse,
+                                trackingDelegate: self)
     }
 
     private func saveTextFieldData() {

--- a/HealthSDK/GiniHealthSDKExample/GiniHealthSDKExample/OrdersList/OrderListCoordinator.swift
+++ b/HealthSDK/GiniHealthSDKExample/GiniHealthSDKExample/OrdersList/OrderListCoordinator.swift
@@ -22,13 +22,15 @@ final class OrderListCoordinator: NSObject, Coordinator {
     func start(documentService: GiniHealthSDK.DefaultDocumentService,
                hardcodedOrdersController: HardcodedOrdersControllerProtocol,
                health: GiniHealth,
-               orders: [Order]? = nil) {
+               orders: [Order]? = nil,
+               shouldUseAlternativeNavigation: Bool) {
         self.orderListViewController = OrderListViewController()
         orderListViewController.viewModel = OrderListViewModel(coordinator: self,
                                                                orders: orders,
                                                                documentService: documentService,
                                                                hardcodedOrdersController: hardcodedOrdersController,
-                                                               health: health)
+                                                               health: health,
+                                                               shouldUseAlternativeNavigation: shouldUseAlternativeNavigation)
         orderListNavigationController = RootNavigationController(rootViewController: orderListViewController)
         orderListNavigationController.modalPresentationStyle = .fullScreen
         orderListNavigationController.interactivePopGestureRecognizer?.delegate = nil

--- a/HealthSDK/GiniHealthSDKExample/GiniHealthSDKExample/OrdersList/OrderListViewController.swift
+++ b/HealthSDK/GiniHealthSDKExample/GiniHealthSDKExample/OrdersList/OrderListViewController.swift
@@ -113,7 +113,9 @@ final class OrderListViewController: UIViewController {
         let newOrder = Order(amountToPay: "", recipient: "", iban: "", purpose: "")
         viewModel.orders.append(newOrder)
 
-        let orderViewController = OrderDetailViewController(newOrder, health: viewModel.health)
+        let orderViewController = OrderDetailViewController(newOrder,
+                                                            health: viewModel.health,
+                                                            shouldUseAlternativeNavigation: viewModel.shouldUseAlternativeNavigation)
         orderViewController.delegate = self
         self.navigationController?.pushViewController(orderViewController, animated: true)
     }
@@ -161,7 +163,9 @@ extension OrderListViewController: UITableViewDelegate, UITableViewDataSource {
         let order = viewModel.orders[indexPath.row]
 
         // Instantiate InvoiceViewController with the Order instance
-        let orderViewController = OrderDetailViewController(order, health: viewModel.health)
+        let orderViewController = OrderDetailViewController(order,
+                                                            health: viewModel.health,
+                                                            shouldUseAlternativeNavigation: viewModel.shouldUseAlternativeNavigation)
         orderViewController.delegate = self
 
         // Present InvoiceViewController

--- a/HealthSDK/GiniHealthSDKExample/GiniHealthSDKExample/OrdersList/OrderListViewModel.swift
+++ b/HealthSDK/GiniHealthSDKExample/GiniHealthSDKExample/OrdersList/OrderListViewModel.swift
@@ -21,6 +21,7 @@ final class OrderListViewModel {
     let customOrderText = NSLocalizedString("gini.health.example.custom.order.button.title", comment: "")
     let cancelText = NSLocalizedString("gini.health.example.cancel.button.title", comment: "")
     let errorTitleText = NSLocalizedString("gini.health.example.invoicesList.error", comment: "")
+    let shouldUseAlternativeNavigation: Bool
 
     var health: GiniHealth
     
@@ -31,12 +32,14 @@ final class OrderListViewModel {
          orders: [Order]? = nil,
          documentService: GiniHealthSDK.DefaultDocumentService,
          hardcodedOrdersController: HardcodedOrdersControllerProtocol,
-         health: GiniHealth) {
+         health: GiniHealth,
+         shouldUseAlternativeNavigation: Bool) {
         self.coordinator = coordinator
         self.hardcodedOrdersController = hardcodedOrdersController
         self.orders = orders ?? hardcodedOrdersController.orders
         self.documentService = documentService
         self.health = health
+        self.shouldUseAlternativeNavigation = shouldUseAlternativeNavigation
     }
 
     func updateOrder(updatedOrder: Order) {

--- a/HealthSDK/GiniHealthSDKExample/GiniHealthSDKExample/PrivacyInfo.xcprivacy
+++ b/HealthSDK/GiniHealthSDKExample/GiniHealthSDKExample/PrivacyInfo.xcprivacy
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+   PrivacyInfo.xcprivacy
+   GiniHealthSDKExample
+
+   Created by Lester Batres on 12.08.25.
+   Copyright (c) 2025 ___ORGANIZATIONNAME___. All rights reserved.
+-->
+<plist version="1.0">
+    <dict>
+        <key>NSPrivacyTracking</key>
+        <false/>
+        <key>NSPrivacyTrackingDomains</key>
+        <array>
+            <string>firebaselogging-pa.googleapis.com</string>
+            <string>app-measurement.com</string>
+        </array>
+        <key>NSPrivacyCollectedDataTypes</key>
+        <array/>
+        <key>NSPrivacyAccessedAPITypes</key>
+        <array/>
+    </dict>
+</plist>

--- a/MerchantSDK/GiniMerchantSDK/Sources/GiniMerchantSDK/Core/PaymentComponentsController.swift
+++ b/MerchantSDK/GiniMerchantSDK/Sources/GiniMerchantSDK/Core/PaymentComponentsController.swift
@@ -522,6 +522,7 @@ public final class PaymentComponentsController: PaymentComponentsProtocol, Botto
 }
 
 extension PaymentComponentsController: PaymentComponentViewProtocol {
+    
     /// Handles the action when the more information button is tapped on the payment component view, using the provided document ID.
     public func didTapOnMoreInformation(documentId: String?) {
         viewDelegate?.didTapOnMoreInformation(documentId: documentId)
@@ -535,6 +536,10 @@ extension PaymentComponentsController: PaymentComponentViewProtocol {
     /// Handles the action when the pay invoice button is tapped on the payment component view, using the provided document ID.
     public func didTapOnPayInvoice(documentId: String?) {
         viewDelegate?.didTapOnPayInvoice(documentId: documentId)
+    }
+    
+    public func didDismissPaymentComponent() {
+        viewDelegate?.didDismissPaymentComponent()
     }
 }
 

--- a/MerchantSDK/GiniMerchantSDKExample/GiniMerchantSDKExample/Sources/InvoicesList/OrderDetailViewController.swift
+++ b/MerchantSDK/GiniMerchantSDKExample/GiniMerchantSDKExample/Sources/InvoicesList/OrderDetailViewController.swift
@@ -197,6 +197,10 @@ extension OrderDetailViewController: GiniInternalPaymentSDK.PaymentComponentView
             }
         }
     }
+    
+    func didDismissPaymentComponent() {
+        presentedViewController?.dismiss(animated: true)
+    }
 
     private func saveTextFieldData() {
         let textFields = OrderDetailView.textFields


### PR DESCRIPTION
## Pull Request Description

This PR add a new `delegate` to `HealthSDK` to notify to the consumer app that the SDK was dismissed. This to support any kind of navigation that the consumer could be implementing to show our SDK.

[IPC-776]

- A new `delegate` method was added so the consumer app can be listening to it to know if the SDK was dismissed. 

## Notes for Reviewers

- At the example app a new option `Use alternative navigation` was added to `settings` menu to enable the alternative navigation to validate the new delegate. 


[IPC-776]: https://ginis.atlassian.net/browse/IPC-776?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ