### PR TITLE
Unit tests fastlane lane

### DIFF
--- a/.github/workflows/bank-api-library.check.yml
+++ b/.github/workflows/bank-api-library.check.yml
@@ -44,10 +44,19 @@ jobs:
            cd BankAPILibrary/GiniBankAPILibraryPinning
            swift package update
 
-    - name: Build sdk targets
-      run: |
-        xcodebuild -workspace GiniMobile.xcworkspace -scheme "${{ matrix.target }}" -destination "${{ matrix.destination }}" CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO ONLY_ACTIVE_ARCH=NO
+    # Setup ruby to run unit tests for the GiniBankAPILibrary
+    - name: Setup ruby
+      uses: ruby/setup-ruby@dffc446db9ba5a0c4446edb5bca1c5c473a806c5 # v1.245.0
+      with:
+        ruby-version: '3.2.0'
+        bundler-cache: true
 
-    - name: Run unit tests
-      run: |
-        xcodebuild clean test -workspace GiniMobile.xcworkspace -scheme "${{ matrix.target }}Tests" -destination "${{ matrix.destination }}" CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO ONLY_ACTIVE_ARCH=NO
+    - name: Build and run tests for "${{ matrix.target }}"
+      uses: maierj/fastlane-action@5a3b971aaa26776459bb26894d6c1a1a84a311a7 # v3.1.0
+      with:
+        lane: 'run_unit_tests'
+        options: >
+            {
+              "target": "${{ matrix.target }}",
+              "destination": "${{ matrix.destination }}"
+            }

--- a/.github/workflows/bank-sdk.check.yml
+++ b/.github/workflows/bank-sdk.check.yml
@@ -45,6 +45,7 @@ jobs:
            cd BankSDK/GiniBankSDKPinning
            swift package update
 
+    # Setup ruby to run unit tests for the GiniBankSDK
     - name: Setup ruby
       uses: ruby/setup-ruby@dffc446db9ba5a0c4446edb5bca1c5c473a806c5 # v1.245.0
       with:
@@ -55,15 +56,20 @@ jobs:
       uses: maierj/fastlane-action@5a3b971aaa26776459bb26894d6c1a1a84a311a7 # v3.1.0
       env:
         TEST_CLIENT_SECRET: ${{ secrets.GINI_MOBILE_TEST_CLIENT_SECRET }}
+        TEST_CLIENT_ID: "gini-mobile-test"
       with:
         lane: 'run_unit_tests'
         options: >
             {
               "target": "${{ matrix.target }}",
               "destination": "${{ matrix.destination }}",
+              "clientId": "$TEST_CLIENT_ID"
               "clientSecret": "$TEST_CLIENT_SECRET"
             }
+    # Run example app and run unit and integration tests for both GiniBankSDK and GiniBankSDKPinning
     - name: Build example app and run unit and integration tests
+      env:
+        TEST_CLIENT_SECRET: ${{ secrets.GINI_MOBILE_TEST_CLIENT_SECRET }}
       if: ${{ matrix.target == 'GiniBankSDK' }}
       run: >
         xcodebuild clean test
@@ -74,9 +80,11 @@ jobs:
         CODE_SIGNING_REQUIRED=NO
         ONLY_ACTIVE_ARCH=NO
         CLIENT_ID="gini-mobile-test"
-        CLIENT_SECRET="${{ secrets.GINI_MOBILE_TEST_CLIENT_SECRET }}"
+        CLIENT_SECRET="$TEST_CLIENT_SECRET"
 
     - name: Build pinning example app and run unit and integration tests
+      env:
+        TEST_CLIENT_SECRET: ${{ secrets.GINI_MOBILE_TEST_CLIENT_SECRET }}
       if: ${{ matrix.target == 'GiniBankSDKPinning' }}
       run: >
         xcodebuild clean test
@@ -87,4 +95,4 @@ jobs:
         CODE_SIGNING_REQUIRED=NO
         ONLY_ACTIVE_ARCH=NO
         CLIENT_ID="gini-mobile-test"
-        CLIENT_SECRET="${{ secrets.GINI_MOBILE_TEST_CLIENT_SECRET }}"
+        CLIENT_SECRET="$TEST_CLIENT_SECRET"

--- a/.github/workflows/bank-sdk.check.yml
+++ b/.github/workflows/bank-sdk.check.yml
@@ -53,13 +53,15 @@ jobs:
 
     - name: Build and run tests for "${{ matrix.target }}"
       uses: maierj/fastlane-action@v3.1.0
