### PR TITLE
Pp 1562 voiceover onboarding orientation issue

### DIFF
--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Onboarding/OnboardingViewController.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Onboarding/OnboardingViewController.swift
@@ -130,7 +130,7 @@ class OnboardingViewController: UIViewController {
         }
     }
 
-    func postNotificationToCurrentCell() {
+    private func postNotificationToCurrentCell() {
         let currentPage = pageControl.currentPage
         let indexPath = IndexPath(item: currentPage, section: 0)
 
@@ -330,7 +330,8 @@ class OnboardingViewController: UIViewController {
     private func notifyLayoutChangedAfterRotation() {
         // --- VoiceOver focus handling ---
         // Without this small delay, VoiceOver often fails to move focus to the current cell
-        DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
+        DispatchQueue.main.asyncAfter(deadline: .now() + Constants.accessibilityFocusDelay) { [weak self] in
+            guard let self = self else { return }
             self.postNotificationToCurrentCell()
         }
     }
@@ -415,7 +416,7 @@ private extension OnboardingViewController {
         static let bottomBarHeightLandscape: CGFloat = 64
         static let iconPadding: CGFloat = 56
         static let iconWidth: CGFloat = 220
-
+        static let accessibilityFocusDelay: TimeInterval = 1.0
     }
 
     func getBottomPaddingForPageController() -> CGFloat {


### PR DESCRIPTION
## Pull Request Description

<!-- Briefly explain **what** this PR does and **why**. Mention the motivation, feature, or issue it's addressing. -->

[PP-1562](https://ginis.atlassian.net/browse/PP-1562)<!-- Closes ticket number PP-####; Replace with JIRA ticket if relevant -->

Fixes an issue on the Onboarding screen where changing device orientation with VoiceOver enabled caused the screen to jump back to the previous page. This ensures VoiceOver focus stays on the current page when the device orientation changes.

<!--



Some description of HOW you achieved it. Perhaps give a high level description of the chnages you did. Did you need to refactor something? What tradeoffs did you take?

-->

## Notes for Reviewers

The solution improves VoiceOver focus handling after device orientation changes. The postNotificationToCurrentCell method was updated to reliably focus on the current onboarding cell.

- Ensures the collection view cell is visible and its layout is updated before posting the .layoutChanged accessibility notification.

- Guarantees VoiceOver focuses on the current cell after orientation changes by calling postNotificationToCurrentCell.

- Uses [weak self] in closures to prevent retain cycles when posting accessibility notifications.

- Removes SwiftLint warnings for cleaner code.

- Replaces hardcoded values with constants for better readability and maintainability.
<!--

Explain how you verified the changes.
A clear testing scenario helps colleagues who may not be familiar with this part of the code quickly understand and verify the changes. Include steps they can follow to see the impact in action.

You can include: 
- Simulators/Devices you used (e.g. iPhone 13, iPad Pro) 
- iOS versions tested (e.g. 16.0, 17.5) 
- Manual checks (e.g. flow tested: onboarding, permissions, error states) 
- Unit tests added or updated 
 
 Include screenshots, screen recordings, or simulator gifs for UI changes. 
 
 - Optional: Anything that needs extra attention in review? Are there TODOs, known limitations, or follow-up work? 
 
 -->

[PP-1562]: https://ginis.atlassian.net/browse/PP-1562?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