### PR TITLE
fix(GiniBankSDK): Fix iPad voice over when switching to landscape

### DIFF
--- a/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/ReturnAssistant/Onboarding/DigitalInvoiceOnboardingViewController.swift
+++ b/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/ReturnAssistant/Onboarding/DigitalInvoiceOnboardingViewController.swift
@@ -223,11 +223,13 @@ final class DigitalInvoiceOnboardingViewController: UIViewController {
     }
 
     private func updateAccessibilityElements() {
-        let isLandscape = UIDevice.current.isLandscape
-        if isLandscape {
-            view.accessibilityElements = [horizontalItem]
-        } else {
-            view.accessibilityElements = [topImageView, firstLabel, secondLabel, doneButton].compactMap { $0 }
+        let device = UIDevice.current
+
+        view.accessibilityElements = switch (device.isIphone, device.isLandscape) {
+        case (true, true):  // iPhone landscape
+            [horizontalItem]
+        case (true, false), (false, _):  // iPhone portrait sau iPad
+            [topImageView, firstLabel, secondLabel, doneButton].compactMap { $0 }
         }
     }
 


### PR DESCRIPTION
## Pull Request Description

[PP-1544](https://ginis.atlassian.net/browse/PP-1544)

This PR fixes VoiceOver accessibility behavior on iPad when switching to landscape orientation by updating the accessibility elements logic to handle iPhone and iPad devices differently.

1. Updated accessibility element selection logic to use pattern matching with device type and orientation
2. Fixed iPad landscape orientation to use the same accessibility elements as portrait mode
3. Replaced if-else conditional with a switch statement for clearer device-specific logic


[PP-1544]: https://ginis.atlassian.net/browse/PP-1544?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