### PR TITLE
Pp 1909 implement the client configuration properties for the default values

### DIFF
--- a/BankAPILibrary/GiniBankAPILibrary/Sources/GiniBankAPILibrary/Documents/Configuration/ClientConfiguration.swift
+++ b/BankAPILibrary/GiniBankAPILibrary/Sources/GiniBankAPILibrary/Documents/Configuration/ClientConfiguration.swift
@@ -26,21 +26,25 @@ public struct ClientConfiguration: Codable {
     public let eInvoiceEnabled: Bool
     public let paymentHintsEnabled: Bool
     public let savePhotosLocallyEnabled: Bool
+    public let paymentDueDateAmountThreshold: String
+    public let paymentDueDateDaysThreshold: String
 
     /**
      Creates a new `ClientConfiguration` instance.
 
      - Parameters:
-     - clientID: A unique identifier for the client.
-     - userJourneyAnalyticsEnabled: A flag indicating whether user journey analytics is enabled.
-     - skontoEnabled: A flag indicating whether Skonto is enabled.
-     - returnAssistantEnabled: A flag indicating whether the return assistant feature is enabled.
-     - transactionDocsEnabled: A flag indicating whether TransactionDocs feature is enabled.
-     - instantPaymentEnabled: A flag indicating whether Instant Payment feature is enabled.
-     - qrCodeEducationEnabled: A flag indicating whether QR code education is enabled.
-     - eInvoiceEnabled: A flag indicating whether the E-Invoice feature is enabled.
-     - paymentHintsEnabled: A flag indicating whether the user hints are enabled.
-     - savePhotosLocallyEnabled: A flag indicating whether saving photos locally is enabled.
+        - clientID: A unique identifier for the client.
+        - userJourneyAnalyticsEnabled: A flag indicating whether user journey analytics is enabled.
+        - skontoEnabled: A flag indicating whether Skonto is enabled.
+        - returnAssistantEnabled: A flag indicating whether the return assistant feature is enabled.
+        - transactionDocsEnabled: A flag indicating whether TransactionDocs feature is enabled.
+        - instantPaymentEnabled: A flag indicating whether Instant Payment feature is enabled.
+        - qrCodeEducationEnabled: A flag indicating whether QR code education is enabled.
+        - eInvoiceEnabled: A flag indicating whether the E-Invoice feature is enabled.
+        - paymentHintsEnabled: A flag indicating whether the user hints are enabled.
+        - savePhotosLocallyEnabled: A flag indicating whether saving photos locally is enabled.
+        - paymentDueDateAmountThreshold: The minimum payment amount threshold for due date warnings (default value per customer).
+        - paymentDueDateDaysThreshold: The number of days before payment due date to trigger warnings or notifications (default value per customer).
      */
     public init(clientID: String,
                 userJourneyAnalyticsEnabled: Bool,
@@ -51,7 +55,9 @@ public struct ClientConfiguration: Codable {
                 qrCodeEducationEnabled: Bool,
                 eInvoiceEnabled: Bool,
                 paymentHintsEnabled: Bool,
-                savePhotosLocallyEnabled: Bool) {
+                savePhotosLocallyEnabled: Bool,
+                paymentDueDateAmountThreshold: String,
+                paymentDueDateDaysThreshold: String) {
         self.clientID = clientID
         self.userJourneyAnalyticsEnabled = userJourneyAnalyticsEnabled
         self.skontoEnabled = skontoEnabled
@@ -62,5 +68,7 @@ public struct ClientConfiguration: Codable {
         self.eInvoiceEnabled = eInvoiceEnabled
         self.paymentHintsEnabled = paymentHintsEnabled
         self.savePhotosLocallyEnabled = savePhotosLocallyEnabled
+        self.paymentDueDateAmountThreshold = paymentDueDateAmountThreshold
+        self.paymentDueDateDaysThreshold = paymentDueDateDaysThreshold
     }
 }

--- a/BankAPILibrary/GiniBankAPILibrary/Sources/GiniBankAPILibrary/Documents/Configuration/ClientConfiguration.swift
+++ b/BankAPILibrary/GiniBankAPILibrary/Sources/GiniBankAPILibrary/Documents/Configuration/ClientConfiguration.swift
@@ -33,18 +33,18 @@ public struct ClientConfiguration: Codable {
      Creates a new `ClientConfiguration` instance.
 
      - Parameters:
-        - clientID: A unique identifier for the client.
-        - userJourneyAnalyticsEnabled: A flag indicating whether user journey analytics is enabled.
-        - skontoEnabled: A flag indicating whether Skonto is enabled.
-        - returnAssistantEnabled: A flag indicating whether the return assistant feature is enabled.
-        - transactionDocsEnabled: A flag indicating whether TransactionDocs feature is enabled.
-        - instantPaymentEnabled: A flag indicating whether Instant Payment feature is enabled.
-        - qrCodeEducationEnabled: A flag indicating whether QR code education is enabled.
-        - eInvoiceEnabled: A flag indicating whether the E-Invoice feature is enabled.
-        - paymentHintsEnabled: A flag indicating whether the user hints are enabled.
-        - savePhotosLocallyEnabled: A flag indicating whether saving photos locally is enabled.
-        - paymentDueDateAmountThreshold: The minimum payment amount threshold for due date warnings (default value per customer).
-        - paymentDueDateDaysThreshold: The number of days before payment due date to trigger warnings or notifications (default value per customer).
+     - clientID: A unique identifier for the client.
+     - userJourneyAnalyticsEnabled: A flag indicating whether user journey analytics is enabled.
+     - skontoEnabled: A flag indicating whether Skonto is enabled.
+     - returnAssistantEnabled: A flag indicating whether the return assistant feature is enabled.
+     - transactionDocsEnabled: A flag indicating whether TransactionDocs feature is enabled.
+     - instantPaymentEnabled: A flag indicating whether Instant Payment feature is enabled.
+     - qrCodeEducationEnabled: A flag indicating whether QR code education is enabled.
+     - eInvoiceEnabled: A flag indicating whether the E-Invoice feature is enabled.
+     - paymentHintsEnabled: A flag indicating whether the user hints are enabled.
+     - savePhotosLocallyEnabled: A flag indicating whether saving photos locally is enabled.
+     - paymentDueDateAmountThreshold: The minimum payment amount threshold to trigger the due date warning(default value per customer).
+     - paymentDueDateDaysThreshold: The number of days before payment due date to trigger the due date warning(default value per customer).
      */
     public init(clientID: String,
                 userJourneyAnalyticsEnabled: Bool,

--- a/BankAPILibrary/GiniBankAPILibrary/Tests/GiniBankAPILibraryTests/ClientConfigurationTests.swift
+++ b/BankAPILibrary/GiniBankAPILibrary/Tests/GiniBankAPILibraryTests/ClientConfigurationTests.swift
@@ -25,7 +25,9 @@ struct ClientConfigurationTests {
                                          qrCodeEducationEnabled: true,
                                          eInvoiceEnabled: true,
                                          paymentHintsEnabled: true,
-                                         savePhotosLocallyEnabled: true)
+                                         savePhotosLocallyEnabled: true,
+                                         paymentDueDateAmountThreshold: "100.00",
+                                         paymentDueDateDaysThreshold: "30")
 
         #expect(config.clientID == testClientID, "Expected clientID to be \(testClientID)")
         #expect(config.userJourneyAnalyticsEnabled, "Expected userJourneyAnalyticsEnabled to be true")
@@ -37,6 +39,8 @@ struct ClientConfigurationTests {
         #expect(config.eInvoiceEnabled, "Expected eInvoiceEnabled to be true")
         #expect(config.paymentHintsEnabled, "Expected paymentHintsEnabled to be true")
         #expect(config.savePhotosLocallyEnabled, "Expected savePhotosLocallyEnabled to be true")
+        #expect(config.paymentDueDateAmountThreshold == "100.00", "Expected paymentDueDateAmountThreshold to be 100.00")
+        #expect(config.paymentDueDateDaysThreshold == "30", "Expected paymentDueDateDaysThreshold to be 30")
     }
 
     @Test("Initialization with all flags disabled")
@@ -50,7 +54,9 @@ struct ClientConfigurationTests {
                                          qrCodeEducationEnabled: false,
                                          eInvoiceEnabled: false,
                                          paymentHintsEnabled: false,
-                                         savePhotosLocallyEnabled: false)
+                                         savePhotosLocallyEnabled: false,
+                                         paymentDueDateAmountThreshold: "",
+                                         paymentDueDateDaysThreshold: "")
 
         #expect(config.clientID == testClientID, "Expected clientID to be \(testClientID)")
         #expect(!config.userJourneyAnalyticsEnabled, "Expected userJourneyAnalyticsEnabled to be false")
@@ -62,6 +68,8 @@ struct ClientConfigurationTests {
         #expect(!config.eInvoiceEnabled, "Expected eInvoiceEnabled to be false")
         #expect(!config.paymentHintsEnabled, "Expected paymentHintsEnabled to be false")
         #expect(!config.savePhotosLocallyEnabled, "Expected savePhotosLocallyEnabled to be false")
+        #expect(config.paymentDueDateAmountThreshold == "", "Expected paymentDueDateAmountThreshold to be empty")
+        #expect(config.paymentDueDateDaysThreshold == "", "Expected paymentDueDateDaysThreshold to be empty")
     }
 
     // MARK: - JSON Decoding Tests
@@ -83,6 +91,8 @@ struct ClientConfigurationTests {
         #expect(!config.eInvoiceEnabled, "Expected eInvoiceEnabled to be false from JSON")
         #expect(!config.paymentHintsEnabled, "Expected paymentHintsEnabled to be false from JSON")
         #expect(!config.savePhotosLocallyEnabled, "Expected savePhotosLocallyEnabled to be false from JSON")
+        #expect(config.paymentDueDateAmountThreshold == "100", "Expected paymentDueDateAmountThreshold to be 100 from JSON")
+        #expect(config.paymentDueDateDaysThreshold == "30", "Expected paymentDueDateDaysThreshold to be 30 from JSON")
     }
 
     @Test("Decoding fails when missing required clientID field")
@@ -108,7 +118,9 @@ struct ClientConfigurationTests {
                                          qrCodeEducationEnabled: false,
                                          eInvoiceEnabled: true,
                                          paymentHintsEnabled: false,
-                                         savePhotosLocallyEnabled: true)
+                                         savePhotosLocallyEnabled: true,
+                                         paymentDueDateAmountThreshold: "250.50",
+                                         paymentDueDateDaysThreshold: "14")
         let encoder = JSONEncoder()
 
         let data = try encoder.encode(config)
@@ -134,6 +146,10 @@ struct ClientConfigurationTests {
                 "Expected paymentHintsEnabled to be preserved")
         #expect(decodedConfig.savePhotosLocallyEnabled == config.savePhotosLocallyEnabled,
                 "Expected savePhotosLocallyEnabled to be preserved")