+      env:
+        TEST_CLIENT_SECRET: ${{ secrets.GINI_MOBILE_TEST_CLIENT_SECRET }}
       with:
         lane: 'run_unit_tests'
         options: >
             {
               "target": "${{ matrix.target }}",
               "destination": "${{ matrix.destination }}",
-              "clientSecret": "${{ secrets.GINI_MOBILE_TEST_CLIENT_SECRET }}"
+              "clientSecret": "$TEST_CLIENT_SECRET"
             }
     - name: Build example app and run unit and integration tests
       if: ${{ matrix.target == 'GiniBankSDK' }}

--- a/.github/workflows/bank-sdk.check.yml
+++ b/.github/workflows/bank-sdk.check.yml
@@ -45,25 +45,22 @@ jobs:
            cd BankSDK/GiniBankSDKPinning
            swift package update
 
-    - name: Build sdk targets
-      run: |
-        xcodebuild -workspace GiniMobile.xcworkspace -scheme "${{ matrix.target }}" -destination "${{ matrix.destination }}" CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO ONLY_ACTIVE_ARCH=NO
+    - name: setup ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: '3.2.0'
+        bundler-cache: true
 
-    - name: Run unit tests
-      run: |
-        xcodebuild clean test -workspace GiniMobile.xcworkspace -scheme "${{ matrix.target }}Tests" -destination "${{ matrix.destination }}" CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO ONLY_ACTIVE_ARCH=NO
-
-    - name: Extract Device Name
-      id: extract_name
-      run: |
-        DEVICE_NAME=$(echo "${{ matrix.destination }}" | sed -n 's/.*name=\([^,]*\).*/\1/p')
-        echo "DEVICE_NAME=${DEVICE_NAME}" >> $GITHUB_ENV        
-
-    - name: Start iOS Simulator
-      run: |
-        xcrun simctl boot "$DEVICE_NAME"
-        xcrun simctl bootstatus "$DEVICE_NAME" -b
-   
+    - name: Build and run tests for "${{ matrix.target }}"
+      uses: maierj/fastlane-action@v3.1.0
+      with:
+        lane: 'run_unit_tests'
+        options: >
+            {
+              "target": "${{ matrix.target }}",
+              "destination": "${{ matrix.destination }}",
+              "clientSecret": "${{ secrets.GINI_MOBILE_TEST_CLIENT_SECRET }}"
+            }
     - name: Build example app and run unit and integration tests
       if: ${{ matrix.target == 'GiniBankSDK' }}
       run: >

--- a/.github/workflows/bank-sdk.check.yml
+++ b/.github/workflows/bank-sdk.check.yml
@@ -63,7 +63,7 @@ jobs:
             {
               "target": "${{ matrix.target }}",
               "destination": "${{ matrix.destination }}",
-              "clientId": "$TEST_CLIENT_ID"
+              "clientId": "$TEST_CLIENT_ID",
               "clientSecret": "$TEST_CLIENT_SECRET"
             }
     # Run example app and run unit and integration tests for both GiniBankSDK and GiniBankSDKPinning

--- a/.github/workflows/bank-sdk.check.yml
+++ b/.github/workflows/bank-sdk.check.yml
@@ -45,14 +45,14 @@ jobs:
            cd BankSDK/GiniBankSDKPinning
            swift package update
 
-    - name: setup ruby
-      uses: ruby/setup-ruby@v1
+    - name: Setup ruby
+      uses: ruby/setup-ruby@dffc446db9ba5a0c4446edb5bca1c5c473a806c5 # v1.245.0
       with:
         ruby-version: '3.2.0'
         bundler-cache: true
 
     - name: Build and run tests for "${{ matrix.target }}"
-      uses: maierj/fastlane-action@v3.1.0
+      uses: maierj/fastlane-action@5a3b971aaa26776459bb26894d6c1a1a84a311a7 # v3.1.0
       env:
         TEST_CLIENT_SECRET: ${{ secrets.GINI_MOBILE_TEST_CLIENT_SECRET }}
       with:

--- a/.github/workflows/capture-sdk.check.yml
+++ b/.github/workflows/capture-sdk.check.yml
@@ -43,11 +43,20 @@ jobs:
       run: |
            cd CaptureSDK/GiniCaptureSDKPinning
            swift package update
+    
+    # Setup ruby to run unit tests for the GiniCaptureSDK and GiniCaptureSDKPinning
+    - name: Setup ruby
+      uses: ruby/setup-ruby@dffc446db9ba5a0c4446edb5bca1c5c473a806c5 # v1.245.0
+      with:
+        ruby-version: '3.2.0'
+        bundler-cache: true
 
