### PR TITLE
fix(GiniBankSDK): add accessibilityTraits to the image view

### DIFF
--- a/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/ReturnAssistant/Onboarding/DigitalInvoiceOnboardingHorizontalItem.swift
+++ b/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/ReturnAssistant/Onboarding/DigitalInvoiceOnboardingHorizontalItem.swift
@@ -107,6 +107,7 @@ class DigitalInvoiceOnboardingHorizontalItem: UIView {
         }
         topImageView.isAccessibilityElement = true
         topImageView.accessibilityValue = firstLabelText
+        topImageView.accessibilityTraits = .image
         topImageView.setupView()
 
         // title

--- a/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/ReturnAssistant/Onboarding/DigitalInvoiceOnboardingViewController.swift
+++ b/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/ReturnAssistant/Onboarding/DigitalInvoiceOnboardingViewController.swift
@@ -130,6 +130,7 @@ final class DigitalInvoiceOnboardingViewController: UIViewController {
         }
         topImageView.isAccessibilityElement = true
         topImageView.accessibilityValue = firstLabelText
+        topImageView.accessibilityTraits = .image
         topImageView.setupView()
     }
 


### PR DESCRIPTION
PP-1539

## Pull Request Description

This PR updates the RA onboarding screen image accessibility configuration to ensure VoiceOver consistently announces it as an image. The change explicitly adds the .image accessibility trait, and provides a descriptive accessibility label.

<!-- Briefly explain **what** this PR does and **why**. Mention the motivation, feature, or issue it's addressing. -->

[PP-1539](https://ginis.atlassian.net/browse/PP-1539)<!-- Closes ticket number PP-####; Replace with JIRA ticket if relevant -->

<!--

Some description of HOW you achieved it. Perhaps give a high level description of the chnages you did. Did you need to refactor something? What tradeoffs did you take?

-->


<!--

Explain how you verified the changes.
A clear testing scenario helps colleagues who may not be familiar with this part of the code quickly understand and verify the changes. Include steps they can follow to see the impact in action.

You can include: 
- Simulators/Devices you used (e.g. iPhone 13, iPad Pro) 
- iOS versions tested (e.g. 16.0, 17.5) 
- Manual checks (e.g. flow tested: onboarding, permissions, error states) 
- Unit tests added or updated 
 
 Include screenshots, screen recordings, or simulator gifs for UI changes. 
 
 - Optional: Anything that needs extra attention in review? Are there TODOs, known limitations, or follow-up work? 
 
 -->

[PP-1539]: https://ginis.atlassian.net/browse/PP-1539?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