+        #expect(decodedConfig.paymentDueDateAmountThreshold == config.paymentDueDateAmountThreshold,
+                "Expected paymentDueDateAmountThreshold to be preserved")
+        #expect(decodedConfig.paymentDueDateDaysThreshold == config.paymentDueDateDaysThreshold,
+                "Expected paymentDueDateDaysThreshold to be preserved")
     }
 
     // MARK: - Property Combinations Tests
@@ -149,7 +165,9 @@ struct ClientConfigurationTests {
                                          qrCodeEducationEnabled: true,
                                          eInvoiceEnabled: false,
                                          paymentHintsEnabled: true,
-                                         savePhotosLocallyEnabled: false)
+                                         savePhotosLocallyEnabled: false,
+                                         paymentDueDateAmountThreshold: "500.00",
+                                         paymentDueDateDaysThreshold: "7")
 
         #expect(config.userJourneyAnalyticsEnabled, "Expected userJourneyAnalyticsEnabled to be true")
         #expect(!config.skontoEnabled, "Expected skontoEnabled to be false")
@@ -160,5 +178,29 @@ struct ClientConfigurationTests {
         #expect(!config.eInvoiceEnabled, "Expected eInvoiceEnabled to be false")
         #expect(config.paymentHintsEnabled, "Expected paymentHintsEnabled to be true")
         #expect(!config.savePhotosLocallyEnabled, "Expected savePhotosLocallyEnabled to be false")
+        #expect(config.paymentDueDateAmountThreshold == "500.00", "Expected paymentDueDateAmountThreshold to be 500.00")
+        #expect(config.paymentDueDateDaysThreshold == "7", "Expected paymentDueDateDaysThreshold to be 7")
+    }
+
+    // MARK: - Threshold Property Tests
+
+    @Test("Threshold properties handle empty strings correctly")
+    func thresholdPropertiesWithEmptyStrings() {
+        let config = ClientConfiguration(clientID: testClientID,
+                                         userJourneyAnalyticsEnabled: true,
+                                         skontoEnabled: true,
+                                         returnAssistantEnabled: true,
+                                         transactionDocsEnabled: true,
+                                         instantPaymentEnabled: true,
+                                         qrCodeEducationEnabled: true,
+                                         eInvoiceEnabled: true,
+                                         paymentHintsEnabled: true,
+                                         savePhotosLocallyEnabled: true,
+                                         paymentDueDateAmountThreshold: "",
+                                         paymentDueDateDaysThreshold: "")
+
+        // TODO: check if the paymentDueDateAmountThreshold and paymentDueDateDaysThreshold should be empty or optional
+        #expect(config.paymentDueDateAmountThreshold.isEmpty, "Expected paymentDueDateAmountThreshold to be empty")
+        #expect(config.paymentDueDateDaysThreshold.isEmpty, "Expected paymentDueDateDaysThreshold to be empty")
     }
 }