-    - name: Build sdk targets
-      run: |
-        xcodebuild -workspace GiniMobile.xcworkspace -scheme "${{ matrix.target }}" -destination "${{ matrix.destination }}" CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO ONLY_ACTIVE_ARCH=NO
-
-    - name: Run unit tests
-      run: |
-        xcodebuild clean test -workspace GiniMobile.xcworkspace -scheme "${{ matrix.target }}Tests" -destination "${{ matrix.destination }}" CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO ONLY_ACTIVE_ARCH=NO
+    - name: Build and run tests for "${{ matrix.target }}"
+      uses: maierj/fastlane-action@5a3b971aaa26776459bb26894d6c1a1a84a311a7 # v3.1.0
+      with:
+        lane: 'run_unit_tests'
+        options: >
+            {
+              "target": "${{ matrix.target }}",
+              "destination": "${{ matrix.destination }}"
+            }

--- a/.github/workflows/health-api-library.check.yml
+++ b/.github/workflows/health-api-library.check.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        target: [GiniHealthAPILibrary]
+        target: [GiniHealthAPILibrary, GiniHealthAPILibraryExampleTests]
         destination: ['platform=iOS Simulator,OS=18.5,name=iPhone 16']
     steps:
     - uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd # v1.6.0
@@ -36,24 +36,25 @@ jobs:
       run: |
            cd HealthAPILibrary/GiniHealthAPILibrary
            swift package update
+    
+     # Setup ruby to run unit tests for the GiniBankSDK
+    - name: Setup ruby
+      uses: ruby/setup-ruby@dffc446db9ba5a0c4446edb5bca1c5c473a806c5 # v1.245.0
+      with:
+        ruby-version: '3.2.0'
+        bundler-cache: true
 
-    - name: Build sdk targets
-      run: |
-        xcodebuild -workspace GiniMobile.xcworkspace -scheme "${{ matrix.target }}" -destination "${{ matrix.destination }}" CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO ONLY_ACTIVE_ARCH=NO
-
-    - name: Run unit tests
-      run: |
-        xcodebuild clean test -workspace GiniMobile.xcworkspace -scheme "${{ matrix.target }}Tests" -destination "${{ matrix.destination }}" CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO ONLY_ACTIVE_ARCH=NO
-   
-    - name: Build example app and run integration tests
-      if: ${{ matrix.target == 'GiniHealthAPILibrary' }}
-      run: >
-        xcodebuild clean test
-        -project HealthAPILibrary/GiniHealthAPILibraryExample/GiniHealthAPILibraryExample.xcodeproj
-        -scheme "GiniHealthAPILibraryExampleTests"
-        -destination "${{ matrix.destination }}"
-        CODE_SIGN_IDENTITY=""
-        CODE_SIGNING_REQUIRED=NO
-        ONLY_ACTIVE_ARCH=NO
-        CLIENT_ID="gini-mobile-test"
-        CLIENT_SECRET="${{ secrets.GINI_MOBILE_TEST_CLIENT_SECRET }}"
+    - name: Build and run tests for "${{ matrix.target }}"
+      uses: maierj/fastlane-action@5a3b971aaa26776459bb26894d6c1a1a84a311a7 # v3.1.0
+      env:
+        TEST_CLIENT_SECRET: ${{ secrets.GINI_MOBILE_TEST_CLIENT_SECRET }}
+        TEST_CLIENT_ID: "gini-mobile-test"
+      with:
+        lane: 'run_unit_tests'
+        options: >
+            {
+              "target": "${{ matrix.target }}",
+              "destination": "${{ matrix.destination }}",
+              "clientId": "$TEST_CLIENT_ID",
+              "clientSecret": "$TEST_CLIENT_SECRET"
+            }

--- a/.github/workflows/health-sdk.check.yml
+++ b/.github/workflows/health-sdk.check.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        target: [GiniHealthSDK]
+        target: [GiniHealthSDK, GiniHealthSDKExampleTests]
         destination: ['platform=iOS Simulator,OS=18.5,name=iPhone 16']
 
     steps:
@@ -38,38 +38,25 @@ jobs:
       run: |
            cd HealthSDK/GiniHealthSDK
            swift package update
-           
-    - name: Build sdk targets
-      run: |
-        xcodebuild -workspace GiniMobile.xcworkspace -scheme "${{ matrix.target }}" -destination "${{ matrix.destination }}" CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO ONLY_ACTIVE_ARCH=NO
+  
+    # Setup ruby to run unit tests for the GiniBankSDK
+    - name: Setup ruby
+      uses: ruby/setup-ruby@dffc446db9ba5a0c4446edb5bca1c5c473a806c5 # v1.245.0
+      with:
+        ruby-version: '3.2.0'
+        bundler-cache: true
 
