### PR TITLE
Enable crashlytics bank sdk example app

### DIFF
--- a/.github/workflows/bank-sdk.publish.example.app.firebase.yml
+++ b/.github/workflows/bank-sdk.publish.example.app.firebase.yml
@@ -85,7 +85,11 @@ jobs:
         run: |
             plutil -replace client_id -string "gini-mobile-test" BankSDK/GiniBankSDKExample/GiniBankSDKExample/Credentials.plist
             plutil -replace client_password -string "${{ secrets.GINI_MOBILE_TEST_CLIENT_SECRET }}" BankSDK/GiniBankSDKExample/GiniBankSDKExample/Credentials.plist
-                
+            
+      - name: Setup Firebase API Key
+        run: |
+            plutil -replace API_KEY -string "${{ secrets.FIREBASE_API_KEY }}" BankSDK/GiniBankSDKExample/GoogleService-Info.plist
+
       - name: Archiving project
         run: |
             xcodebuild clean archive \

--- a/BankSDK/GiniBankSDKExample/GiniBankSDKExample.xcodeproj/project.pbxproj
+++ b/BankSDK/GiniBankSDKExample/GiniBankSDKExample.xcodeproj/project.pbxproj
@@ -2224,7 +2224,7 @@
 			repositoryURL = "https://github.com/firebase/firebase-ios-sdk.git";
 			requirement = {
 				kind = exactVersion;
-				version = 11.11.0;
+				version = 12.1.0;
 			};
 		};
 		2815B6F22A0CF51C004ABF06 /* XCRemoteSwiftPackageReference "lottie-ios" */ = {

--- a/BankSDK/GiniBankSDKExample/GiniBankSDKExample.xcodeproj/project.pbxproj
+++ b/BankSDK/GiniBankSDKExample/GiniBankSDKExample.xcodeproj/project.pbxproj
@@ -2051,6 +2051,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
+				OTHER_SWIFT_FLAGS = "\"-enable-experimental-feature AccessLevelOnImport\"";
 				PRODUCT_BUNDLE_IDENTIFIER = net.gini.banksdk.example.tests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -2076,6 +2077,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
+				OTHER_SWIFT_FLAGS = "\"-enable-experimental-feature AccessLevelOnImport\"";
 				PRODUCT_BUNDLE_IDENTIFIER = net.gini.banksdk.example.tests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";

--- a/BankSDK/GiniBankSDKExample/GiniBankSDKExample.xcodeproj/project.pbxproj
+++ b/BankSDK/GiniBankSDKExample/GiniBankSDKExample.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		281417ED2DAEC7E500D138CF /* result_Gini_invoice_example_instant_payment_remslips_after_feedback.json in Resources */ = {isa = PBXBuildFile; fileRef = 281417E92DAEC7E500D138CF /* result_Gini_invoice_example_instant_payment_remslips_after_feedback.json */; };
 		281417EF2DAFDBDE00D138CF /* Gini_invoice_example_instant_payment_remslips.pdf in Resources */ = {isa = PBXBuildFile; fileRef = 281417EE2DAFDBDE00D138CF /* Gini_invoice_example_instant_payment_remslips.pdf */; };
 		281417F02DAFDBDE00D138CF /* Gini_invoice_example_instant_payment_remslips.pdf in Resources */ = {isa = PBXBuildFile; fileRef = 281417EE2DAFDBDE00D138CF /* Gini_invoice_example_instant_payment_remslips.pdf */; };
+		281E9BA52E4CBB26008372EC /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 281E9BA42E4CBB26008372EC /* GoogleService-Info.plist */; };
 		284F52082BD954B200CF70AD /* GiniBankCustomResourceProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 284F52072BD954B200CF70AD /* GiniBankCustomResourceProvider.swift */; };
 		284F520A2BD959F300CF70AD /* UIColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 284F52092BD959F300CF70AD /* UIColor.swift */; };
 		2870683C2CB94E9900D5F2C9 /* DigitalInvoiceWithSkontoIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2870683B2CB94E9900D5F2C9 /* DigitalInvoiceWithSkontoIntegrationTests.swift */; };
