### PR TITLE
 fix(GiniInternalPaymentSDK): Dispatch error handling to main queue

### DIFF
--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/PaymentReviewModel.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/PaymentReviewModel.swift
@@ -204,8 +204,10 @@ public class PaymentReviewModel {
             case let .success(requestId):
                 completion?(requestId)
             case let .failure(error):
-                if self?.delegate?.shouldHandleErrorInternally(error: error) == true {
-                    self?.onCreatePaymentRequestErrorHandling?()
+                DispatchQueue.main.async { [weak self] in
+                    if self?.delegate?.shouldHandleErrorInternally(error: error) == true {
+                        self?.onCreatePaymentRequestErrorHandling?()
+                    }
                 }
             }
         })

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/PaymentReviewModel.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/PaymentReviewModel.swift
@@ -200,13 +200,14 @@ public class PaymentReviewModel {
         isLoading = true
         delegate?.createPaymentRequest(paymentInfo: paymentInfo, completion: { [weak self] result in
             DispatchQueue.main.async { [weak self] in
-                self?.isLoading = false
+                guard let self else { return }
+                isLoading = false
                 switch result {
                 case let .success(requestId):
                     completion?(requestId)
                 case let .failure(error):
-                    if self?.delegate?.shouldHandleErrorInternally(error: error) == true {
-                        self?.onCreatePaymentRequestErrorHandling?()
+                    if delegate?.shouldHandleErrorInternally(error: error) == true {
+                        onCreatePaymentRequestErrorHandling?()
                     }
                 }
             }

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/PaymentReviewModel.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/PaymentReviewModel.swift
@@ -199,12 +199,12 @@ public class PaymentReviewModel {
     func createPaymentRequest(paymentInfo: PaymentInfo, completion: ((_ paymentRequestId: String) -> ())? = nil) {
         isLoading = true
         delegate?.createPaymentRequest(paymentInfo: paymentInfo, completion: { [weak self] result in
-            self?.isLoading = false
-            switch result {
-            case let .success(requestId):
-                completion?(requestId)
-            case let .failure(error):
-                DispatchQueue.main.async { [weak self] in
+            DispatchQueue.main.async { [weak self] in
+                self?.isLoading = false
+                switch result {
+                case let .success(requestId):
+                    completion?(requestId)
+                case let .failure(error):
                     if self?.delegate?.shouldHandleErrorInternally(error: error) == true {
                         self?.onCreatePaymentRequestErrorHandling?()
                     }


### PR DESCRIPTION
## Pull Request Description
This PR aims to make PaymentReviewModel.createPaymentRequest safer for UIKit usage by ensuring success and  error handling that may touch UI is executed on the main thread.

Changes:
Wrapping both in DispatchQueue.main.async
  prevents UIKit from being touched off-main and avoids a data race on
  the delegate reference.

  HEAL-307