--- a/BankAPILibrary/GiniBankAPILibrary/Tests/GiniBankAPILibraryTests/Resources/clientConfiguration.json
+++ b/BankAPILibrary/GiniBankAPILibrary/Tests/GiniBankAPILibraryTests/Resources/clientConfiguration.json
@@ -8,5 +8,7 @@
     "qrCodeEducationEnabled": false,
     "eInvoiceEnabled": false,
     "paymentHintsEnabled": false,
-    "savePhotosLocallyEnabled": false
+    "savePhotosLocallyEnabled": false,
+    "paymentDueDateAmountThreshold": "100",
+    "paymentDueDateDaysThreshold": "30"
 }

--- a/BankSDK/GiniBankSDK/Tests/GiniBankSDKTests/NetworkingScreenApiCoordinatorTests.swift
+++ b/BankSDK/GiniBankSDK/Tests/GiniBankSDKTests/NetworkingScreenApiCoordinatorTests.swift
@@ -42,10 +42,8 @@ final class NetworkingScreenApiCoordinatorTests: XCTestCase {
         XCTAssertEqual(service.apiDomain.domainString, "pay-api.gini.net", "Service api domain should match our default")
 
         // check token
-        let receivedToken = try XCTUnwrap(
-            login(service: service),
-            "Should log in successfully"
-        )
+        let receivedToken = try XCTUnwrap(login(service: service),
+                                          "Should log in successfully")
         XCTAssertEqual(receivedToken, tokenSource.token, "Received token should match the expected token")
 
         // check for delegates/configs
@@ -68,22 +66,17 @@ final class NetworkingScreenApiCoordinatorTests: XCTestCase {
         XCTAssertEqual(service.apiDomain.domainString, "pay-api.gini.net", "Service api domain should match our default")
 
         // check token
-        let receivedToken = try XCTUnwrap(
-            login(service: service),
-            "Should log in successfully"
-        )
+        let receivedToken = try XCTUnwrap(login(service: service),
+                                          "Should log in successfully")
         XCTAssertEqual(receivedToken, tokenSource.token, "Received token should match the expected token")
 
         // check for delegates/configs
-        XCTAssertNotNil(
-            coordinator.resultsDelegate as? MockCaptureResultsDelegate,
-            "Coordinator should have correct results delegate instance"
-        )
+        XCTAssertNotNil(coordinator.resultsDelegate as? MockCaptureResultsDelegate,
+                        "Coordinator should have correct results delegate instance"
+)
         XCTAssertEqual(coordinator.giniBankConfiguration, configuration, "Coordinator should have correct configuration instance")
-        XCTAssertNotNil(
-            coordinator.trackingDelegate as? MockTrackingDelegate,
-            "Coordinator should have correct tracking delegate instance"
-        )
+        XCTAssertNotNil( coordinator.trackingDelegate as? MockTrackingDelegate,
+                         "Coordinator should have correct tracking delegate instance")
         XCTAssertEqual(coordinator.documentService.metadata?.headers, metadata.headers, "Metadata headers should match")
     }
 
@@ -351,6 +344,8 @@ extension ClientConfiguration {
                   qrCodeEducationEnabled: false,
                   eInvoiceEnabled: false,
                   paymentHintsEnabled: paymentHintsEnabled,
-                  savePhotosLocallyEnabled: false)
+                  savePhotosLocallyEnabled: false,
+                  paymentDueDateAmountThreshold: "",
+                  paymentDueDateDaysThreshold: "")
     }
 }

