### PR TITLE
Introducing env files for generation of certificates and prov profiles

### DIFF
--- a/BankSDK/GiniBankSDKExample/GiniBankSDKExample.xcodeproj/project.pbxproj
+++ b/BankSDK/GiniBankSDKExample/GiniBankSDKExample.xcodeproj/project.pbxproj
@@ -2624,8 +2624,9 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
-				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = JA825X8F7Z;
+				CODE_SIGN_STYLE = Manual;
+				DEVELOPMENT_TEAM = "";
+				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = JA825X8F7Z;
 				INFOPLIST_FILE = Tests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -2635,6 +2636,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = net.gini.banksdk.example.tests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
@@ -2649,8 +2651,9 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
-				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = JA825X8F7Z;
+				CODE_SIGN_STYLE = Manual;
+				DEVELOPMENT_TEAM = "";
+				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = JA825X8F7Z;
 				INFOPLIST_FILE = Tests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -2660,6 +2663,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = net.gini.banksdk.example.tests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;

--- a/fastlane/.env.adhoc
+++ b/fastlane/.env.adhoc
@@ -1,0 +1,7 @@
+BUILD_CONFIGURATION = "Release"
+MATCH_GIT_URL = "<MATCH_GIT_URL>"
+MATCH_GIT_BRANCH = "master"
+MATCH_TYPE = "adhoc"
+FASTLANE_TEAM_ID = "JA825X8F7Z"
+MATCH_APP_IDENTIFIER = net.gini.merchantsdk.example,net.gini.banksdk.example,net.gini.banksdk.example.bank,net.gini.banksdk.example.ShareExtension,net.gini.banksdk.example.swiftui,net.gini.healthsdk.example
+MATCH_USERNAME =  "<MATCH_USERNAME_ACCOUNT_HOLDER>"

--- a/fastlane/.env.appstore
+++ b/fastlane/.env.appstore
@@ -1,0 +1,7 @@
+BUILD_CONFIGURATION = "Release"
+MATCH_GIT_URL = "<MATCH_GIT_URL>"
+MATCH_GIT_BRANCH = "master"
+MATCH_TYPE = "appstore"
+FASTLANE_TEAM_ID = "JA825X8F7Z"
+MATCH_APP_IDENTIFIER = net.gini.merchantsdk.example,net.gini.banksdk.example,net.gini.banksdk.example.bank,net.gini.banksdk.example.ShareExtension,net.gini.banksdk.example.swiftui,net.gini.healthsdk.example
+MATCH_USERNAME = "<MATCH_USERNAME_ACCOUNT_HOLDER>"

--- a/fastlane/.env.development
+++ b/fastlane/.env.development
@@ -1,0 +1,7 @@
+BUILD_CONFIGURATION = "Debug"
+MATCH_GIT_URL = "<MATCH_GIT_URL>"
+MATCH_GIT_BRANCH = "master"
+MATCH_TYPE = "development"
+FASTLANE_TEAM_ID = "JA825X8F7Z"
+MATCH_APP_IDENTIFIER = net.gini.merchantsdk.example,net.gini.banksdk.example,net.gini.banksdk.example.bank,net.gini.banksdk.example.ShareExtension,net.gini.banksdk.example.swiftui,net.gini.healthsdk.example
+MATCH_USERNAME = "<MATCH_USERNAME_ACCOUNT_HOLDER>"


### PR DESCRIPTION
## Pull Request Description

This PR introduces Fastlane environment files intended to parameterize certificate/provisioning-profile generation (Match) across development/ad-hoc/app-store contexts, and adjusts code-signing settings in the BankSDK example Xcode project.

**Changes:**
- Added `fastlane/.env.*` files for development, ad-hoc, and app-store signing contexts.
- Updated the BankSDK example project’s test target build settings to use manual signing with an iPhoneOS-specific team value.