-    - name: Run unit tests
-      run: |
-        xcodebuild clean test -workspace GiniMobile.xcworkspace -scheme "${{ matrix.target }}Tests" -destination "${{ matrix.destination }}" CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO ONLY_ACTIVE_ARCH=NO
-   
-    - name: Build example app
-      run: |
-        xcodebuild -project HealthSDK/GiniHealthSDKExample/GiniHealthSDKExample.xcodeproj -scheme "GiniHealthSDKExample" -destination "${{ matrix.destination }}" CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO ONLY_ACTIVE_ARCH=NO    
-
-    - name: Extract Device Name
-      id: extract_name
-      run: |
-        DEVICE_NAME=$(echo "${{ matrix.destination }}" | sed -n 's/.*name=\([^,]*\).*/\1/p')
-        echo "DEVICE_NAME=${DEVICE_NAME}" >> $GITHUB_ENV        
-
-    - name: Start iOS Simulator
-      run: |
-        xcrun simctl boot "$DEVICE_NAME"
-        xcrun simctl bootstatus "$DEVICE_NAME" -b        
-
-    - name: Build example app and run integration tests
-      run: >
-        xcodebuild clean test
-        -project HealthSDK/GiniHealthSDKExample/GiniHealthSDKExample.xcodeproj
-        -scheme "GiniHealthSDKExampleTests"
-        -destination "${{ matrix.destination }}"
-        CODE_SIGN_IDENTITY=""
-        CODE_SIGNING_REQUIRED=NO
-        ONLY_ACTIVE_ARCH=NO
-        CLIENT_ID="gini-mobile-test"
-        CLIENT_SECRET="${{ secrets.GINI_MOBILE_TEST_CLIENT_SECRET }}"
+    - name: Build and run tests for "${{ matrix.target }}"
+      uses: maierj/fastlane-action@5a3b971aaa26776459bb26894d6c1a1a84a311a7 # v3.1.0
+      env:
+        TEST_CLIENT_SECRET: ${{ secrets.GINI_MOBILE_TEST_CLIENT_SECRET }}
+        TEST_CLIENT_ID: "gini-mobile-test"
+      with:
+        lane: 'run_unit_tests'
+        options: >
+            {
+              "target": "${{ matrix.target }}",
+              "destination": "${{ matrix.destination }}",
+              "clientId": "$TEST_CLIENT_ID",
+              "clientSecret": "$TEST_CLIENT_SECRET"
+            }

--- a/.github/workflows/internal-payment-sdk.check.yml
+++ b/.github/workflows/internal-payment-sdk.check.yml
@@ -42,6 +42,6 @@ jobs:
         lane: 'build_scheme'
         options: >
             {
-              "scheme": "${{ matrix.target }}",
+              "target": "${{ matrix.target }}",
               "destination": "${{ matrix.destination }}"
             }

--- a/.github/workflows/internal-payment-sdk.check.yml
+++ b/.github/workflows/internal-payment-sdk.check.yml
@@ -29,22 +29,19 @@ jobs:
            cd GiniComponents/GiniInternalPaymentSDK
            swift package update
 
-  # GiniInternalPaymentSDK Build Lane
-  # Purpose: 
-  #   - Current: Build the GiniInternalPaymentSDK target to verify compilation
-  #   - Future: Extend to run unit tests when test suite is implemented
+  # Build the GiniInternalPaymentSDK target to verify compilation
     - name: Setup ruby
       uses: ruby/setup-ruby@dffc446db9ba5a0c4446edb5bca1c5c473a806c5 # v1.245.0
       with:
         ruby-version: '3.2.0'
         bundler-cache: true
 
-    - name: Build and run tests for "${{ matrix.target }}"
+    - name: Build "${{ matrix.target }}"
       uses: maierj/fastlane-action@5a3b971aaa26776459bb26894d6c1a1a84a311a7 # v3.1.0
       with:
-        lane: 'run_unit_tests'
+        lane: 'build_scheme'
         options: >
             {
-              "target": "${{ matrix.target }}",
+              "scheme": "${{ matrix.target }}",
               "destination": "${{ matrix.destination }}"
             }

--- a/.github/workflows/internal-payment-sdk.check.yml
+++ b/.github/workflows/internal-payment-sdk.check.yml
@@ -29,6 +29,22 @@ jobs:
            cd GiniComponents/GiniInternalPaymentSDK
            swift package update
 