--- a/BankSDK/GiniBankSDKExample/GiniBankSDKExample/SettingsViewController/SettingsViewController+SwitchOptionModel.swift
+++ b/BankSDK/GiniBankSDKExample/GiniBankSDKExample/SettingsViewController/SettingsViewController+SwitchOptionModel.swift
@@ -236,7 +236,7 @@ struct SwitchOptionModel {
             case .skontoHelpNavigationBarBottomAdapter:
                 return "The custom bottom navigation bar is shown if `Bottom navigation bar` is also enabled."
             case .paymentHintsEnabled:
-                return "Features included under this flag due date and paid state"
+                return "Features included under this flag: due date and paid state"
             case .closeSDK:
                 return "Self-destruct SDK after 10 seconds"
 			default:

--- a/BankSDK/GiniBankSDKExample/Tests/IntegrationTests/ClientConfiguration/ClientConfigurationTests.swift
+++ b/BankSDK/GiniBankSDKExample/Tests/IntegrationTests/ClientConfiguration/ClientConfigurationTests.swift
@@ -97,5 +97,8 @@ class ClientConfigurationTests: BaseIntegrationTest {
         XCTAssertNotNil(configuration.eInvoiceEnabled, "eInvoiceEnabled should be present")
         XCTAssertNotNil(configuration.paymentHintsEnabled, "paymentHintsEnabled should be present")
         XCTAssertNotNil(configuration.savePhotosLocallyEnabled, "savePhotosLocallyEnabled should be present")
+        // TODO: uncomment the next 2 tests when backend is in place
+//        XCTAssertNotNil(configuration.paymentDueDateAmountThreshold, "paymentDueDateAmountThreshold should be present")
+//        XCTAssertNotNil(configuration.paymentDueDateDaysThreshold, "paymentDueDateDaysThreshold should be present")
     }
 }


### PR DESCRIPTION
## Pull Request Description

<!-- Briefly explain **what** this PR does and **why**. Mention the motivation, feature, or issue it's addressing. -->

[PP-1909](https://ginis.atlassian.net/browse/PP-1909)

This PR implements client configuration properties for payment due date default values by adding two new threshold fields to the ClientConfiguration struct. The changes support configuring the minimum payment amount and the number of days before due date for triggering the warning.

- Added `paymentDueDateAmountThreshold` and `paymentDueDateDaysThreshold` string properties to ClientConfiguration
- Updated all ClientConfiguration initializations across tests and example code to include the new threshold parameters
- Added comprehensive test coverage for the new threshold properties

[PP-1909]: https://ginis.atlassian.net/browse/PP-1909?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