### PR TITLE
Pp 1544 in i pad devices voice over ra onboarding screen changing the orientation is not reading the elements

### DIFF
--- a/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/ReturnAssistant/Onboarding/DigitalInvoiceOnboardingViewController.swift
+++ b/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/ReturnAssistant/Onboarding/DigitalInvoiceOnboardingViewController.swift
@@ -223,11 +223,13 @@ final class DigitalInvoiceOnboardingViewController: UIViewController {
     }
 
     private func updateAccessibilityElements() {
-        let isLandscape = UIDevice.current.isLandscape
-        if isLandscape {
-            view.accessibilityElements = [horizontalItem]
-        } else {
-            view.accessibilityElements = [topImageView, firstLabel, secondLabel, doneButton].compactMap { $0 }
+        let device = UIDevice.current
+
+        view.accessibilityElements = switch (device.isIphone, device.isLandscape) {
+        case (true, true):  // iPhone landscape
+            [horizontalItem]
+        case (true, false), (false, _):  // iPhone portrait sau iPad
+            [topImageView, firstLabel, secondLabel, doneButton].compactMap { $0 }
         }
     }
 

--- a/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/ReturnAssistant/Onboarding/DigitalInvoiceOnboardingViewController.swift
+++ b/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/ReturnAssistant/Onboarding/DigitalInvoiceOnboardingViewController.swift
@@ -228,7 +228,7 @@ final class DigitalInvoiceOnboardingViewController: UIViewController {
         view.accessibilityElements = switch (device.isIphone, device.isLandscape) {
         case (true, true):  // iPhone landscape
             [horizontalItem]
-        case (true, false), (false, _):  // iPhone portrait sau iPad
+        case (true, false), (false, _):  // iPhone portrait or iPad
             [topImageView, firstLabel, secondLabel, doneButton].compactMap { $0 }
         }
     }


### PR DESCRIPTION
## Pull Request Description
[PP-1544](https://ginis.atlassian.net/browse/PP-1544)

This PR fixes VoiceOver accessibility behavior on iPad when switching to landscape orientation by updating the accessibility elements logic to handle iPhone and iPad devices differently.

Updated accessibility element selection logic to use pattern matching with device type and orientation
Fixed iPad landscape orientation to use the same accessibility elements as portrait mode
Replaced if-else conditional with a switch statement for clearer device-specific logic

Tested on:
IPad Air(5th generation 17.5)
iPad Pro(11 inch 15.5)
iPad(A16 18.3)
iPad mini(6th gen 18.0)


[PP-1544]: https://ginis.atlassian.net/browse/PP-1544?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