-    - name: Build sdk targets
-      run: |
-        xcodebuild -workspace GiniMobile.xcworkspace -scheme "${{ matrix.target }}" -destination "${{ matrix.destination }}" CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO ONLY_ACTIVE_ARCH=NO
+  # GiniInternalPaymentSDK Build Lane
+  # Purpose: 
+  #   - Current: Build the GiniInternalPaymentSDK target to verify compilation
+  #   - Future: Extend to run unit tests when test suite is implemented
+    - name: Setup ruby
+      uses: ruby/setup-ruby@dffc446db9ba5a0c4446edb5bca1c5c473a806c5 # v1.245.0
+      with:
+        ruby-version: '3.2.0'
+        bundler-cache: true
+
+    - name: Build and run tests for "${{ matrix.target }}"
+      uses: maierj/fastlane-action@5a3b971aaa26776459bb26894d6c1a1a84a311a7 # v3.1.0
+      with:
+        lane: 'run_unit_tests'
+        options: >
+            {
+              "target": "${{ matrix.target }}",
+              "destination": "${{ matrix.destination }}"
+            }

--- a/.github/workflows/merchant-sdk.check.yml
+++ b/.github/workflows/merchant-sdk.check.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        target: [GiniMerchantSDK]
+        target: [GiniMerchantSDK, GiniMerchantSDKExampleTests]
         destination: ['platform=iOS Simulator,OS=18.5,name=iPhone 16']
     steps:
     - uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd # v1.6.0
@@ -36,37 +36,24 @@ jobs:
            cd MerchantSDK/GiniMerchantSDK
            swift package update
 
-    - name: Build sdk targets
-      run: |
-        xcodebuild -workspace GiniMobile.xcworkspace -scheme "${{ matrix.target }}" -destination "${{ matrix.destination }}" CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO ONLY_ACTIVE_ARCH=NO
+    # Setup ruby to run unit tests for the GiniBankSDK
+    - name: Setup ruby
+      uses: ruby/setup-ruby@dffc446db9ba5a0c4446edb5bca1c5c473a806c5 # v1.245.0
+      with:
+        ruby-version: '3.2.0'
+        bundler-cache: true
 
-    - name: Run unit tests
-      run: |
-        xcodebuild clean test -workspace GiniMobile.xcworkspace -scheme "${{ matrix.target }}Tests" -destination "${{ matrix.destination }}" CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO ONLY_ACTIVE_ARCH=NO
-   
-    - name: Build example app
-      run: |
-        xcodebuild -project MerchantSDK/GiniMerchantSDKExample/GiniMerchantSDKExample.xcodeproj -scheme "GiniMerchantSDKExample" -destination "${{ matrix.destination }}" CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO ONLY_ACTIVE_ARCH=NO    
-
-    - name: Extract Device Name
-      id: extract_name
-      run: |
-        DEVICE_NAME=$(echo "${{ matrix.destination }}" | sed -n 's/.*name=\([^,]*\).*/\1/p')
-        echo "DEVICE_NAME=${DEVICE_NAME}" >> $GITHUB_ENV        
-
-    - name: Start iOS Simulator
-      run: |
-        xcrun simctl boot "$DEVICE_NAME"
-        xcrun simctl bootstatus "$DEVICE_NAME" -b                
-
-    - name: Build example app and run integration tests
-      run: >
-        xcodebuild clean test
-        -project MerchantSDK/GiniMerchantSDKExample/GiniMerchantSDKExample.xcodeproj
-        -scheme "GiniMerchantSDKExampleTests"
-        -destination "${{ matrix.destination }}"
-        CODE_SIGN_IDENTITY=""
-        CODE_SIGNING_REQUIRED=NO
-        ONLY_ACTIVE_ARCH=NO
-        CLIENT_ID="gini-mobile-test"
-        CLIENT_SECRET="${{ secrets.GINI_MOBILE_TEST_CLIENT_SECRET }}"
+    - name: Build and run tests for "${{ matrix.target }}"
+      uses: maierj/fastlane-action@5a3b971aaa26776459bb26894d6c1a1a84a311a7 # v3.1.0
+      env:
+        TEST_CLIENT_SECRET: ${{ secrets.GINI_MOBILE_TEST_CLIENT_SECRET }}
+        TEST_CLIENT_ID: "gini-mobile-test"
+      with:
+        lane: 'run_unit_tests'
+        options: >
+            {
+              "target": "${{ matrix.target }}",
+              "destination": "${{ matrix.destination }}",
+              "clientId": "$TEST_CLIENT_ID",
+              "clientSecret": "$TEST_CLIENT_SECRET"
+            }

