### PR TITLE
fix(GiniBankSDK): Update Xcode version and simualtor OS for github ac…

### DIFF
--- a/.github/workflows/bank-api-library.build.docs.yml
+++ b/.github/workflows/bank-api-library.build.docs.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
     - uses: maxim-lobanov/setup-xcode@v1.6.0
       with:
-        xcode-version: '15.3'
+        xcode-version: '16.4'
 
     - name: Checkout
       uses: actions/checkout@v4

--- a/.github/workflows/bank-api-library.check.yml
+++ b/.github/workflows/bank-api-library.check.yml
@@ -21,11 +21,11 @@ jobs:
     strategy:
       matrix:
         target: [GiniBankAPILibrary, GiniBankAPILibraryPinning]
-        destination: ['platform=iOS Simulator,OS=17.5,name=iPhone 15']
+        destination: ['platform=iOS Simulator,OS=18.5,name=iPhone 16']
     steps:
     - uses: maxim-lobanov/setup-xcode@v1.6.0
       with:
-        xcode-version: '15.3'
+        xcode-version: '16.4'
 
     - name: Checkout
       uses: actions/checkout@v4

--- a/.github/workflows/bank-api-library.publish.docs.yml
+++ b/.github/workflows/bank-api-library.publish.docs.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
     - uses: maxim-lobanov/setup-xcode@v1.6.0
       with:
-        xcode-version: '15.3'
+        xcode-version: '16.4'
 
     - name: Checkout
       uses: actions/checkout@v4

--- a/.github/workflows/bank-api-library.release.yml
+++ b/.github/workflows/bank-api-library.release.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
     - uses: maxim-lobanov/setup-xcode@v1.6.0
       with:
-        xcode-version: '15.3'
+        xcode-version: '16.4'
 
     - name: Checkout
       uses: actions/checkout@v4

--- a/.github/workflows/bank-sdk.build.docs.yml
+++ b/.github/workflows/bank-sdk.build.docs.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
     - uses: maxim-lobanov/setup-xcode@v1.6.0
       with:
-        xcode-version: '15.3'
+        xcode-version: '16.4'
 
     - name: Checkout
       uses: actions/checkout@v4

--- a/.github/workflows/bank-sdk.check.yml
+++ b/.github/workflows/bank-sdk.check.yml
@@ -22,11 +22,11 @@ jobs:
     strategy:
       matrix:
         target: [GiniBankSDK, GiniBankSDKPinning]
-        destination: ['platform=iOS Simulator,OS=17.5,name=iPhone 15']
+        destination: ['platform=iOS Simulator,OS=18.5,name=iPhone 16']
     steps:
     - uses: maxim-lobanov/setup-xcode@v1.6.0
       with:
-        xcode-version: '15.3'
+        xcode-version: '16.4'
 
     - name: Checkout
       uses: actions/checkout@v4

--- a/.github/workflows/bank-sdk.publish.docs.yml
+++ b/.github/workflows/bank-sdk.publish.docs.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
     - uses: maxim-lobanov/setup-xcode@v1.6.0
       with:
-        xcode-version: '15.3'
+        xcode-version: '16.4'
 
     - name: Checkout
       uses: actions/checkout@v4

--- a/.github/workflows/bank-sdk.publish.example.app.firebase.yml
+++ b/.github/workflows/bank-sdk.publish.example.app.firebase.yml
@@ -23,7 +23,7 @@ jobs:
 
       - uses: maxim-lobanov/setup-xcode@v1.6.0
         with:
-          xcode-version: '15.3'
+          xcode-version: '16.4'
 
       - name: Setup provisioning profile
         env:

--- a/.github/workflows/bank-sdk.release.yml
+++ b/.github/workflows/bank-sdk.release.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
     - uses: maxim-lobanov/setup-xcode@v1.6.0
       with:
-        xcode-version: '15.3'
+        xcode-version: '16.4'
 
     - name: Checkout
       uses: actions/checkout@v4

--- a/.github/workflows/capture-sdk.build.docs.yml
+++ b/.github/workflows/capture-sdk.build.docs.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
     - uses: maxim-lobanov/setup-xcode@v1.6.0
       with:
-        xcode-version: '15.3'
+        xcode-version: '16.4'
 
     - name: Checkout
       uses: actions/checkout@v4

--- a/.github/workflows/capture-sdk.check.yml
+++ b/.github/workflows/capture-sdk.check.yml
@@ -21,11 +21,11 @@ jobs:
     strategy:
       matrix:
         target: [GiniCaptureSDK, GiniCaptureSDKPinning]
-        destination: ['platform=iOS Simulator,OS=17.5,name=iPhone 15']
+        destination: ['platform=iOS Simulator,OS=18.5,name=iPhone 16']
     steps:
     - uses: maxim-lobanov/setup-xcode@v1.6.0
       with:
-        xcode-version: '15.3'
+        xcode-version: '16.4'
 
     - name: Checkout
       uses: actions/checkout@v4

--- a/.github/workflows/capture-sdk.publish.docs.yml
+++ b/.github/workflows/capture-sdk.publish.docs.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
     - uses: maxim-lobanov/setup-xcode@v1.6.0
       with:
-        xcode-version: '15.3'
+        xcode-version: '16.4'
 
     - name: Checkout
       uses: actions/checkout@v4

--- a/.github/workflows/capture-sdk.release.yml
+++ b/.github/workflows/capture-sdk.release.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
     - uses: maxim-lobanov/setup-xcode@v1.6.0
       with:
-        xcode-version: '15.3'
+        xcode-version: '16.4'
 
     - name: Checkout
       uses: actions/checkout@v4


### PR DESCRIPTION
## Pull Request Description

This PR updates the Xcode version and iOS simulator configuration across multiple GitHub Actions workflows for GiniBankSDK, GiniCaptureSDK, and GiniBankAPILibrary projects. The changes standardize the development environment to use Xcode 16.4 and iOS 18.5 simulator with iPhone 16.

- Updates Xcode version from 15.3 to 16.4 across all workflow files
- Updates the iOS simulator from iPhone 15 with iOS 17.5 to iPhone 16 with iOS 18.5
- Applies changes consistently across all CI/CD workflows for BankSDK, CaptureSDK, and API library

## Why do we need this?
We run almost all our jobs inside of gitHub action on the `macos-latest` and Github chnaged the version for the Xcode for this setup to be Xcode 16 instead of 15 as default version.
"macos-15 is ready to be the default version for the macos-latest label in GitHub Actions and Azure DevOps."
"Default Xcode will be changed to 16.4 on macOS 15 Sequoia."

More details can be found here: 
https://github.com/actions/runner-images/issues/12751
https://github.com/actions/runner-images/issues/12541