### PR TITLE
Pp 1540 voice over extra word is mentioned in onboarding screen flat paper step

### DIFF
--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Onboarding/OnboardingDataSource.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Onboarding/OnboardingDataSource.swift
@@ -139,10 +139,10 @@ class OnboardingDataSource: NSObject, BaseCollectionViewDataSource {
         let isIphoneLandscape = UIDevice.current.isIphone && collectionView.currentInterfaceOrientation.isLandscape
         let isIphoneSmall = UIDevice.current.isSmallIphone
         let suffix = isIphoneSmall ? "iphoneland-small" : "iphoneland"
-        let reuseId = isIphoneLandscape ? OnboardingPageCell.reuseIdentifier + suffix : OnboardingPageCell.reuseIdentifier
-        if let cell = collectionView.dequeueReusableCell(
-            withReuseIdentifier: reuseId,
-            for: indexPath) as? OnboardingPageCell {
+        let cellIdentifier = OnboardingPageCell.reuseIdentifier
+        let reuseId = isIphoneLandscape ? cellIdentifier + suffix : cellIdentifier
+        if let cell = collectionView.dequeueReusableCell(withReuseIdentifier: reuseId,
+                                                         for: indexPath) as? OnboardingPageCell {
             configureCell(cell: cell, indexPath: indexPath)
             cell.updateConstraintsForCurrentTraits()
             return cell

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Onboarding/Views/OnboardingPageCell.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Onboarding/Views/OnboardingPageCell.swift
@@ -21,8 +21,15 @@ class OnboardingPageCell: UICollectionViewCell {
     }
 
     private func setupView() {
+        isAccessibilityElement = false
         iconView.isAccessibilityElement = true
         iconView.accessibilityTraits = .image
+        iconView.icon?.isAccessibilityElement = false
+        // Tell VoiceOver that this is a static image that doesn't need analysis
+        // .image marks it as an image element
+        //  .staticText indicates it's static content (no dynamic analysis needed)
+        iconView.accessibilityTraits = [.image, .staticText]
+
         titleLabel.textColor = GiniColor(light: UIColor.GiniCapture.dark1,
                                          dark: UIColor.GiniCapture.light1).uiColor()
         titleLabel.font = GiniConfiguration.shared.textStyleFonts[.title2Bold]


### PR DESCRIPTION
## Pull Request Description

The PR is fixing VoiceOver reading random text from the image on the Onboarding screen.

[PP-1540](https://ginis.atlassian.net/browse/PP-1540)

Set accessibility traits to [.image, .staticText] to prevent VoiceOver from scanning the image for text and only read the configured accessibility label.

## Notes for Reviewers

This issue was reproduced on iOS 17 and iOS 18 as well.
Tested on:
iPhone 15Pro with iOS 17


[PP-1540]: https://ginis.atlassian.net/browse/PP-1540?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