--- a/.github/workflows/utilites.check.yml
+++ b/.github/workflows/utilites.check.yml
@@ -29,22 +29,19 @@ jobs:
            cd GiniComponents/GiniUtilites
            swift package update
   
-  # GiniUtilities Build Lane
-  # Purpose: 
-  #   - Current: Build the GiniUtilities target to verify compilation
-  #   - Future: Extend to run unit tests when test suite is implemented
+  # Build the GiniUtilities target to verify compilation
     - name: Setup ruby
       uses: ruby/setup-ruby@dffc446db9ba5a0c4446edb5bca1c5c473a806c5 # v1.245.0
       with:
         ruby-version: '3.2.0'
         bundler-cache: true
 
-    - name: Build and run tests for "${{ matrix.target }}"
+    - name: Build "${{ matrix.target }}"
       uses: maierj/fastlane-action@5a3b971aaa26776459bb26894d6c1a1a84a311a7 # v3.1.0
       with:
-        lane: 'run_unit_tests'
+        lane: 'build_scheme'
         options: >
             {
-              "target": "${{ matrix.target }}",
+              "scheme": "${{ matrix.target }}",
               "destination": "${{ matrix.destination }}"
             }

--- a/.github/workflows/utilites.check.yml
+++ b/.github/workflows/utilites.check.yml
@@ -28,7 +28,23 @@ jobs:
       run: |
            cd GiniComponents/GiniUtilites
            swift package update
+  
+  # GiniUtilities Build Lane
+  # Purpose: 
+  #   - Current: Build the GiniUtilities target to verify compilation
+  #   - Future: Extend to run unit tests when test suite is implemented
+    - name: Setup ruby
+      uses: ruby/setup-ruby@dffc446db9ba5a0c4446edb5bca1c5c473a806c5 # v1.245.0
+      with:
+        ruby-version: '3.2.0'
+        bundler-cache: true
 
-    - name: Build sdk targets
-      run: |
-        xcodebuild -workspace GiniMobile.xcworkspace -scheme "${{ matrix.target }}" -destination "${{ matrix.destination }}" CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO ONLY_ACTIVE_ARCH=NO
+    - name: Build and run tests for "${{ matrix.target }}"
+      uses: maierj/fastlane-action@5a3b971aaa26776459bb26894d6c1a1a84a311a7 # v3.1.0
+      with:
+        lane: 'run_unit_tests'
+        options: >
+            {
+              "target": "${{ matrix.target }}",
+              "destination": "${{ matrix.destination }}"
+            }

--- a/.github/workflows/utilites.check.yml
+++ b/.github/workflows/utilites.check.yml
@@ -42,6 +42,6 @@ jobs:
         lane: 'build_scheme'
         options: >
             {
-              "scheme": "${{ matrix.target }}",
+              "target": "${{ matrix.target }}",
               "destination": "${{ matrix.destination }}"
             }

--- a/BankSDK/GiniBankSDK/.swiftpm/xcode/xcshareddata/xcschemes/GiniBankSDK.xcscheme
+++ b/BankSDK/GiniBankSDK/.swiftpm/xcode/xcshareddata/xcschemes/GiniBankSDK.xcscheme
@@ -28,6 +28,16 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "GiniBankSDKTests"
+               BuildableName = "GiniBankSDKTests"
+               BlueprintName = "GiniBankSDKTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction

--- a/CaptureSDK/GiniCaptureSDK/.swiftpm/xcode/xcshareddata/xcschemes/GiniCaptureSDK.xcscheme
+++ b/CaptureSDK/GiniCaptureSDK/.swiftpm/xcode/xcshareddata/xcschemes/GiniCaptureSDK.xcscheme
@@ -28,6 +28,16 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "GiniCaptureSDKTests"
+               BuildableName = "GiniCaptureSDKTests"
+               BlueprintName = "GiniCaptureSDKTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction

--- a/CaptureSDK/GiniCaptureSDKPinning/.swiftpm/xcode/xcshareddata/xcschemes/GiniCaptureSDKPinning.xcscheme
+++ b/CaptureSDK/GiniCaptureSDKPinning/.swiftpm/xcode/xcshareddata/xcschemes/GiniCaptureSDKPinning.xcscheme
@@ -28,6 +28,16 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "GiniCaptureSDKPinningTests"
+               BuildableName = "GiniCaptureSDKPinningTests"
+               BlueprintName = "GiniCaptureSDKPinningTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction

--- a/GiniComponents/GiniUtilites/.swiftpm/xcode/xcshareddata/xcschemes/GiniUtilites.xcscheme
+++ b/GiniComponents/GiniUtilites/.swiftpm/xcode/xcshareddata/xcschemes/GiniUtilites.xcscheme
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1640"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "GiniUtilites"
+               BuildableName = "GiniUtilites"
+               BlueprintName = "GiniUtilites"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "GiniUtilites"
+            BuildableName = "GiniUtilites"
+            BlueprintName = "GiniUtilites"
+            ReferencedContainer = "container:">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/HealthSDK/GiniHealthSDK/.swiftpm/xcode/xcshareddata/xcschemes/GiniHealthSDK.xcscheme
+++ b/HealthSDK/GiniHealthSDK/.swiftpm/xcode/xcshareddata/xcschemes/GiniHealthSDK.xcscheme
@@ -28,6 +28,16 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "GiniHealthSDKTests"
+               BuildableName = "GiniHealthSDKTests"
+               BlueprintName = "GiniHealthSDKTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -503,16 +503,36 @@ Runs unit tests for a given target using the `scan` action (a wrapper around xco
 Parameters:
 - `target`: The name of the target whose test scheme will be executed. Example: `GinBankSDK`.
 - `destination`: The destination for the tests. Example: `platform=iOS Simulator,name=iPhone 15,OS=17.4`.
-- `clientSecret`: The clientSecret for the hosting app
+- `clientId`: (Optional) The clientId for the hosting app. If provided, clientSecret must also be provided.
+- `clientSecret`: (Optional) The clientSecret for the hosting app. If provided, clientId must also be provided.
 DOC
 
 lane :run_unit_tests do |options|
   target = options[:target]
   destination = options[:destination]
+  clientId = options[:clientId]
   clientSecret = options[:clientSecret]
 
   unless target && destination
     UI.user_error!("Missing 'target' or 'destination' parameter. Pass both to run the tests.")