@@ -260,6 +261,7 @@
 		281417E82DAEC7E500D138CF /* result_Gini_invoice_example_instant_payment_remslips.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = result_Gini_invoice_example_instant_payment_remslips.json; sourceTree = "<group>"; };
 		281417E92DAEC7E500D138CF /* result_Gini_invoice_example_instant_payment_remslips_after_feedback.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = result_Gini_invoice_example_instant_payment_remslips_after_feedback.json; sourceTree = "<group>"; };
 		281417EE2DAFDBDE00D138CF /* Gini_invoice_example_instant_payment_remslips.pdf */ = {isa = PBXFileReference; lastKnownFileType = image.pdf; path = Gini_invoice_example_instant_payment_remslips.pdf; sourceTree = "<group>"; };
+		281E9BA42E4CBB26008372EC /* GoogleService-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		284F52072BD954B200CF70AD /* GiniBankCustomResourceProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GiniBankCustomResourceProvider.swift; sourceTree = "<group>"; };
 		284F52092BD959F300CF70AD /* UIColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIColor.swift; sourceTree = "<group>"; };
 		2870683B2CB94E9900D5F2C9 /* DigitalInvoiceWithSkontoIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DigitalInvoiceWithSkontoIntegrationTests.swift; sourceTree = "<group>"; };
@@ -1072,6 +1074,7 @@
 				F490C7C125DE72E400D8CA6F /* Products */,
 				F439C21927355C310010D77D /* Frameworks */,
 				28DAF4802CD292DD0035A1FF /* Recovered References */,
+				281E9BA42E4CBB26008372EC /* GoogleService-Info.plist */,
 			);
 			sourceTree = "<group>";
 		};
@@ -1369,6 +1372,7 @@
 				287068422CB950D400D5F2C9 /* result_Gini_invoice_example_RA_Skonto.json in Resources */,
 				4C84B5DD264ED55100853F33 /* Credentials.plist in Resources */,
 				F4083ED72735B0CB004DDD3B /* LocalizableCustomName.strings in Resources */,
+				281E9BA52E4CBB26008372EC /* GoogleService-Info.plist in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/BankSDK/GiniBankSDKExample/GiniBankSDKExample.xcodeproj/project.pbxproj
+++ b/BankSDK/GiniBankSDKExample/GiniBankSDKExample.xcodeproj/project.pbxproj
@@ -2224,7 +2224,7 @@
 			repositoryURL = "https://github.com/firebase/firebase-ios-sdk.git";
 			requirement = {
 				kind = exactVersion;
-				version = 11.12.0;
+				version = 11.11.0;
 			};
 		};
 		2815B6F22A0CF51C004ABF06 /* XCRemoteSwiftPackageReference "lottie-ios" */ = {

--- a/BankSDK/GiniBankSDKExample/GiniBankSDKExample.xcodeproj/project.pbxproj
+++ b/BankSDK/GiniBankSDKExample/GiniBankSDKExample.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		28004ED62E4CC5D600B89DAC /* FirebaseCrashlytics in Frameworks */ = {isa = PBXBuildFile; productRef = 28004ED52E4CC5D600B89DAC /* FirebaseCrashlytics */; };
+		28004ED82E4CC5D600B89DAC /* FirebasePerformance in Frameworks */ = {isa = PBXBuildFile; productRef = 28004ED72E4CC5D600B89DAC /* FirebasePerformance */; };
 		281417EA2DAEC7E500D138CF /* result_Gini_invoice_example_instant_payment_remslips.json in Resources */ = {isa = PBXBuildFile; fileRef = 281417E82DAEC7E500D138CF /* result_Gini_invoice_example_instant_payment_remslips.json */; };
 		281417EB2DAEC7E500D138CF /* result_Gini_invoice_example_instant_payment_remslips_after_feedback.json in Resources */ = {isa = PBXBuildFile; fileRef = 281417E92DAEC7E500D138CF /* result_Gini_invoice_example_instant_payment_remslips_after_feedback.json */; };
 		281417EC2DAEC7E500D138CF /* result_Gini_invoice_example_instant_payment_remslips.json in Resources */ = {isa = PBXBuildFile; fileRef = 281417E82DAEC7E500D138CF /* result_Gini_invoice_example_instant_payment_remslips.json */; };
@@ -493,9 +495,11 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				28004ED82E4CC5D600B89DAC /* FirebasePerformance in Frameworks */,
 				F439C21B27355C310010D77D /* GiniBankSDK in Frameworks */,
 				502B63FA2C3FED5D00B5D5EA /* PhotosUI.framework in Frameworks */,
 				F439C21D27355C3A0010D77D /* GiniCaptureSDK in Frameworks */,
+				28004ED62E4CC5D600B89DAC /* FirebaseCrashlytics in Frameworks */,
 				F439C21F27355C430010D77D /* GiniBankAPILibrary in Frameworks */,
 				F4BC984E2ADEA1B600E9E2D0 /* Lottie in Frameworks */,
 			);
