### PR TITLE
Ipc 788 duplicated payment providers

### DIFF
--- a/GiniComponents/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/BanksView/BanksBottomViewModel.swift
+++ b/GiniComponents/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/BanksView/BanksBottomViewModel.swift
@@ -34,7 +34,7 @@ public final class BanksBottomViewModel {
     let poweredByGiniViewModel: PoweredByGiniViewModel
     let moreInformationViewModel: MoreInformationViewModel
     let paymentInfoViewModel: PaymentInfoViewModel
-    let internalPaymentProvider: [PaymentProvider] = []
+    
     public weak var viewDelegate: BanksSelectionProtocol?
     public var documentId: String?
 
@@ -72,7 +72,7 @@ public final class BanksBottomViewModel {
         self.poweredByGiniViewModel = PoweredByGiniViewModel(configuration: poweredByGiniConfiguration, strings: poweredByGiniStrings)
         self.moreInformationViewModel = MoreInformationViewModel(configuration: moreInformationConfiguration, strings: moreInformationStrings)
         
-        self.paymentInfoViewModel = PaymentInfoViewModel(paymentProviders: paymentProviders,
+        self.paymentInfoViewModel = PaymentInfoViewModel(paymentProviders: paymentProviders.uniqued(by: { $0.id }),
                                                          configuration: paymentInfoConfiguration,
                                                          strings: paymentInfoStrings,
                                                          poweredByGiniConfiguration: poweredByGiniConfiguration,
@@ -86,6 +86,7 @@ public final class BanksBottomViewModel {
                                                  isInstalled: isPaymentProviderInstalled(paymentProvider: $0),
                                                  paymentProvider: $0)})
             .filter { $0.paymentProvider.gpcSupportedPlatforms.contains(.ios) || $0.paymentProvider.openWithSupportedPlatforms.contains(.ios) }
+            .uniqued(by: { $0.paymentProvider.id })
             .sorted {
                 // First, sort by isInstalled
                 if $0.isInstalled != $1.isInstalled {
@@ -94,6 +95,7 @@ public final class BanksBottomViewModel {
                 // Then sort by paymentProvider.index if both have the same isInstalled value
                 return ($0.paymentProvider.index ?? 0) < ($1.paymentProvider.index ?? 0)
             }
+
         self.calculateHeights()
     }
 

--- a/GiniComponents/GiniUtilites/Sources/GiniUtilites/Extensions/Array+Extensions.swift
+++ b/GiniComponents/GiniUtilites/Sources/GiniUtilites/Extensions/Array+Extensions.swift
@@ -1,0 +1,31 @@
+//
+//  Array+Extensions.swift
+//
+//  Copyright © 2025 Gini GmbH. All rights reserved.
+//
+
+
+extension Array {
+    
+    /**
+     * Removes duplicate elements from the array based on a specified key.
+     *
+     * This method maintains the order of elements, keeping the first occurrence
+     * of each unique element and removing subsequent duplicates.
+     *
+     * - Parameter transform: A closure that transforms each element into a
+     *   `Hashable` value used for uniqueness comparison.
+     * - Returns: A new array containing only unique elements based on the
+     *   specified key, preserving the original order.
+     *
+     * Example:
+     * ```swift
+     * let paymentProviders = [provider1, provider2, provider1, provider3]
+     * let uniqueProviders = paymentProviders.uniqued(by: { $0.id })
+     * ```
+     */
+    public func uniqued<T: Hashable>(by transform: (Element) -> T) -> [Element] {
+        var seen = Set<T>()
+        return filter { seen.insert(transform($0)).inserted }
+    }
+}

--- a/HealthAPILibrary/GiniHealthAPILibrary/.jazzy.yaml
+++ b/HealthAPILibrary/GiniHealthAPILibrary/.jazzy.yaml
@@ -5,7 +5,7 @@ xcodebuild_arguments:
 - "-scheme"
 - GiniHealthAPILibrary
 - "-destination"
-- platform=iOS Simulator,OS=17.5,name=iPhone 15
+- platform=iOS Simulator,OS=18.5,name=iPhone 16
 author: Gini GmbH
 author_url: https://gini.net
 module: GiniHealthAPILibrary

--- a/HealthSDK/GiniHealthSDK/Sources/GiniHealthSDK/Core/GiniHealth.swift
+++ b/HealthSDK/GiniHealthSDK/Sources/GiniHealthSDK/Core/GiniHealth.swift
@@ -183,43 +183,6 @@ public struct DataForReview {
     public func fetchBankLogos() -> (logos: [Data]?, additionalBankCount: Int?) {
         return paymentComponentsController.fetchBankLogos()
     }
-    /**
-     Getting a list of the installed banking apps which support Gini Pay Connect functionality.
-     
-     - Parameters:
-        - completion: An action for processing asynchronous data received from the service with Result type as a paramater.
-     Result is a value that represents either a success or a failure, including an associated value in each case.
-     Completion block called on main thread.
-     In success case it includes array of payment providers, which are represebt the installed on the phone apps.
-     In case of failure error that there are no supported banking apps installed.
-     
-     */
-    private func fetchInstalledBankingApps(completion: @escaping (Result<PaymentProviders, GiniHealthError>) -> Void) {
-        fetchBankingApps { result in
-            DispatchQueue.main.async {
-                switch result {
-                case .success(let providers):
-                    self.updateBankProviders(providers: providers)
-
-                    if self.bankProviders.count > 0 {
-                        completion(.success(self.bankProviders))
-                    } else {
-                        completion(.failure(.noInstalledApps))
-                    }
-                case let .failure(error):
-                    completion(.failure(GiniHealthError.apiError(error)))
-                }
-            }
-        }
-    }
-
-    private func updateBankProviders(providers: PaymentProviders) {
-        for provider in providers {
-            if let url = URL(string:provider.appSchemeIOS), UIApplication.shared.canOpenURL(url) {
-                self.bankProviders.append(provider)
-            }
-        }
-    }
 
     /**
      Getting a list of the banking apps supported by SDK

--- a/HealthSDK/GiniHealthSDK/Sources/GiniHealthSDK/Core/PaymentComponentsController+Helpers.swift
+++ b/HealthSDK/GiniHealthSDK/Sources/GiniHealthSDK/Core/PaymentComponentsController+Helpers.swift
@@ -771,8 +771,11 @@ extension PaymentComponentsController: PaymentComponentViewProtocol {
         let alertController = UIAlertController(title: NSLocalizedStringPreferredFormat("gini.health.errors.default", comment: ""),
                                                 message: "",
                                                 preferredStyle: .alert)
-        alertController.addAction(UIAlertAction(title: "Ok", style: .default))
-        self.navigationControllerProvided?.present(alertController, animated: true)
+        alertController.addAction(UIAlertAction(title: "Ok", style: .default, handler: { [weak self] _ in
+            self?.notifySDKWasDismissedIfNeeded()
+        }))
+        
+        navigationControllerProvided?.present(alertController, animated: true)
     }
     
     private func handlePaymentRequestResult(_ result: Result<String, GiniHealthAPILibrary.GiniError>) {

--- a/HealthSDK/GiniHealthSDKExample/GiniHealthSDKExampleTests/AlternativeNavigationTests.swift
+++ b/HealthSDK/GiniHealthSDKExample/GiniHealthSDKExampleTests/AlternativeNavigationTests.swift
@@ -159,6 +159,21 @@ struct AlternativeNavigationTests {
         #expect(giniHealthDelegate.didDismissHealthSDKCount == 0,
                 "didDismissHealthSDK should not be called when the navigation controller is not empty")
     }
+    
+    @Test func dismissSDKAfterAlertControllerPresentation() {
+        let navigationController = MockNavigationController()
+        navigationController.giniHealthDelegate = giniHealthDelegate
+        
+        let alertController = UIAlertController(title: "test", message: "test", preferredStyle: .alert)
+        
+        homeViewController.present(navigationController, animated: false)
+        navigationController.present(alertController, animated: false)
+        
+        navigationController.dismiss(animated: true)
+        
+        #expect(giniHealthDelegate.didDismissHealthSDKCount == 1,
+                "didDismissHealthSDK should be called after presented alert is dismissed")
+    }
 
     private func giniPaymentInfo() -> GiniHealthSDK.PaymentInfo {
         PaymentInfo(recipient: "testRecipient",

--- a/MerchantSDK/GiniMerchantSDK/Sources/GiniMerchantSDK/Core/GiniMerchant.swift
+++ b/MerchantSDK/GiniMerchantSDK/Sources/GiniMerchantSDK/Core/GiniMerchant.swift
@@ -132,44 +132,6 @@ public struct DataForReview {
     }
     
     /**
-     Getting a list of the installed banking apps which support Gini Pay Connect functionality.
-     
-     - Parameters:
-        - completion: An action for processing asynchronous data received from the service with Result type as a paramater.
-     Result is a value that represents either a success or a failure, including an associated value in each case.
-     Completion block called on main thread.
-     In success case it includes array of payment providers, which are represebt the installed on the phone apps.
-     In case of failure error that there are no supported banking apps installed.
-     
-     */
-    private func fetchInstalledBankingApps(completion: @escaping (Result<PaymentProviders, GiniMerchantError>) -> Void) {
-        fetchBankingApps { result in
-            DispatchQueue.main.async {
-                switch result {
-                case .success(let providers):
-                    self.updateBankProviders(providers: providers)
-                    
-                    if self.bankProviders.count > 0 {
-                        completion(.success(self.bankProviders))
-                    } else {
-                        completion(.failure(.noInstalledApps))
-                    }
-                case let .failure(error):
-                    completion(.failure(GiniMerchantError.apiError(error)))
-                }
-            }
-        }
-    }
-    
-    private func updateBankProviders(providers: PaymentProviders) {
-        for provider in providers {
-            if let url = URL(string:provider.appSchemeIOS), UIApplication.shared.canOpenURL(url) {
-                self.bankProviders.append(provider)
-            }
-        }
-    }
-    
-    /**
      Getting a list of the banking apps supported by SDK
      
      - Parameters:

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -180,31 +180,27 @@ platform :ios do
         UI.message "Disable jekyll"
         sh("touch .nojekyll")
 
-        if is_stable_release
-          UI.message <<~MESSAGE
-            Update the package root index.html to redirect to this documentation version.
-          MESSAGE
+        UI.message <<~MESSAGE
+          Update the package root index.html to redirect to this documentation version.
+        MESSAGE
   
-          index_html = <<~INDEX_HTML
-          <!DOCTYPE html>
-          <html lang="en">
-            <head>
-              <meta charset="UTF-8">
-              <title>#{documentation_title}</title>
-              <meta http-equiv="refresh" content="0; URL=https://developer.gini.net/gini-mobile-ios/#{destination_path}/index.html" />
-            </head>
-            <body>
-              Redirecting to the latest stable version...
-            </body>
-          </html>
-          INDEX_HTML
+        index_html = <<~INDEX_HTML
+        <!DOCTYPE html>
+        <html lang="en">
+          <head>
+            <meta charset="UTF-8">
+            <title>#{documentation_title}</title>
+            <meta http-equiv="refresh" content="0; URL=https://developer.gini.net/gini-mobile-ios/#{destination_path}/index.html" />
+          </head>
+          <body>
+            Redirecting to the latest stable version...
+          </body>
+        </html>
+        INDEX_HTML
   
-          File.open("#{package_folder}/index.html", "w") { |f| 
-            f.write index_html
-          }
-        else
-          UI.message "Not changing the project root index.html."
-        end
+        File.open("#{package_folder}/index.html", "w") { |f| 
+          f.write index_html
+        }
 
         if !dry_run 
           UI.message "Commit and push the new documentation"


### PR DESCRIPTION
## Pull Request Description

This PR adds the following:

- A call to `didDismissHealthSDK` for the cases when an error is presented before navigating to `PaymentReviewViewController`
- Add the `uniqued` method to an `Array` extension to prevent duplications on `paymentProviders` list.
- Removes the `is_stable_release` validation from `publish_docs` lane to be able to make a release of the documentation from any branch. Not only `main`

[IPC-788]<!-- Closes ticket number PP-####; Replace with JIRA ticket if relevant -->

## Notes for Reviewers

- In order to test the error scenario, you need to use Charles to edit the request of the `get /documents` endpoint to use an invalid id and get a 404. Also need to enable the `alternative navigation` flag. 