### PR TITLE
Cx credentials firebase build

### DIFF
--- a/.github/workflows/bank-sdk.publish.example.app.firebase.yml
+++ b/.github/workflows/bank-sdk.publish.example.app.firebase.yml
@@ -69,11 +69,6 @@ jobs:
         run: |
             plutil -replace API_KEY -string "$FIREBASE_API_KEY" BankSDK/GiniBankSDKExample/GoogleService-Info.plist
 
-      - name: Set build number
-        run: |
-          cd BankSDK/GiniBankSDKExample
-          xcrun agvtool new-version -all ${{ github.run_number }}
-
       - name: Archiving project
         uses: maierj/fastlane-action@5a3b971aaa26776459bb26894d6c1a1a84a311a7 # v3.1.0
         env:

--- a/.github/workflows/bank-sdk.publish.example.app.firebase.yml
+++ b/.github/workflows/bank-sdk.publish.example.app.firebase.yml
@@ -55,15 +55,24 @@ jobs:
         env:
           TEST_CLIENT_SECRET: ${{ secrets.GINI_MOBILE_CI_PASSWORD }}
           TEST_CLIENT_ID: ${{ secrets.GINI_MOBILE_CI_USERNAME }}
+          CX_CLIENT_SECRET: ${{ secrets.GINI_MOBILE_CI_CX_PASSWORD }}
+          CX_CLIENT_ID: ${{ secrets.GINI_MOBILE_CI_CX_USERNAME }}
         run: |
             plutil -replace client_id -string "$TEST_CLIENT_ID" BankSDK/GiniBankSDKExample/GiniBankSDKExample/Credentials.plist
             plutil -replace client_password -string "$TEST_CLIENT_SECRET" BankSDK/GiniBankSDKExample/GiniBankSDKExample/Credentials.plist
-            
+            plutil -replace cx_client_id -string "$CX_CLIENT_ID" BankSDK/GiniBankSDKExample/GiniBankSDKExample/Credentials.plist
+            plutil -replace cx_client_password -string "$CX_CLIENT_SECRET" BankSDK/GiniBankSDKExample/GiniBankSDKExample/Credentials.plist
+
       - name: Setup Firebase API Key
         env:
           FIREBASE_API_KEY: ${{ secrets.FIREBASE_API_KEY }}
         run: |
             plutil -replace API_KEY -string "$FIREBASE_API_KEY" BankSDK/GiniBankSDKExample/GoogleService-Info.plist
+
+      - name: Set build number
+        run: |
+          cd BankSDK/GiniBankSDKExample
+          xcrun agvtool new-version -all ${{ github.run_number }}
 
       - name: Archiving project
         uses: maierj/fastlane-action@5a3b971aaa26776459bb26894d6c1a1a84a311a7 # v3.1.0

--- a/BankSDK/GiniBankSDKExample/GiniBankSDKExample/Credentials.plist
+++ b/BankSDK/GiniBankSDKExample/GiniBankSDKExample/Credentials.plist
@@ -8,5 +8,9 @@
 	<string>***</string>
 	<key>client_id</key>
 	<string>***</string>
+	<key>cx_client_id</key>
+	<string>***</string>
+	<key>cx_client_password</key>
+	<string>***</string>
 </dict>
 </plist>

--- a/BankSDK/GiniBankSDKExample/GiniBankSDKExample/CredentialsManager.swift
+++ b/BankSDK/GiniBankSDKExample/GiniBankSDKExample/CredentialsManager.swift
@@ -10,24 +10,30 @@ import GiniBankAPILibrary
 final class CredentialsManager {
 
     class func fetchClientFromBundle() -> Client {
-        let clientID = "client_id"
-        let clientPassword = "client_password"
+        return fetchClient(idKey: "client_id", passwordKey: "client_password")
+    }
+
+    class func fetchCXClientFromBundle() -> Client {
+        return fetchClient(idKey: "cx_client_id", passwordKey: "cx_client_password")
+    }
+
+    private class func fetchClient(idKey: String, passwordKey: String) -> Client {
         let clientEmailDomain = "client_domain"
         let credentialsPlistPath = Bundle.main.path(forResource: "Credentials", ofType: "plist")
-        
+
         if let path = credentialsPlistPath,
             let keys = NSDictionary(contentsOfFile: path),
-            let client_id = keys[clientID] as? String,
-            let client_password = keys[clientPassword] as? String,
+            let client_id = keys[idKey] as? String,
+            let client_password = keys[passwordKey] as? String,
             let client_email_domain = keys[clientEmailDomain] as? String,
             !client_id.isEmpty, !client_password.isEmpty, !client_email_domain.isEmpty {
-            
+
             return Client(id: client_id,
                           secret: client_password,
                           domain: client_email_domain)
         }
-        
-        print("⚠️ No credentials were fetched from the Credentials.plist file")
+
+        print("⚠️ No credentials were fetched from the Credentials.plist file for keys: \(idKey), \(passwordKey)")
         return Client(id: "",
                       secret: "",
                       domain: "")

--- a/BankSDK/GiniBankSDKExample/GiniBankSDKExample/SettingsViewController/CredentialsSet.swift
+++ b/BankSDK/GiniBankSDKExample/GiniBankSDKExample/SettingsViewController/CredentialsSet.swift
@@ -7,7 +7,10 @@
 import Foundation
 
 struct CredentialsSet {
-    static let setB = (clientId: "...", clientSecret: "...")
+    static let setB: (clientId: String, clientSecret: String) = {
+        let client = CredentialsManager.fetchCXClientFromBundle()
+        return (clientId: client.id, clientSecret: client.secret)
+    }()
     static var setA: (clientId: String, clientSecret: String) {
         let client = CredentialsManager.fetchClientFromBundle()
         return (clientId: client.id, clientSecret: client.secret)


### PR DESCRIPTION
## Pull Request Description

<!-- Briefly explain **what** this PR does and **why**. Mention the motivation, feature, or issue it's addressing. -->


This PR updates the BankSDK example app and its Firebase distribution workflow to support a second (“CX” / cross-border) credential set loaded from Credentials.plist.
<!--

Some description of HOW you achieved it. Perhaps give a high level description of the chnages you did. Did you need to refactor something? What tradeoffs did you take?

-->

## Notes for Reviewers

- Load the second credential set (setB) from the app bundle instead of using placeholder values.
- Refactor CredentialsManager to support fetching multiple credential sets via plist key parameters.
- Extend the Firebase publish workflow to inject CX credentials into Credentials.plist from GitHub Secrets.

<!--

Explain how you verified the changes.
A clear testing scenario helps colleagues who may not be familiar with this part of the code quickly understand and verify the changes. Include steps they can follow to see the impact in action.

You can include: 
- Simulators/Devices you used (e.g. iPhone 13, iPad Pro) 
- iOS versions tested (e.g. 16.0, 17.5) 
- Manual checks (e.g. flow tested: onboarding, permissions, error states) 
- Unit tests added or updated 
 
 Include screenshots, screen recordings, or simulator gifs for UI changes. 
 
 - Optional: Anything that needs extra attention in review? Are there TODOs, known limitations, or follow-up work? 
 
 -->