+  end
+
+  # Validate that clientId and clientSecret are used together
+  if (clientId && !clientSecret) || (!clientId && clientSecret)
+    UI.user_error!("clientId and clientSecret must be provided together or not at all.")
+  end
+
+  # Build xcargs array conditionally
+  xcargs = [
+    'CODE_SIGNING_REQUIRED=NO',
+    'CODE_SIGN_IDENTITY=""',
+    'ONLY_ACTIVE_ARCH=NO'
+  ]
+  
+  # Add CLIENT_ID and CLIENT_SECRET only if both are provided
+  if clientId && clientSecret && !clientId.empty? && !clientSecret.empty?
+    xcargs << "CLIENT_ID=#{clientId}"
+    xcargs << "CLIENT_SECRET=#{clientSecret}"
   end
 
   scan(
@@ -521,13 +541,7 @@ lane :run_unit_tests do |options|
     clean: true,
     destination: destination,
     disable_concurrent_testing: false,
-    xcargs: [
-      'CLIENT_ID="gini-mobile-test"',
-      "CLIENT_SECRET=#{clientSecret}",
-      'CODE_SIGNING_REQUIRED=NO',
-      'CODE_SIGN_IDENTITY=""',
-      'ONLY_ACTIVE_ARCH=NO'
-    ].join(' '),
+    xcargs: xcargs.join(' '),
     output_types: "",                 # prevent report generation
     output_directory: "./tmp_test_output",
     fail_build: true,
@@ -537,5 +551,4 @@ lane :run_unit_tests do |options|
   # Clean up the report files that were generated
   sh("rm -rf ./tmp_test_output") if File.exist?("./tmp_test_output")
 end
-
 end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -551,4 +551,30 @@ lane :run_unit_tests do |options|
   # Clean up the report files that were generated
   sh("rm -rf ./tmp_test_output") if File.exist?("./tmp_test_output")
 end
+
+<<~DOC
+Builds targets using the `gym` action (a wrapper around xcodebuild).
+
+This lane builds the specified target without code signing or archiving, useful for 
+CI/CD pipelines where you only need to verify the build succeeds.
+
+Parameters:
+- `scheme`: The name of the scheme to build. Example: `GinBankSDK`.
+- `destination`: The destination for the build. Example: `platform=iOS Simulator,name=iPhone 15,OS=17.4`.
+DOC
+lane :build_scheme do |options|
+  gym(
+    workspace: "GiniMobile.xcworkspace",
+    scheme: options[:target],
+    destination: options[:destination],
+    skip_codesigning: true,
+    skip_archive: true,
+    skip_package_ipa: true,
+    xcargs: {
+      "CODE_SIGN_IDENTITY" => "",
+      "CODE_SIGNING_REQUIRED" => "NO",
+      "ONLY_ACTIVE_ARCH" => "NO"
+    }
+  )
+end
 end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -536,7 +536,6 @@ lane :run_unit_tests do |options|
   
   # Clean up the report files that were generated
   sh("rm -rf ./tmp_test_output") if File.exist?("./tmp_test_output")
-  sh("rm -rf ./tmp_derived_data") if File.exist?("./tmp_derived_data")
 end
 
 end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -496,4 +496,47 @@ platform :ios do
       sh "cd #{podspecs_repo_sdk_folder_path} && git push origin master"
     end
   end
+
+desc <<~DOC
+Runs unit tests for a given target using the `scan` action (a wrapper around xcodebuild).
+
+Parameters:
+- `target`: The name of the target whose test scheme will be executed. Example: `GinBankSDK`.
+- `destination`: The destination for the tests. Example: `platform=iOS Simulator,name=iPhone 15,OS=17.4`.
+- `clientSecret`: The clientSecret for the hosting app
+DOC
+
+lane :run_unit_tests do |options|
+  target = options[:target]
+  destination = options[:destination]
+  clientSecret = options[:clientSecret]
+
+  unless target && destination
+    UI.user_error!("Missing 'target' or 'destination' parameter. Pass both to run the tests.")
+  end
+
+  scan(
+    workspace: "GiniMobile.xcworkspace",
+    scheme: target,
+    clean: true,
+    destination: destination,
+    disable_concurrent_testing: false,
+    xcargs: [
+      'CLIENT_ID="gini-mobile-test"',
+      "CLIENT_SECRET=#{clientSecret}",
+      'CODE_SIGNING_REQUIRED=NO',
+      'CODE_SIGN_IDENTITY=""',
+      'ONLY_ACTIVE_ARCH=NO'
+    ].join(' '),
+    output_types: "",                 # prevent report generation
+    output_directory: "./tmp_test_output",
+    fail_build: true,
+    code_coverage: true
+  )
+  
+  # Clean up the report files that were generated
+  sh("rm -rf ./tmp_test_output") if File.exist?("./tmp_test_output")
+  sh("rm -rf ./tmp_derived_data") if File.exist?("./tmp_derived_data")
+end
+
 end

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -145,6 +145,20 @@ Parameters:
 
 
 
+### ios run_unit_tests
+
+```sh
+[bundle exec] fastlane ios run_unit_tests
+```
+
+Runs unit tests for a given target using the `scan` action (a wrapper around xcodebuild).
+
+Parameters:
+- `target`: The name of the target whose test scheme will be executed. Example: `GinBankSDK`.
+- `destination`: The destination for the tests. Example: `platform=iOS Simulator,name=iPhone 15,OS=17.4`.
+- `clientSecret`: The clientSecret for the hosting app
+
+
 ----
 
 This README.md is auto-generated and will be re-generated every time [_fastlane_](https://fastlane.tools) is run.

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -160,6 +160,14 @@ Parameters:
 - `clientSecret`: (Optional) The clientSecret for the hosting app. If provided, clientId must also be provided.
 
 
+### ios build_scheme
+
+```sh
+[bundle exec] fastlane ios build_scheme
+```
+
+
+
 ----
 
 This README.md is auto-generated and will be re-generated every time [_fastlane_](https://fastlane.tools) is run.

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -156,7 +156,8 @@ Runs unit tests for a given target using the `scan` action (a wrapper around xco
 Parameters:
 - `target`: The name of the target whose test scheme will be executed. Example: `GinBankSDK`.
 - `destination`: The destination for the tests. Example: `platform=iOS Simulator,name=iPhone 15,OS=17.4`.
-- `clientSecret`: The clientSecret for the hosting app
+- `clientId`: (Optional) The clientId for the hosting app. If provided, clientSecret must also be provided.
+- `clientSecret`: (Optional) The clientSecret for the hosting app. If provided, clientId must also be provided.
 
 
 ----


### PR DESCRIPTION
## Pull Request Description

[PP-1820](https://ginis.atlassian.net/browse/PP-1820)

This PR adds a new Fastlane lane for running unit tests with configurable parameters. The lane provides a standardized way to execute unit tests for specific targets with custom destinations and client secrets.

Key changes:

- Added run_unit_tests lane with support for target, destination, clientId, and clientSecret parameters
- Updated Xcode scheme to include test target configuration
- Generated corresponding documentation for the new lane

Local Usage:
`bundle exec fastlane run_unit_tests target:"GiniBankAPILibrary" destination:"platform=iOS Simulator,name=iPhone 15 Pro,OS=17.2" clientId:"<secretid>"  clientSecret:"<secret>"`

[PP-1820]: https://ginis.atlassian.net/browse/PP-1820?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