@@ -1212,6 +1216,8 @@
 				F439C21C27355C3A0010D77D /* GiniCaptureSDK */,
 				F439C21E27355C430010D77D /* GiniBankAPILibrary */,
 				F4BC984D2ADEA1B600E9E2D0 /* Lottie */,
+				28004ED52E4CC5D600B89DAC /* FirebaseCrashlytics */,
+				28004ED72E4CC5D600B89DAC /* FirebasePerformance */,
 			);
 			productName = "Example Swift";
 			productReference = F490C7E225DE873900D8CA6F /* GiniBankSDKExample.app */;
@@ -1293,6 +1299,7 @@
 			mainGroup = F490C7B625DE72E400D8CA6F;
 			packageReferences = (
 				2815B6F22A0CF51C004ABF06 /* XCRemoteSwiftPackageReference "lottie-ios" */,
+				28004ED42E4CC5D600B89DAC /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */,
 			);
 			productRefGroup = F490C7C125DE72E400D8CA6F /* Products */;
 			projectDirPath = "";
@@ -2185,6 +2192,14 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
+		28004ED42E4CC5D600B89DAC /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/firebase/firebase-ios-sdk.git";
+			requirement = {
+				kind = exactVersion;
+				version = 11.15.0;
+			};
+		};
 		2815B6F22A0CF51C004ABF06 /* XCRemoteSwiftPackageReference "lottie-ios" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/airbnb/lottie-ios.git";
@@ -2196,6 +2211,16 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
+		28004ED52E4CC5D600B89DAC /* FirebaseCrashlytics */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 28004ED42E4CC5D600B89DAC /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebaseCrashlytics;
+		};
+		28004ED72E4CC5D600B89DAC /* FirebasePerformance */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 28004ED42E4CC5D600B89DAC /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebasePerformance;
+		};
 		28C3443B2C5CF8C500FD03C5 /* GiniCaptureSDK */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = GiniCaptureSDK;

--- a/BankSDK/GiniBankSDKExample/GiniBankSDKExample.xcodeproj/project.pbxproj
+++ b/BankSDK/GiniBankSDKExample/GiniBankSDKExample.xcodeproj/project.pbxproj
@@ -2051,7 +2051,6 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				OTHER_SWIFT_FLAGS = "\"-enable-experimental-feature AccessLevelOnImport\"";
 				PRODUCT_BUNDLE_IDENTIFIER = net.gini.banksdk.example.tests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -2077,7 +2076,6 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				OTHER_SWIFT_FLAGS = "\"-enable-experimental-feature AccessLevelOnImport\"";
 				PRODUCT_BUNDLE_IDENTIFIER = net.gini.banksdk.example.tests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";

--- a/BankSDK/GiniBankSDKExample/GiniBankSDKExample.xcodeproj/project.pbxproj
+++ b/BankSDK/GiniBankSDKExample/GiniBankSDKExample.xcodeproj/project.pbxproj
@@ -1204,6 +1204,7 @@
 				F490C7E025DE873900D8CA6F /* Resources */,
 				8356CC2028D3652E0079AF00 /* SwiftLint */,
 				F4C723B828F8354400BDDEA7 /* Embed Foundation Extensions */,
+				281E9BB02E4CBDE4008372EC /* Upload DSYM */,
 			);
 			buildRules = (
 			);
@@ -1418,6 +1419,29 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
+		281E9BB02E4CBDE4008372EC /* Upload DSYM */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${DWARF_DSYM_FOLDER_PATH}/${DWARF_DSYM_FILE_NAME}",
+				"${DWARF_DSYM_FOLDER_PATH}/${DWARF_DSYM_FILE_NAME}/Contents/Resources/DWARF/${PRODUCT_NAME}",
+				"${DWARF_DSYM_FOLDER_PATH}/${DWARF_DSYM_FILE_NAME}/Contents/Info.plist",
+				"$(TARGET_BUILD_DIR)/$(UNLOCALIZED_RESOURCES_FOLDER_PATH)/GoogleService-Info.plist",
+				"$(TARGET_BUILD_DIR)/$(EXECUTABLE_PATH)",
+			);
+			name = "Upload DSYM";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "# Type a script or drag a script file from your workspace to insert its path.\n\"${BUILD_DIR%/Build/*}/SourcePackages/checkouts/firebase-ios-sdk/Crashlytics/run\"\n\n";
+		};
 		8356CC2028D3652E0079AF00 /* SwiftLint */ = {
 			isa = PBXShellScriptBuildPhase;
 			alwaysOutOfDate = 1;
@@ -1961,6 +1985,7 @@
 				CODE_SIGN_ENTITLEMENTS = "GiniBankSDKExample/Example Swift.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEVELOPMENT_TEAM = JA825X8F7Z;
 				INFOPLIST_FILE = GiniBankSDKExample/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
@@ -1968,6 +1993,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
+				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_BUNDLE_IDENTIFIER = net.gini.banksdk.example;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1998,6 +2024,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
+				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_BUNDLE_IDENTIFIER = net.gini.banksdk.example;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/BankSDK/GiniBankSDKExample/GiniBankSDKExample.xcodeproj/project.pbxproj
+++ b/BankSDK/GiniBankSDKExample/GiniBankSDKExample.xcodeproj/project.pbxproj
@@ -2224,7 +2224,7 @@
 			repositoryURL = "https://github.com/firebase/firebase-ios-sdk.git";
 			requirement = {
 				kind = exactVersion;
-				version = 11.15.0;
+				version = 11.12.0;
 			};
 		};
 		2815B6F22A0CF51C004ABF06 /* XCRemoteSwiftPackageReference "lottie-ios" */ = {

--- a/BankSDK/GiniBankSDKExample/GiniBankSDKExample/AppDelegate.swift
+++ b/BankSDK/GiniBankSDKExample/GiniBankSDKExample/AppDelegate.swift
@@ -18,7 +18,12 @@ import Firebase
     var window: UIWindow?
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-
+#if DEBUG
+        /// This is to not initialize what we don't need in the tests.
+        if ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] != nil {
+            return true
+        }
+#endif
         FirebaseApp.configure()
 
         window = UIWindow(frame: UIScreen.main.bounds)

--- a/BankSDK/GiniBankSDKExample/GiniBankSDKExample/AppDelegate.swift
+++ b/BankSDK/GiniBankSDKExample/GiniBankSDKExample/AppDelegate.swift
@@ -7,6 +7,7 @@
 
 import UIKit
 import GiniBankSDK
+import Firebase
 
 @UIApplicationMain
     final class AppDelegate: UIResponder, UIApplicationDelegate {
@@ -17,6 +18,9 @@ import GiniBankSDK
     var window: UIWindow?
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+
+        FirebaseApp.configure()
+
         window = UIWindow(frame: UIScreen.main.bounds)
         coordinator = AppCoordinator(window: window ?? UIWindow())
         coordinator.start()

--- a/BankSDK/GiniBankSDKExample/GiniBankSDKExample/DemoViewController.swift
+++ b/BankSDK/GiniBankSDKExample/GiniBankSDKExample/DemoViewController.swift
@@ -74,18 +74,6 @@ final class DemoViewController: UIViewController {
         configureSettingsButton()
 
         dismissKeyboardOnTap()
-        // Do any additional setup after loading the view, typically from a nib.
-
-        let button = UIButton(type: .roundedRect)
-        button.frame = CGRect(x: 20, y: 50, width: 100, height: 30)
-        button.setTitle("Test Crash", for: [])
-        button.addTarget(self, action: #selector(self.crashButtonTapped(_:)), for: .touchUpInside)
-        view.addSubview(button)
-    }
-
-    @IBAction func crashButtonTapped(_ sender: AnyObject) {
-        let numbers = [0]
-        let _ = numbers[1]
     }
 
     override func viewDidAppear(_ animated: Bool) {

--- a/BankSDK/GiniBankSDKExample/GiniBankSDKExample/DemoViewController.swift
+++ b/BankSDK/GiniBankSDKExample/GiniBankSDKExample/DemoViewController.swift
@@ -74,8 +74,20 @@ final class DemoViewController: UIViewController {
         configureSettingsButton()
 
         dismissKeyboardOnTap()
+        // Do any additional setup after loading the view, typically from a nib.
+
+        let button = UIButton(type: .roundedRect)
+        button.frame = CGRect(x: 20, y: 50, width: 100, height: 30)
+        button.setTitle("Test Crash", for: [])
+        button.addTarget(self, action: #selector(self.crashButtonTapped(_:)), for: .touchUpInside)
+        view.addSubview(button)
     }
-    
+
+    @IBAction func crashButtonTapped(_ sender: AnyObject) {
+        let numbers = [0]
+        let _ = numbers[1]
+    }
+
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         subscribeOnKeyboardNotifications()

--- a/BankSDK/GiniBankSDKExample/GoogleService-Info.plist
+++ b/BankSDK/GiniBankSDKExample/GoogleService-Info.plist
@@ -15,15 +15,15 @@
 	<key>STORAGE_BUCKET</key>
 	<string>ginibank-ca4f2.firebasestorage.app</string>
 	<key>IS_ADS_ENABLED</key>
-	<false></false>
+	<false/>
 	<key>IS_ANALYTICS_ENABLED</key>
-	<false></false>
+	<false/>
 	<key>IS_APPINVITE_ENABLED</key>
-	<true></true>
+	<true/>
 	<key>IS_GCM_ENABLED</key>
-	<true></true>
+	<true/>
 	<key>IS_SIGNIN_ENABLED</key>
-	<true></true>
+	<true/>
 	<key>GOOGLE_APP_ID</key>
 	<string>1:1008447554665:ios:c5c2362ee87d0bd605cef8</string>
 </dict>

--- a/BankSDK/GiniBankSDKExample/GoogleService-Info.plist
+++ b/BankSDK/GiniBankSDKExample/GoogleService-Info.plist
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>API_KEY</key>
+	<string>AIzaSyAqPhYmDvODxPQm0g96_6EPmAVo1NUtymU</string>
+	<key>GCM_SENDER_ID</key>
+	<string>1008447554665</string>
+	<key>PLIST_VERSION</key>
+	<string>1</string>
+	<key>BUNDLE_ID</key>
+	<string>net.gini.banksdk.example</string>
+	<key>PROJECT_ID</key>
+	<string>ginibank-ca4f2</string>
+	<key>STORAGE_BUCKET</key>
+	<string>ginibank-ca4f2.firebasestorage.app</string>
+	<key>IS_ADS_ENABLED</key>
+	<false></false>
+	<key>IS_ANALYTICS_ENABLED</key>
+	<false></false>
+	<key>IS_APPINVITE_ENABLED</key>
+	<true></true>
+	<key>IS_GCM_ENABLED</key>
+	<true></true>
+	<key>IS_SIGNIN_ENABLED</key>
+	<true></true>
+	<key>GOOGLE_APP_ID</key>
+	<string>1:1008447554665:ios:c5c2362ee87d0bd605cef8</string>
+</dict>
+</plist>

--- a/BankSDK/GiniBankSDKExample/GoogleService-Info.plist
+++ b/BankSDK/GiniBankSDKExample/GoogleService-Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>API_KEY</key>
-	<string>AIzaSyAqPhYmDvODxPQm0g96_6EPmAVo1NUtymU</string>
+	<string>&quot;&quot;</string>
 	<key>GCM_SENDER_ID</key>
 	<string>1008447554665</string>
 	<key>PLIST_VERSION</key>

--- a/GiniMobile.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/GiniMobile.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -2,12 +2,138 @@
   "object": {
     "pins": [
       {
+        "package": "abseil",
+        "repositoryURL": "https://github.com/google/abseil-cpp-binary.git",
+        "state": {
+          "branch": null,
+          "revision": "bbe8b69694d7873315fd3a4ad41efe043e1c07c5",
+          "version": "1.2024072200.0"
+        }
+      },
+      {
+        "package": "AppCheck",
+        "repositoryURL": "https://github.com/google/app-check.git",
+        "state": {
+          "branch": null,
+          "revision": "61b85103a1aeed8218f17c794687781505fbbef5",
+          "version": "11.2.0"
+        }
+      },
+      {
+        "package": "Firebase",
+        "repositoryURL": "https://github.com/firebase/firebase-ios-sdk.git",
+        "state": {
+          "branch": null,
+          "revision": "fdc352fabaf5916e7faa1f96ad02b1957e93e5a5",
+          "version": "11.15.0"
+        }
+      },
+      {
+        "package": "GoogleAdsOnDeviceConversion",
+        "repositoryURL": "https://github.com/googleads/google-ads-on-device-conversion-ios-sdk",
+        "state": {
+          "branch": null,
+          "revision": "e15f979c3eaf477d24e5bfec9d87f1d76fbac297",
+          "version": "2.2.0"
+        }
+      },
+      {
+        "package": "GoogleAppMeasurement",
+        "repositoryURL": "https://github.com/google/GoogleAppMeasurement.git",
+        "state": {
+          "branch": null,
+          "revision": "45ce435e9406d3c674dd249a042b932bee006f60",
+          "version": "11.15.0"
+        }
+      },
+      {
+        "package": "GoogleDataTransport",
+        "repositoryURL": "https://github.com/google/GoogleDataTransport.git",
+        "state": {
+          "branch": null,
+          "revision": "617af071af9aa1d6a091d59a202910ac482128f9",
+          "version": "10.1.0"
+        }
+      },
+      {
+        "package": "GoogleUtilities",
+        "repositoryURL": "https://github.com/google/GoogleUtilities.git",
+        "state": {
+          "branch": null,
+          "revision": "60da361632d0de02786f709bdc0c4df340f7613e",
+          "version": "8.1.0"
+        }
+      },
+      {
+        "package": "gRPC",
+        "repositoryURL": "https://github.com/google/grpc-binary.git",
+        "state": {
+          "branch": null,
+          "revision": "cc0001a0cf963aa40501d9c2b181e7fc9fd8ec71",
+          "version": "1.69.0"
+        }
+      },
+      {
+        "package": "GTMSessionFetcher",
+        "repositoryURL": "https://github.com/google/gtm-session-fetcher.git",
+        "state": {
+          "branch": null,
+          "revision": "a2ab612cb980066ee56d90d60d8462992c07f24b",
+          "version": "3.5.0"
+        }
+      },
+      {
+        "package": "InteropForGoogle",
+        "repositoryURL": "https://github.com/google/interop-ios-for-google-sdks.git",
+        "state": {
+          "branch": null,
+          "revision": "040d087ac2267d2ddd4cca36c757d1c6a05fdbfe",
+          "version": "101.0.0"
+        }
+      },
+      {
+        "package": "leveldb",
+        "repositoryURL": "https://github.com/firebase/leveldb.git",
+        "state": {
+          "branch": null,
+          "revision": "a0bc79961d7be727d258d33d5a6b2f1023270ba1",
+          "version": "1.22.5"
+        }
+      },
+      {
         "package": "Lottie",
         "repositoryURL": "https://github.com/airbnb/lottie-ios.git",
         "state": {
           "branch": null,
           "revision": "d6feea26a370019b4d3a85f5984cb95a2734776f",
           "version": "4.2.0"
+        }
+      },
+      {
+        "package": "nanopb",
+        "repositoryURL": "https://github.com/firebase/nanopb.git",
+        "state": {
+          "branch": null,
+          "revision": "b7e1104502eca3a213b46303391ca4d3bc8ddec1",
+          "version": "2.30910.0"
+        }
+      },
+      {
+        "package": "Promises",
+        "repositoryURL": "https://github.com/google/promises.git",
+        "state": {
+          "branch": null,
+          "revision": "540318ecedd63d883069ae7f1ed811a2df00b6ac",
+          "version": "2.4.0"
+        }
+      },
+      {
+        "package": "SwiftProtobuf",
+        "repositoryURL": "https://github.com/apple/swift-protobuf.git",
+        "state": {
+          "branch": null,
+          "revision": "d72aed98f8253ec1aa9ea1141e28150f408cf17f",
+          "version": "1.29.0"
         }
       },
       {

--- a/GiniMobile.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/GiniMobile.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -24,17 +24,8 @@
         "repositoryURL": "https://github.com/firebase/firebase-ios-sdk.git",
         "state": {
           "branch": null,
-          "revision": "fdc352fabaf5916e7faa1f96ad02b1957e93e5a5",
-          "version": "11.15.0"
-        }
-      },
-      {
-        "package": "GoogleAdsOnDeviceConversion",
-        "repositoryURL": "https://github.com/googleads/google-ads-on-device-conversion-ios-sdk",
-        "state": {
-          "branch": null,
-          "revision": "e15f979c3eaf477d24e5bfec9d87f1d76fbac297",
-          "version": "2.2.0"
+          "revision": "fbd463894af94d90eb4d6a4e54080459a8179519",
+          "version": "11.12.0"
         }
       },
       {
@@ -42,8 +33,8 @@
         "repositoryURL": "https://github.com/google/GoogleAppMeasurement.git",
         "state": {
           "branch": null,
-          "revision": "45ce435e9406d3c674dd249a042b932bee006f60",
-          "version": "11.15.0"
+          "revision": "f7460ea630bddf172115c28493ae8b3798d95ce3",
+          "version": "11.12.0"
         }
       },
       {

--- a/GiniMobile.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/GiniMobile.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/firebase/firebase-ios-sdk.git",
         "state": {
           "branch": null,
-          "revision": "fbd463894af94d90eb4d6a4e54080459a8179519",
-          "version": "11.12.0"
+          "revision": "d1f7c7e8eaa74d7e44467184dc5f592268247d33",
+          "version": "11.11.0"
         }
       },
       {
@@ -33,8 +33,8 @@
         "repositoryURL": "https://github.com/google/GoogleAppMeasurement.git",
         "state": {
           "branch": null,
-          "revision": "f7460ea630bddf172115c28493ae8b3798d95ce3",
-          "version": "11.12.0"
+          "revision": "dd89fc79a77183830742a16866d87e4e54785734",
+          "version": "11.11.0"
         }
       },
       {

--- a/HealthSDK/GiniHealthSDKExample/GiniHealthSDKExample.xcodeproj/project.pbxproj
+++ b/HealthSDK/GiniHealthSDKExample/GiniHealthSDKExample.xcodeproj/project.pbxproj
@@ -829,7 +829,7 @@
 /* Begin XCRemoteSwiftPackageReference section */
 		288F884E2E4A5563004D7A60 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */ = {
 			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/firebase/firebase-ios-sdk";
+			repositoryURL = "https://github.com/firebase/firebase-ios-sdk.git";
 			requirement = {
 				kind = exactVersion;
 				version = 12.1.0;


### PR DESCRIPTION
## Pull Request Description

This pull request introduces FirebaseCrashlytics and FirebasePerformance frameworks to the GiniBankSDKExample app.
To achieve this, I followed all the steps [described](https://firebase.google.com/docs/crashlytics/get-started?platform=ios) here.

**Important** to know that we need to use Firebase version 11.11.0 and not other version above this one because of the deprecation of the Xcode 15 version.

Check the release notes for[ Version 11.12.0](https://firebase.google.com/support/release-notes/ios#version_11120_-_april_21_2025), where they mentioned they dropped support for Xcode15.

For us is important because GitHub Actions are still configured to run on Xcode 15.

## Notes for Reviewers

If you want to test, please follow the steps described [here](https://firebase.google.com/docs/crashlytics/get-started?platform=ios#force-test-crash). 

Please keep in mind this:  **The Xcode debugger prevents crash reports from being sent to Crashlytics. Complete the following steps to disconnect your test device or simulator from the Xcode debugger before forcing a crash.**

So you need to detach the device from Xcode before testing the crash.
