### PR TITLE
Fix/heal 333 payment review increased font

### DIFF
--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/BottomSheet/GiniBottomSheetModifier.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/BottomSheet/GiniBottomSheetModifier.swift
@@ -14,11 +14,7 @@ struct GiniBottomSheetModifier: ViewModifier {
     
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @Environment(\.accessibilityVoiceOverEnabled) private var isVoiceOverEnabled
-    @Environment(\.verticalSizeClass) private var verticalSizeClass
-    
-    private var isLandscape: Bool {
-        verticalSizeClass == .compact
-    }
+    @Environment(\.giniLayout) private var giniLayout
     
     init(contentHeight: CGFloat,
          allowsDismiss: Bool = false,
@@ -50,7 +46,7 @@ struct GiniBottomSheetModifier: ViewModifier {
     }
     
     private func detentsForOrientation() -> Set<PresentationDetent> {
-        if isLandscape {
+        if giniLayout.isLandscape {
             return [.large]
         } else {
             // Only one detent in portrait: the sheet stays at its content height and the

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/BottomSheet/GiniBottomSheetModifier.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/BottomSheet/GiniBottomSheetModifier.swift
@@ -53,7 +53,10 @@ struct GiniBottomSheetModifier: ViewModifier {
         if isLandscape {
             return [.large]
         } else {
-            return [.height(contentHeight), .large]
+            /// Only one detent in portrait: the sheet stays at its content height and the
+            /// inner ScrollView scrolls to show the focused field. A .large detent causes
+            /// iOS to auto-snap to full screen when the keyboard appears.
+            return [.height(contentHeight)]
         }
     }
     

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/BottomSheet/GiniBottomSheetModifier.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/BottomSheet/GiniBottomSheetModifier.swift
@@ -53,9 +53,9 @@ struct GiniBottomSheetModifier: ViewModifier {
         if isLandscape {
             return [.large]
         } else {
-            /// Only one detent in portrait: the sheet stays at its content height and the
-            /// inner ScrollView scrolls to show the focused field. A .large detent causes
-            /// iOS to auto-snap to full screen when the keyboard appears.
+            // Only one detent in portrait: the sheet stays at its content height and the
+            // inner ScrollView scrolls to show the focused field. A .large detent causes
+            // iOS to auto-snap to full screen when the keyboard appears.
             return [.height(contentHeight)]
         }
     }

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/BottomSheet/GiniBottomSheetModifier.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/BottomSheet/GiniBottomSheetModifier.swift
@@ -43,7 +43,7 @@ struct GiniBottomSheetModifier: ViewModifier {
             base
                 .presentationBackgroundInteraction(allowsDismiss ? .automatic : presentationBackgroundInteractionForVoiceOver)
                 .presentationCompactAdaptation(horizontal: .sheet, vertical: .fullScreenCover)
-                .presentationContentInteraction(.resizes)
+                .presentationContentInteraction(.scrolls)
         } else {
             base
         }
@@ -53,7 +53,7 @@ struct GiniBottomSheetModifier: ViewModifier {
         if isLandscape {
             return [.large]
         } else {
-            return [.height(contentHeight)]
+            return [.height(contentHeight), .large]
         }
     }
     

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentButton/PaymentPrimaryButton.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentButton/PaymentPrimaryButton.swift
@@ -21,8 +21,9 @@ public final class PaymentPrimaryButton: UIButton {
     private lazy var buttonTitleLabel: UILabel = {
         let label = UILabel()
         label.translatesAutoresizingMaskIntoConstraints = false
-        label.numberOfLines = 1
+        label.numberOfLines = 0
         label.adjustsFontSizeToFitWidth = true
+        label.adjustsFontForContentSizeCategory = true
         label.textAlignment = .center
         return label
     }()

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentButton/PaymentPrimaryButton.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentButton/PaymentPrimaryButton.swift
@@ -66,7 +66,8 @@ public final class PaymentPrimaryButton: UIButton {
             contentView.trailingAnchor.constraint(equalTo: trailingAnchor),
             contentView.topAnchor.constraint(equalTo: topAnchor),
             contentView.bottomAnchor.constraint(equalTo: bottomAnchor),
-            contentView.centerYAnchor.constraint(equalTo: buttonTitleLabel.centerYAnchor)
+            buttonTitleLabel.topAnchor.constraint(equalTo: contentView.topAnchor, constant: Constants.titlePadding),
+            buttonTitleLabel.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -Constants.titlePadding)
         ])
         
         titleLeadingConstraint?.isActive = true

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentButton/PaymentPrimaryButton.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentButton/PaymentPrimaryButton.swift
@@ -22,7 +22,6 @@ public final class PaymentPrimaryButton: UIButton {
         let label = UILabel()
         label.translatesAutoresizingMaskIntoConstraints = false
         label.numberOfLines = 0
-        label.adjustsFontSizeToFitWidth = true
         label.adjustsFontForContentSizeCategory = true
         label.textAlignment = .center
         return label

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentButton/PaymentSecondaryButton.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentButton/PaymentSecondaryButton.swift
@@ -31,7 +31,6 @@ public final class PaymentSecondaryButton: UIButton {
         label.numberOfLines = 0
         label.lineBreakMode = .byTruncatingTail
         label.adjustsFontForContentSizeCategory = true
-        label.adjustsFontSizeToFitWidth = true
         return label
     }()
 

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentComponents/PaymentComponentView.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentComponents/PaymentComponentView.swift
@@ -21,7 +21,7 @@ public final class PaymentComponentView: UIView {
         label.text = viewModel.strings.selectYourBankLabelText
         label.textColor = viewModel.configuration.selectYourBankAccentColor
         label.font = viewModel.configuration.selectYourBankLabelFont
-        label.adjustsFontSizeToFitWidth = true
+        label.adjustsFontForContentSizeCategory = true
         label.numberOfLines = 0
         return label
     }()

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentInfo/PaymentInfoViewController.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentInfo/PaymentInfoViewController.swift
@@ -69,6 +69,7 @@ public final class PaymentInfoViewController: GiniBottomSheetViewController {
         paragraphStyle.lineHeightMultiple = Constants.payBillsTitleLineHeight
         label.attributedText = NSMutableAttributedString(string: viewModel.strings.payBillsTitleText,
                                                          attributes: [NSAttributedString.Key.paragraphStyle: paragraphStyle])
+        label.adjustsFontForContentSizeCategory = true
         return label
     }()
     
@@ -98,6 +99,7 @@ public final class PaymentInfoViewController: GiniBottomSheetViewController {
         paragraphStyle.lineHeightMultiple = Constants.questionsTitleLineHeight
         label.attributedText = NSMutableAttributedString(string: viewModel.strings.questionsTitleText,
                                                          attributes: [NSAttributedString.Key.paragraphStyle: paragraphStyle])
+        label.adjustsFontForContentSizeCategory = true
         return label
     }()
     

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/PaymentReviewObservableModel.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/PaymentReviewObservableModel.swift
@@ -21,13 +21,45 @@ final class PaymentReviewObservableModel: ObservableObject {
     private var bannerDismissed: Bool = false
     private var reduceMotion: Bool = UIAccessibility.isReduceMotionEnabled
     private var reduceMotionObserver: NSObjectProtocol?
-    
+    private var cancellables = Set<AnyCancellable>()
+
     var isBottomSheetMode: Bool {
         model.displayMode == .bottomSheet
     }
-    
+
     var invoiceImageAccessibilityLabel: String {
         model.strings.invoiceImageAccessibilityLabel
+    }
+
+    /**
+     Reflects whether the amount field inside the payment information form is currently focused.
+     Changes trigger a re-render of `PaymentReviewContentView` so the landscape Done toolbar
+     can appear or disappear in sync with keyboard focus.
+     */
+    var isAmountFieldFocused: Bool {
+        paymentInformationObservableModel.isAmountFieldFocused
+    }
+
+    /**
+     The localized title for the keyboard Done button.
+     */
+    var keyboardDoneButtonTitle: String {
+        containerViewModel.strings.keyboardDoneButtonTitle
+    }
+
+    /**
+     Tracks the keyboard-dismissed analytics event and clears the stored active field so that
+     a subsequent device rotation does not restore focus (and reopen the keyboard).
+     Call this when the user explicitly taps the Done button.
+     */
+    func trackKeyboardDismissed() {
+        // Clear immediately — the 0.1 s delay in `onChange(of: focusedField)` is designed to
+        // distinguish rotation from a manual dismiss, but if the user rotates right after tapping
+        // Done the view is already gone and the check sees `isViewVisible == false`, keeping
+        // `activeField` set and reopening the keyboard in the new layout. Clearing here first
+        // wins the race.
+        paymentInformationObservableModel.activeField = nil
+        model.delegate?.trackOnPaymentReviewCloseKeyboardClicked()
     }
     
     @Published private var showBanner: Bool
@@ -86,7 +118,7 @@ final class PaymentReviewObservableModel: ObservableObject {
                     }
                 }
             } catch {
-                /// Task was cancelled - no action needed
+                // Task was cancelled - no action needed
             }
         }
     }
@@ -125,7 +157,10 @@ final class PaymentReviewObservableModel: ObservableObject {
             self?.didTapPay(paymentInfo)
         },
                                             onKeyboardDismissed: { [weak self] in
-            self?.model.delegate?.trackOnPaymentReviewCloseKeyboardClicked()
+            // Route through `trackKeyboardDismissed()` so `activeField` is cleared immediately.
+            // Calling the delegate directly would skip that and leave the field set, causing
+            // the keyboard to reopen if the user rotates right after tapping Done.
+            self?.trackKeyboardDismissed()
         })
     }
     
@@ -146,6 +181,12 @@ final class PaymentReviewObservableModel: ObservableObject {
     }
     
     private func setupBindings() {
+        // Forward `isAmountFieldFocused` changes from the inner observable model so that
+        // `PaymentReviewContentView` re-renders when the amount field gains or loses focus.
+        paymentInformationObservableModel.$isAmountFieldFocused
+            .sink { [weak self] _ in self?.objectWillChange.send() }
+            .store(in: &cancellables)
+
         // Observe changes from the original model
         model.onPreviewImagesFetched = { [weak self] in
             Task { @MainActor [weak self] in

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/Views/EnvironmentValues+Landscape.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/Views/EnvironmentValues+Landscape.swift
@@ -1,0 +1,18 @@
+//
+//  EnvironmentValues+Landscape.swift
+//
+//  Copyright © 2026 Gini GmbH. All rights reserved.
+//
+
+import SwiftUI
+
+extension EnvironmentValues {
+    /**
+     `true` when the device is in landscape orientation.
+     On iPhone this maps to `verticalSizeClass == .compact`; iPads always return `.regular`
+     for both orientations so landscape there is handled separately via the portrait/sheet flow.
+     */
+    var isLandscape: Bool {
+        verticalSizeClass == .compact
+    }
+}

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/Views/EnvironmentValues+Landscape.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/Views/EnvironmentValues+Landscape.swift
@@ -6,7 +6,16 @@
 
 import SwiftUI
 
-extension EnvironmentValues {
+/** Gini-specific layout helpers derived from the current SwiftUI environment.
+ Using a dedicated type avoids adding unnamespaced properties to `EnvironmentValues`
+ that could collide with names defined in the host application. */
+struct GiniLayoutEnvironment {
+    private let verticalSizeClass: UserInterfaceSizeClass?
+
+    init(verticalSizeClass: UserInterfaceSizeClass?) {
+        self.verticalSizeClass = verticalSizeClass
+    }
+
     /**
      `true` when the current environment uses a compact vertical size class.
      On iPhone this commonly maps to landscape orientation. On iPad, size classes can vary
@@ -15,5 +24,13 @@ extension EnvironmentValues {
      */
     var isLandscape: Bool {
         verticalSizeClass == .compact
+    }
+}
+
+extension EnvironmentValues {
+    /** Gini-specific layout helpers. Use this instead of extending `EnvironmentValues` directly
+     to avoid property name collisions with host application extensions. */
+    var giniLayout: GiniLayoutEnvironment {
+        GiniLayoutEnvironment(verticalSizeClass: verticalSizeClass)
     }
 }

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/Views/EnvironmentValues+Landscape.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/Views/EnvironmentValues+Landscape.swift
@@ -8,9 +8,10 @@ import SwiftUI
 
 extension EnvironmentValues {
     /**
-     `true` when the device is in landscape orientation.
-     On iPhone this maps to `verticalSizeClass == .compact`; iPads always return `.regular`
-     for both orientations so landscape there is handled separately via the portrait/sheet flow.
+     `true` when the current environment uses a compact vertical size class.
+     On iPhone this commonly maps to landscape orientation. On iPad, size classes can vary
+     depending on multitasking and window size, so iPad landscape handling in this flow is
+     managed separately via the portrait/sheet flow.
      */
     var isLandscape: Bool {
         verticalSizeClass == .compact

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/Views/PaymentInformation/PaymentReviewPaymentInformationObservableModel.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/Views/PaymentInformation/PaymentReviewPaymentInformationObservableModel.swift
@@ -9,10 +9,38 @@ import GiniHealthAPILibrary
 import SwiftUI
 import GiniUtilites
 
+/** Identifies which payment form field is currently focused.
+ Stored in the observable model so focus can be restored after orientation changes recreate the view.
+ */
+enum ActivePaymentField {
+    case recipient
+    case iban
+    case amount
+    case paymentPurpose
+}
+
 final class PaymentReviewPaymentInformationObservableModel: ObservableObject {
     
     private let ibanValidator = IBANValidator()
-    
+
+    /**
+     Tracks which field was focused before the view was recreated (e.g. after rotation),
+     so the keyboard can be restored in the new layout.
+     */
+    var activeField: ActivePaymentField? = nil
+
+    /**
+     Set to `true` while the view is on screen. Used to distinguish a rotation (view
+     disappears quickly) from the user explicitly dismissing the keyboard (view stays visible).
+     */
+    var isViewVisible: Bool = false
+
+    /**
+     Tracks whether the amount field is currently focused.
+     Published so the outer layout can observe it and show a full-width Done toolbar in landscape.
+     */
+    @Published var isAmountFieldFocused: Bool = false
+
     private var cancellables = Set<AnyCancellable>()
     
     @Published var extractions: [Extraction]
@@ -177,7 +205,7 @@ final class PaymentReviewPaymentInformationObservableModel: ObservableObject {
             }
         }
         
-        /// Subscribe to payment provider changes
+        // Subscribe to payment provider changes
         model.$selectedPaymentProvider
             .receive(on: DispatchQueue.main)
             .sink { [weak self] newProvider in

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/Views/PaymentInformation/PaymentReviewPaymentInformationObservableModel.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/Views/PaymentInformation/PaymentReviewPaymentInformationObservableModel.swift
@@ -12,7 +12,7 @@ import GiniUtilites
 /** Identifies which payment form field is currently focused.
  Stored in the observable model so focus can be restored after orientation changes recreate the view.
  */
-enum ActivePaymentField {
+enum ActivePaymentField: Equatable {
     case recipient
     case iban
     case amount

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/Views/PaymentInformation/PaymentReviewPaymentInformationView.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/Views/PaymentInformation/PaymentReviewPaymentInformationView.swift
@@ -78,28 +78,28 @@ struct PaymentReviewPaymentInformationView: View {
                 viewModel.isViewVisible = true
 
                 populateFields()
-                /// Notify VoiceOver that a new screen (the sheet) appeared,
-                /// so it moves focus into the sheet content.
+                // Notify VoiceOver that a new screen (the sheet) appeared,
+                // so it moves focus into the sheet content.
                 UIAccessibility.post(notification: .screenChanged, argument: nil)
-                /// After a rotation the view is recreated; restore keyboard if it was open.
+                // After a rotation the view is recreated; restore keyboard if it was open.
                 restoreFocusIfNeeded()
             }
             .onDisappear {
                 viewModel.isViewVisible = false
             }
-        /// Track which field is active so it can be restored after orientation changes.
+        // Track which field is active so it can be restored after orientation changes.
             .onChange(of: focusedField) { newField in
                 if let field = newField {
                     viewModel.activeField = mapToActiveField(field)
                     viewModel.isAmountFieldFocused = (field == .amount)
                 } else {
-                    /// Clear amount-focus immediately so the Done toolbar hides right away.
+                    // Clear amount-focus immediately so the Done toolbar hides right away.
                     viewModel.isAmountFieldFocused = false
-                    /// Don't clear activeField immediately: the same nil event fires during rotation
-                    /// (view is destroyed) AND when the user manually dismisses the keyboard.
-                    /// After a short delay, check if the view is still on screen:
-                    ///   - Still visible  → user dismissed keyboard → clear activeField
-                    ///   - Gone (rotation) → keep activeField so the new layout can restore it
+                    // Don't clear activeField immediately: the same nil event fires during rotation
+                    // (view is destroyed) AND when the user manually dismisses the keyboard.
+                    // After a short delay, check if the view is still on screen:
+                    //   - Still visible  → user dismissed keyboard → clear activeField
+                    //   - Gone (rotation) → keep activeField so the new layout can restore it
                     Task { @MainActor in
                         try? await Task.sleep(nanoseconds: 100_000_000) // 0.1 s
                         if viewModel.isViewVisible {
@@ -123,20 +123,20 @@ struct PaymentReviewPaymentInformationView: View {
     @ViewBuilder
     private var scrollView: some View {
         baseScrollView
-            /// Keyboard safe area is suppressed so neither portrait nor landscape creates
-            /// an automatic gap. Keyboard space is re-injected explicitly via safeAreaInset.
+            // Keyboard safe area is suppressed so neither portrait nor landscape creates
+            // an automatic gap. Keyboard space is re-injected explicitly via safeAreaInset.
             .ignoresSafeArea(.keyboard)
             .safeAreaInset(edge: .bottom) {
                 VStack(spacing: 0) {
-                    /// Done button shown here only in portrait (bottom-sheet mode). In landscape
-                    /// the outer PaymentReviewContentView renders a full-width Done toolbar above
-                    /// the keyboard, so the narrow per-panel bar is suppressed.
+                    // Done button shown here only in portrait (bottom-sheet mode). In landscape
+                    // the outer PaymentReviewContentView renders a full-width Done toolbar above
+                    // the keyboard, so the narrow per-panel bar is suppressed.
                     if !isLandscape && focusedField == .amount && keyboardHeight > 0 {
                         doneButtonBar
                     }
-                    /// In landscape the keyboard sits below the inline view; re-inject its
-                    /// height so the ScrollView scrolls content above it. In portrait the
-                    /// sheet already repositions above the keyboard — no extra space needed.
+                    // In landscape the keyboard sits below the inline view; re-inject its
+                    // height so the ScrollView scrolls content above it. In portrait the
+                    // sheet already repositions above the keyboard — no extra space needed.
                     Color.clear.frame(height: isLandscape ? keyboardHeight : 0)
                 }
             }
@@ -480,7 +480,7 @@ struct PaymentReviewPaymentInformationView: View {
             viewModel.recipientInputState.hasError = !viewModel.validateRecipient(viewModel.recipientInputState.text)
             viewModel.recipientInputState.errorMessage = viewModel.recipientError
             
-            /// Announce error to VoiceOver
+            // Announce error to VoiceOver
             if viewModel.recipientInputState.hasError,
                 let errorMessage = viewModel.recipientError {
                 UIAccessibility.post(notification: .announcement, argument: errorMessage)
@@ -495,7 +495,7 @@ struct PaymentReviewPaymentInformationView: View {
             viewModel.ibanInputState.hasError = !viewModel.validateIBAN(viewModel.ibanInputState.text)
             viewModel.ibanInputState.errorMessage = viewModel.ibanError
             
-            /// Announce error to VoiceOver
+            // Announce error to VoiceOver
             if viewModel.ibanInputState.hasError,
                 let errorMessage = viewModel.ibanError {
                 UIAccessibility.post(notification: .announcement, argument: errorMessage)
@@ -522,7 +522,7 @@ struct PaymentReviewPaymentInformationView: View {
             viewModel.amountInputState.hasError = !viewModel.validateAmount(viewModel.amountInputState.text, amount: viewModel.amountToPay.value)
             viewModel.amountInputState.errorMessage = viewModel.amountError
             
-            /// Announce error to VoiceOver
+            // Announce error to VoiceOver
             if viewModel.amountInputState.hasError,
                 let errorMessage = viewModel.amountError {
                 UIAccessibility.post(notification: .announcement, argument: errorMessage)
@@ -537,7 +537,7 @@ struct PaymentReviewPaymentInformationView: View {
             viewModel.paymentPurposeInputState.hasError = !viewModel.validatePaymentPurpose(viewModel.paymentPurposeInputState.text)
             viewModel.paymentPurposeInputState.errorMessage = viewModel.paymentPurposeError
             
-            /// Announce error to VoiceOver
+            // Announce error to VoiceOver
             if viewModel.paymentPurposeInputState.hasError,
                 let errorMessage = viewModel.paymentPurposeError {
                 UIAccessibility.post(notification: .announcement, argument: errorMessage)

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/Views/PaymentInformation/PaymentReviewPaymentInformationView.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/Views/PaymentInformation/PaymentReviewPaymentInformationView.swift
@@ -28,7 +28,7 @@ struct PaymentReviewPaymentInformationView: View {
     @Binding private var contentHeight: CGFloat
     @Binding private var showBanner: Bool
     
-    @Environment(\.isLandscape) private var isLandscape
+    @Environment(\.giniLayout) private var giniLayout
     @Environment(\.dynamicTypeSize) private var dynamicTypeSize
 
     @State private var keyboardHeight: CGFloat = 0
@@ -89,27 +89,7 @@ struct PaymentReviewPaymentInformationView: View {
             }
         // Track which field is active so it can be restored after orientation changes.
             .onChange(of: focusedField) { newField in
-                if let field = newField {
-                    viewModel.activeField = mapToActiveField(field)
-                    viewModel.isAmountFieldFocused = (field == .amount)
-                } else {
-                    // Clear amount-focus immediately so the Done toolbar hides right away.
-                    viewModel.isAmountFieldFocused = false
-                    // Don't clear activeField immediately: the same nil event fires during rotation
-                    // (view is destroyed) AND when the user manually dismisses the keyboard.
-                    // Capture the current field so the task can verify nothing changed during the delay:
-                    //   - Still visible + focus still nil + same field → user dismissed → clear activeField
-                    //   - Gone (rotation) or focus moved to another field → keep activeField for restoration
-                    let fieldToClear = viewModel.activeField
-                    Task { @MainActor in
-                        try? await Task.sleep(nanoseconds: 100_000_000) // 0.1 s
-                        if viewModel.isViewVisible,
-                           focusedField == nil,
-                           viewModel.activeField == fieldToClear {
-                            viewModel.activeField = nil
-                        }
-                    }
-                }
+                handleFocusedFieldChange(newField)
             }
             .background(Color(.systemBackground))
             .onReceive(NotificationCenter.default.publisher(for: UIResponder.keyboardWillShowNotification)) { notification in
@@ -134,13 +114,13 @@ struct PaymentReviewPaymentInformationView: View {
                     // Done button shown here only in portrait (bottom-sheet mode). In landscape
                     // the outer PaymentReviewContentView renders a full-width Done toolbar above
                     // the keyboard, so the narrow per-panel bar is suppressed.
-                    if !isLandscape && focusedField == .amount && keyboardHeight > 0 {
+                    if !giniLayout.isLandscape && focusedField == .amount && keyboardHeight > 0 {
                         doneButtonBar
                     }
                     // In landscape the keyboard sits below the inline view; re-inject its
                     // height so the ScrollView scrolls content above it. In portrait the
                     // sheet already repositions above the keyboard — no extra space needed.
-                    Color.clear.frame(height: isLandscape ? keyboardHeight : 0)
+                    Color.clear.frame(height: giniLayout.isLandscape ? keyboardHeight : 0)
                 }
             }
     }
@@ -224,7 +204,7 @@ struct PaymentReviewPaymentInformationView: View {
                 topTrailingRadius: Constants.bannerCornerRadius
             )
         )
-        .offset(y: isLandscape ? Constants.zero : Constants.bannerYOffset)
+        .offset(y: giniLayout.isLandscape ? Constants.zero : Constants.bannerYOffset)
         .transition(.move(edge: .top).combined(with: .opacity))
         .accessibilityElement(children: .combine)
         .accessibilityAddTraits(.isStaticText)
@@ -458,6 +438,36 @@ struct PaymentReviewPaymentInformationView: View {
             case .iban: return .iban
             case .amount: return .amount
             case .paymentPurpose: return .paymentPurpose
+        }
+    }
+
+    /**
+     Handles focus changes on the active field.
+     When focus moves to a field, the model's `activeField` and `isAmountFieldFocused` are updated.
+     When focus is cleared, amount-focus is cleared immediately and `activeField` is cleared
+     after a short delay — distinguishing a user keyboard dismissal from a rotation-triggered view recreation.
+     */
+    private func handleFocusedFieldChange(_ newField: Field?) {
+        if let field = newField {
+            viewModel.activeField = mapToActiveField(field)
+            viewModel.isAmountFieldFocused = (field == .amount)
+        } else {
+            // Clear amount-focus immediately so the Done toolbar hides right away.
+            viewModel.isAmountFieldFocused = false
+            // Don't clear activeField immediately: the same nil event fires during rotation
+            // (view is destroyed) AND when the user manually dismisses the keyboard.
+            // Capture the current field so the task can verify nothing changed during the delay:
+            //   - Still visible + focus still nil + same field → user dismissed → clear activeField
+            //   - Gone (rotation) or focus moved to another field → keep activeField for restoration
+            let fieldToClear = viewModel.activeField
+            Task { @MainActor in
+                try? await Task.sleep(nanoseconds: 100_000_000) // 0.1 s
+                if viewModel.isViewVisible,
+                   focusedField == nil,
+                   viewModel.activeField == fieldToClear {
+                    viewModel.activeField = nil
+                }
+            }
         }
     }
 

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/Views/PaymentInformation/PaymentReviewPaymentInformationView.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/Views/PaymentInformation/PaymentReviewPaymentInformationView.swift
@@ -29,6 +29,7 @@ struct PaymentReviewPaymentInformationView: View {
     @Binding private var showBanner: Bool
     
     @Environment(\.verticalSizeClass) private var verticalSizeClass
+    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
     
     private var isLandscape: Bool {
         verticalSizeClass == .compact
@@ -65,31 +66,45 @@ struct PaymentReviewPaymentInformationView: View {
     }
     
     var body: some View {
-        VStack(spacing: Constants.zero) {
-            ScrollView {
-                VStack(spacing: Constants.textFieldsContainerSpacing) {
-                    recipientTextField
-                    
+        ScrollView {
+            VStack(spacing: Constants.textFieldsContainerSpacing) {
+                recipientTextField
+
+                if dynamicTypeSize.isAccessibilitySize {
+                    VStack(spacing: Constants.textFieldsContainerSpacing) {
+                        ibanTextField
+                        amountTextField
+                    }
+                } else {
                     HStack(spacing: Constants.textFieldsContainerSpacing) {
                         ibanTextField
                         amountTextField
                     }
-                    
-                    paymentPurposeTextField
-                    
+                }
+
+                paymentPurposeTextField
+
+                if dynamicTypeSize.isAccessibilitySize {
+                    VStack(spacing: Constants.buttonsContainerSpacing) {
+                        paymentProviderSelectionPicker
+                        payButton
+                    }
+                    .padding(.bottom, Constants.buttonsContainerBottomPadding)
+                } else {
                     HStack(spacing: Constants.buttonsContainerSpacing) {
                         paymentProviderSelectionPicker
                         payButton
                     }
                     .padding(.bottom, Constants.buttonsContainerBottomPadding)
-                    
-                    if viewModel.shouldShowBrandedView {
-                        poweredByGiniView
-                    }
                 }
-                .padding(.horizontal, Constants.textFieldsContainerHorizontalPadding)
-                .padding(.top, Constants.textFieldsContainerTopPadding)
+
+                if viewModel.shouldShowBrandedView {
+                    poweredByGiniView
+                }
             }
+            .padding(.horizontal, Constants.textFieldsContainerHorizontalPadding)
+            .padding(.top, Constants.textFieldsContainerTopPadding)
+            .getHeight(for: $contentHeight)
         }
         .overlay(alignment: .top) {
             if showBanner {
@@ -113,7 +128,6 @@ struct PaymentReviewPaymentInformationView: View {
                 }
             }
         }
-        .getHeight(for: $contentHeight)
         .background(Color(.systemBackground))
     }
     
@@ -297,7 +311,8 @@ struct PaymentReviewPaymentInformationView: View {
             .background(Color(selectedPaymentProviderBackgroundColor))
             .clipShape(.rect(cornerRadius: viewModel.model.primaryButtonConfiguration.cornerRadius))
             .font(Font(viewModel.model.primaryButtonConfiguration.titleFont))
-            .frame(height: Constants.payButtonHeight)
+            .frame(minHeight: Constants.payButtonHeight)
+            .accessibilityLabel(viewModel.model.strings.payInvoiceLabelText)
             .accessibilityHint(viewModelStrings.bankSelectionAccessibility.payInvoiceHint)
         }
     }

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/Views/PaymentInformation/PaymentReviewPaymentInformationView.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/Views/PaymentInformation/PaymentReviewPaymentInformationView.swift
@@ -97,12 +97,15 @@ struct PaymentReviewPaymentInformationView: View {
                     viewModel.isAmountFieldFocused = false
                     // Don't clear activeField immediately: the same nil event fires during rotation
                     // (view is destroyed) AND when the user manually dismisses the keyboard.
-                    // After a short delay, check if the view is still on screen:
-                    //   - Still visible  → user dismissed keyboard → clear activeField
-                    //   - Gone (rotation) → keep activeField so the new layout can restore it
+                    // Capture the current field so the task can verify nothing changed during the delay:
+                    //   - Still visible + focus still nil + same field → user dismissed → clear activeField
+                    //   - Gone (rotation) or focus moved to another field → keep activeField for restoration
+                    let fieldToClear = viewModel.activeField
                     Task { @MainActor in
                         try? await Task.sleep(nanoseconds: 100_000_000) // 0.1 s
-                        if viewModel.isViewVisible {
+                        if viewModel.isViewVisible,
+                           focusedField == nil,
+                           viewModel.activeField == fieldToClear {
                             viewModel.activeField = nil
                         }
                     }

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/Views/PaymentInformation/PaymentReviewPaymentInformationView.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/Views/PaymentInformation/PaymentReviewPaymentInformationView.swift
@@ -28,14 +28,10 @@ struct PaymentReviewPaymentInformationView: View {
     @Binding private var contentHeight: CGFloat
     @Binding private var showBanner: Bool
     
-    @Environment(\.verticalSizeClass) private var verticalSizeClass
+    @Environment(\.isLandscape) private var isLandscape
     @Environment(\.dynamicTypeSize) private var dynamicTypeSize
 
     @State private var keyboardHeight: CGFloat = 0
-
-    private var isLandscape: Bool {
-        verticalSizeClass == .compact
-    }
     
     private var textFieldConfiguration: TextFieldConfiguration {
         viewModel.model.defaultStyleInputFieldConfiguration
@@ -79,22 +75,42 @@ struct PaymentReviewPaymentInformationView: View {
                 }
             }
             .onAppear {
+                viewModel.isViewVisible = true
+
                 populateFields()
-                // Notify VoiceOver that a new screen (the sheet) appeared,
-                // so it moves focus into the sheet content.
+                /// Notify VoiceOver that a new screen (the sheet) appeared,
+                /// so it moves focus into the sheet content.
                 UIAccessibility.post(notification: .screenChanged, argument: nil)
+                /// After a rotation the view is recreated; restore keyboard if it was open.
+                restoreFocusIfNeeded()
             }
-            .toolbar {
-                ToolbarItemGroup(placement: .keyboard) {
-                    if focusedField == .amount {
-                        amountToolbarView
+            .onDisappear {
+                viewModel.isViewVisible = false
+            }
+        /// Track which field is active so it can be restored after orientation changes.
+            .onChange(of: focusedField) { newField in
+                if let field = newField {
+                    viewModel.activeField = mapToActiveField(field)
+                    viewModel.isAmountFieldFocused = (field == .amount)
+                } else {
+                    /// Clear amount-focus immediately so the Done toolbar hides right away.
+                    viewModel.isAmountFieldFocused = false
+                    /// Don't clear activeField immediately: the same nil event fires during rotation
+                    /// (view is destroyed) AND when the user manually dismisses the keyboard.
+                    /// After a short delay, check if the view is still on screen:
+                    ///   - Still visible  → user dismissed keyboard → clear activeField
+                    ///   - Gone (rotation) → keep activeField so the new layout can restore it
+                    Task { @MainActor in
+                        try? await Task.sleep(nanoseconds: 100_000_000) // 0.1 s
+                        if viewModel.isViewVisible {
+                            viewModel.activeField = nil
+                        }
                     }
                 }
             }
             .background(Color(.systemBackground))
             .onReceive(NotificationCenter.default.publisher(for: UIResponder.keyboardWillShowNotification)) { notification in
-                guard isLandscape,
-                      let frame = notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? CGRect else { return }
+                guard let frame = notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? CGRect else { return }
                 keyboardHeight = frame.height
             }
             .onReceive(NotificationCenter.default.publisher(for: UIResponder.keyboardWillHideNotification)) { _ in
@@ -106,17 +122,39 @@ struct PaymentReviewPaymentInformationView: View {
 
     @ViewBuilder
     private var scrollView: some View {
-        if #available(iOS 15.0, *) {
-            baseScrollView
-                .safeAreaInset(edge: .bottom) {
-                    // In landscape the parent ignores the keyboard safe area to prevent layout
-                    // shrinking; re-inject it here so the ScrollView scrolls the focused field
-                    // above the keyboard.
+        baseScrollView
+            /// Keyboard safe area is suppressed so neither portrait nor landscape creates
+            /// an automatic gap. Keyboard space is re-injected explicitly via safeAreaInset.
+            .ignoresSafeArea(.keyboard)
+            .safeAreaInset(edge: .bottom) {
+                VStack(spacing: 0) {
+                    /// Done button shown here only in portrait (bottom-sheet mode). In landscape
+                    /// the outer PaymentReviewContentView renders a full-width Done toolbar above
+                    /// the keyboard, so the narrow per-panel bar is suppressed.
+                    if !isLandscape && focusedField == .amount && keyboardHeight > 0 {
+                        doneButtonBar
+                    }
+                    /// In landscape the keyboard sits below the inline view; re-inject its
+                    /// height so the ScrollView scrolls content above it. In portrait the
+                    /// sheet already repositions above the keyboard — no extra space needed.
                     Color.clear.frame(height: isLandscape ? keyboardHeight : 0)
                 }
-        } else {
-            baseScrollView
+            }
+    }
+
+    @ViewBuilder
+    private var doneButtonBar: some View {
+        HStack {
+            Spacer()
+            Button(viewModelStrings.keyboardDoneButtonTitle) {
+                onKeyboardDismissed()
+                focusedField = nil
+            }
+            .padding(.horizontal, Constants.doneButtonHorizontalPadding)
         }
+        .frame(height: Constants.doneButtonBarHeight)
+        .background(Color(UIColor.systemGroupedBackground))
+        .overlay(alignment: .top) { Divider() }
     }
 
     private var baseScrollView: some View {
@@ -254,15 +292,6 @@ struct PaymentReviewPaymentInformationView: View {
     }
     
     @ViewBuilder
-    private var amountToolbarView: some View {
-        Spacer()
-        Button(viewModelStrings.keyboardDoneButtonTitle) {
-            onKeyboardDismissed()
-            focusedField = nil
-        }
-    }
-
-    @ViewBuilder
     private var paymentPurposeTextField: some View {
         TextField(Constants.emptyString, text: $viewModel.paymentPurposeInputState.text)
         .focused($focusedField, equals: .paymentPurpose)
@@ -358,7 +387,7 @@ struct PaymentReviewPaymentInformationView: View {
     }
     
     // MARK: Private methods
-    
+
     private func populateFields() {
         viewModel.populateFieldsIfNeeded()
     }
@@ -402,7 +431,46 @@ struct PaymentReviewPaymentInformationView: View {
         
         return isValid
     }
-    
+    // MARK: - Orientation Helpers
+
+    /**
+     Maps the private `Field` enum to the model-level `ActivePaymentField`
+     so the focused field can survive view recreation on orientation change.
+     */
+    private func mapToActiveField(_ field: Field) -> ActivePaymentField {
+        switch field {
+            case .recipient: return .recipient
+            case .iban: return .iban
+            case .amount: return .amount
+            case .paymentPurpose: return .paymentPurpose
+        }
+    }
+
+    /**
+     Inverse mapping: `ActivePaymentField` → `Field`.
+     */
+    private func mapToFocusField(_ activeField: ActivePaymentField) -> Field {
+        switch activeField {
+            case .recipient: return .recipient
+            case .iban: return .iban
+            case .amount: return .amount
+            case .paymentPurpose: return .paymentPurpose
+        }
+    }
+
+    /**
+     Re-applies keyboard focus after the view is recreated by an orientation change.
+     The delay lets the rotation animation and any pending keyboard dismissal finish
+     before requesting focus again.
+     */
+    private func restoreFocusIfNeeded() {
+        guard let field = viewModel.activeField else { return }
+        Task { @MainActor in
+            try? await Task.sleep(nanoseconds: 400_000_000) // 0.4 s
+            focusedField = mapToFocusField(field)
+        }
+    }
+
     // MARK: - Focus Change Handlers
 
     private func handleRecipientFocusChange(isFocused: Bool) {
@@ -412,7 +480,7 @@ struct PaymentReviewPaymentInformationView: View {
             viewModel.recipientInputState.hasError = !viewModel.validateRecipient(viewModel.recipientInputState.text)
             viewModel.recipientInputState.errorMessage = viewModel.recipientError
             
-            // Announce error to VoiceOver
+            /// Announce error to VoiceOver
             if viewModel.recipientInputState.hasError,
                 let errorMessage = viewModel.recipientError {
                 UIAccessibility.post(notification: .announcement, argument: errorMessage)
@@ -427,7 +495,7 @@ struct PaymentReviewPaymentInformationView: View {
             viewModel.ibanInputState.hasError = !viewModel.validateIBAN(viewModel.ibanInputState.text)
             viewModel.ibanInputState.errorMessage = viewModel.ibanError
             
-            // Announce error to VoiceOver
+            /// Announce error to VoiceOver
             if viewModel.ibanInputState.hasError,
                 let errorMessage = viewModel.ibanError {
                 UIAccessibility.post(notification: .announcement, argument: errorMessage)
@@ -454,7 +522,7 @@ struct PaymentReviewPaymentInformationView: View {
             viewModel.amountInputState.hasError = !viewModel.validateAmount(viewModel.amountInputState.text, amount: viewModel.amountToPay.value)
             viewModel.amountInputState.errorMessage = viewModel.amountError
             
-            // Announce error to VoiceOver
+            /// Announce error to VoiceOver
             if viewModel.amountInputState.hasError,
                 let errorMessage = viewModel.amountError {
                 UIAccessibility.post(notification: .announcement, argument: errorMessage)
@@ -469,7 +537,7 @@ struct PaymentReviewPaymentInformationView: View {
             viewModel.paymentPurposeInputState.hasError = !viewModel.validatePaymentPurpose(viewModel.paymentPurposeInputState.text)
             viewModel.paymentPurposeInputState.errorMessage = viewModel.paymentPurposeError
             
-            // Announce error to VoiceOver
+            /// Announce error to VoiceOver
             if viewModel.paymentPurposeInputState.hasError,
                 let errorMessage = viewModel.paymentPurposeError {
                 UIAccessibility.post(notification: .announcement, argument: errorMessage)
@@ -496,5 +564,7 @@ struct PaymentReviewPaymentInformationView: View {
         static let textFieldsContainerHorizontalPadding = 16.0
         static let textFieldsContainerTopPadding = 24.0
         static let poweredByGiniTopPadding = 8.0
+        static let doneButtonBarHeight = 44.0
+        static let doneButtonHorizontalPadding = 16.0
     }
 }

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/Views/PaymentInformation/PaymentReviewPaymentInformationView.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/Views/PaymentInformation/PaymentReviewPaymentInformationView.swift
@@ -30,7 +30,9 @@ struct PaymentReviewPaymentInformationView: View {
     
     @Environment(\.verticalSizeClass) private var verticalSizeClass
     @Environment(\.dynamicTypeSize) private var dynamicTypeSize
-    
+
+    @State private var keyboardHeight: CGFloat = 0
+
     private var isLandscape: Bool {
         verticalSizeClass == .compact
     }
@@ -66,6 +68,58 @@ struct PaymentReviewPaymentInformationView: View {
     }
     
     var body: some View {
+        scrollView
+            .overlay(alignment: .top) {
+                if showBanner {
+                    infoBannerView
+                        .onAppear {
+                            UIAccessibility.post(notification: .announcement,
+                                                 argument: viewModel.model.strings.infoBarMessage)
+                        }
+                }
+            }
+            .onAppear {
+                populateFields()
+                // Notify VoiceOver that a new screen (the sheet) appeared,
+                // so it moves focus into the sheet content.
+                UIAccessibility.post(notification: .screenChanged, argument: nil)
+            }
+            .toolbar {
+                ToolbarItemGroup(placement: .keyboard) {
+                    if focusedField == .amount {
+                        amountToolbarView
+                    }
+                }
+            }
+            .background(Color(.systemBackground))
+            .onReceive(NotificationCenter.default.publisher(for: UIResponder.keyboardWillShowNotification)) { notification in
+                guard isLandscape,
+                      let frame = notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? CGRect else { return }
+                keyboardHeight = frame.height
+            }
+            .onReceive(NotificationCenter.default.publisher(for: UIResponder.keyboardWillHideNotification)) { _ in
+                keyboardHeight = 0
+            }
+    }
+
+    // MARK: Private views
+
+    @ViewBuilder
+    private var scrollView: some View {
+        if #available(iOS 15.0, *) {
+            baseScrollView
+                .safeAreaInset(edge: .bottom) {
+                    // In landscape the parent ignores the keyboard safe area to prevent layout
+                    // shrinking; re-inject it here so the ScrollView scrolls the focused field
+                    // above the keyboard.
+                    Color.clear.frame(height: isLandscape ? keyboardHeight : 0)
+                }
+        } else {
+            baseScrollView
+        }
+    }
+
+    private var baseScrollView: some View {
         ScrollView {
             VStack(spacing: Constants.textFieldsContainerSpacing) {
                 recipientTextField
@@ -106,33 +160,10 @@ struct PaymentReviewPaymentInformationView: View {
             .padding(.top, Constants.textFieldsContainerTopPadding)
             .getHeight(for: $contentHeight)
         }
-        .overlay(alignment: .top) {
-            if showBanner {
-                infoBannerView
-                    .onAppear {
-                        UIAccessibility.post(notification: .announcement,
-                                             argument: viewModel.model.strings.infoBarMessage)
-                    }
-            }
-        }
-        .onAppear {
-            populateFields()
-            // Notify VoiceOver that a new screen (the sheet) appeared,
-            // so it moves focus into the sheet content.
-            UIAccessibility.post(notification: .screenChanged, argument: nil)
-        }
-        .toolbar {
-            ToolbarItemGroup(placement: .keyboard) {
-                if focusedField == .amount {
-                    amountToolbarView
-                }
-            }
-        }
-        .background(Color(.systemBackground))
     }
-    
+
     // MARK: Private views
-    
+
     @ViewBuilder
     private var infoBannerView: some View {
         HStack {
@@ -230,7 +261,7 @@ struct PaymentReviewPaymentInformationView: View {
             focusedField = nil
         }
     }
-    
+
     @ViewBuilder
     private var paymentPurposeTextField: some View {
         TextField(Constants.emptyString, text: $viewModel.paymentPurposeInputState.text)

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/Views/PaymentReviewContentView.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/Views/PaymentReviewContentView.swift
@@ -37,9 +37,9 @@ public struct PaymentReviewContentView: View {
         .ignoresSafeArea(.keyboard)
         .animation(.easeInOut(duration: Constants.layoutTransitionDuration), value: isLandscape)
         .onChange(of: isLandscape) { landscape in
-            /// When rotating to landscape in documentCollection mode, dismiss the
-            /// sheet immediately (without animation) so the crossfade transition
-            /// isn't disrupted by the sheet's own dismissal animation.
+            // When rotating to landscape in documentCollection mode, dismiss the
+            // sheet immediately (without animation) so the crossfade transition
+            // isn't disrupted by the sheet's own dismissal animation.
             if landscape && !viewModel.isBottomSheetMode && showBottomSheet {
                 showBottomSheet = false
             }
@@ -55,12 +55,12 @@ public struct PaymentReviewContentView: View {
         .onAppear {
             viewModel.dismissBannerAfterDelay()
         }
-        /// Full-width Done toolbar rendered above the keyboard in landscape (documentCollection)
-        /// mode. `ToolbarItemGroup(placement: .keyboard)` is the correct way to place content
-        /// above the keyboard — `safeAreaInset` on the HStack would place it behind the keyboard
-        /// because the outer container suppresses the keyboard safe area with `ignoresSafeArea`.
-        /// The inner form view's narrow Done bar is suppressed in landscape so only this
-        /// full-width version appears.
+        // Full-width Done toolbar rendered above the keyboard in landscape (documentCollection)
+        // mode. `ToolbarItemGroup(placement: .keyboard)` is the correct way to place content
+        // above the keyboard — `safeAreaInset` on the HStack would place it behind the keyboard
+        // because the outer container suppresses the keyboard safe area with `ignoresSafeArea`.
+        // The inner form view's narrow Done bar is suppressed in landscape so only this
+        // full-width version appears.
         .toolbar {
             ToolbarItemGroup(placement: .keyboard) {
                 if isLandscape && !viewModel.isBottomSheetMode && viewModel.isAmountFieldFocused {
@@ -93,10 +93,10 @@ public struct PaymentReviewContentView: View {
             }
         }
         .onAppear {
-            /// On iOS 16/17, rotating to landscape destroys portraitLayout which
-            /// dismisses the sheet and sets showBottomSheet to false. Restore it
-            /// when portraitLayout reappears in documentCollection mode.
-            /// Delay so the layout crossfade finishes before the sheet slides in.
+            // On iOS 16/17, rotating to landscape destroys portraitLayout which
+            // dismisses the sheet and sets showBottomSheet to false. Restore it
+            // when portraitLayout reappears in documentCollection mode.
+            // Delay so the layout crossfade finishes before the sheet slides in.
             if !viewModel.isBottomSheetMode && !showBottomSheet {
                 DispatchQueue.main.asyncAfter(deadline: .now() + Constants.layoutTransitionDuration) {
                     /// Re-check conditions in case the mode changed during the delay.

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/Views/PaymentReviewContentView.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/Views/PaymentReviewContentView.swift
@@ -36,6 +36,7 @@ public struct PaymentReviewContentView: View {
                     .transition(.opacity)
             }
         }
+        .ignoresSafeArea(.keyboard)
         .animation(.easeInOut(duration: Constants.layoutTransitionDuration), value: isLandscape)
         .onChange(of: isLandscape) { landscape in
             // When rotating to landscape in documentCollection mode, dismiss the

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/Views/PaymentReviewContentView.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/Views/PaymentReviewContentView.swift
@@ -14,7 +14,7 @@ public struct PaymentReviewContentView: View {
     @State private var bottomSheetHeight = Constants.bottomSheetDefaultHeight
     
     @Environment(\.accessibilityVoiceOverEnabled) private var isVoiceOverEnabled
-    @Environment(\.isLandscape) private var isLandscape
+    @Environment(\.giniLayout) private var giniLayout
     
     /**
      The init method is internal to prevent users from creating instances of this view directly
@@ -26,7 +26,7 @@ public struct PaymentReviewContentView: View {
     
     public var body: some View {
         GeometryReader { geometry in
-            if isLandscape && !viewModel.isBottomSheetMode {
+            if giniLayout.isLandscape && !viewModel.isBottomSheetMode {
                 landscapeLayout(geometry: geometry)
                     .transition(.opacity)
             } else {
@@ -35,8 +35,8 @@ public struct PaymentReviewContentView: View {
             }
         }
         .ignoresSafeArea(.keyboard)
-        .animation(.easeInOut(duration: Constants.layoutTransitionDuration), value: isLandscape)
-        .onChange(of: isLandscape) { landscape in
+        .animation(.easeInOut(duration: Constants.layoutTransitionDuration), value: giniLayout.isLandscape)
+        .onChange(of: giniLayout.isLandscape) { landscape in
             // When rotating to landscape in documentCollection mode, dismiss the
             // sheet immediately (without animation) so the crossfade transition
             // isn't disrupted by the sheet's own dismissal animation.
@@ -63,14 +63,14 @@ public struct PaymentReviewContentView: View {
         // full-width version appears.
         .toolbar {
             ToolbarItemGroup(placement: .keyboard) {
-                if isLandscape && !viewModel.isBottomSheetMode && viewModel.isAmountFieldFocused {
+                if giniLayout.isLandscape && !viewModel.isBottomSheetMode && viewModel.isAmountFieldFocused {
                     Spacer()
                     Button(viewModel.keyboardDoneButtonTitle) {
                         viewModel.trackKeyboardDismissed()
-                        UIApplication.shared.sendAction(
-                            #selector(UIResponder.resignFirstResponder),
-                            to: nil, from: nil, for: nil
-                        )
+                        UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder),
+                                                        to: nil,
+                                                        from: nil,
+                                                        for: nil)
                     }
                     .padding(.trailing, Constants.doneButtonHorizontalPadding)
                 }

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/Views/PaymentReviewContentView.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/Views/PaymentReviewContentView.swift
@@ -14,14 +14,12 @@ public struct PaymentReviewContentView: View {
     @State private var bottomSheetHeight = Constants.bottomSheetDefaultHeight
     
     @Environment(\.accessibilityVoiceOverEnabled) private var isVoiceOverEnabled
-    @Environment(\.verticalSizeClass) var verticalSizeClass
+    @Environment(\.isLandscape) private var isLandscape
     
-    private var isLandscape: Bool {
-        verticalSizeClass == .compact
-    }
-    
-    /// The init method is internal to prevent users from creating instances of this view directly
-    /// outside of GiniInternalPaymentSDK.
+    /**
+     The init method is internal to prevent users from creating instances of this view directly
+     outside of GiniInternalPaymentSDK.
+     */
     init(viewModel: PaymentReviewObservableModel) {
         self.viewModel = viewModel
     }
@@ -39,9 +37,9 @@ public struct PaymentReviewContentView: View {
         .ignoresSafeArea(.keyboard)
         .animation(.easeInOut(duration: Constants.layoutTransitionDuration), value: isLandscape)
         .onChange(of: isLandscape) { landscape in
-            // When rotating to landscape in documentCollection mode, dismiss the
-            // sheet immediately (without animation) so the crossfade transition
-            // isn't disrupted by the sheet's own dismissal animation.
+            /// When rotating to landscape in documentCollection mode, dismiss the
+            /// sheet immediately (without animation) so the crossfade transition
+            /// isn't disrupted by the sheet's own dismissal animation.
             if landscape && !viewModel.isBottomSheetMode && showBottomSheet {
                 showBottomSheet = false
             }
@@ -56,6 +54,27 @@ public struct PaymentReviewContentView: View {
         }
         .onAppear {
             viewModel.dismissBannerAfterDelay()
+        }
+        /// Full-width Done toolbar rendered above the keyboard in landscape (documentCollection)
+        /// mode. `ToolbarItemGroup(placement: .keyboard)` is the correct way to place content
+        /// above the keyboard — `safeAreaInset` on the HStack would place it behind the keyboard
+        /// because the outer container suppresses the keyboard safe area with `ignoresSafeArea`.
+        /// The inner form view's narrow Done bar is suppressed in landscape so only this
+        /// full-width version appears.
+        .toolbar {
+            ToolbarItemGroup(placement: .keyboard) {
+                if isLandscape && !viewModel.isBottomSheetMode && viewModel.isAmountFieldFocused {
+                    Spacer()
+                    Button(viewModel.keyboardDoneButtonTitle) {
+                        viewModel.trackKeyboardDismissed()
+                        UIApplication.shared.sendAction(
+                            #selector(UIResponder.resignFirstResponder),
+                            to: nil, from: nil, for: nil
+                        )
+                    }
+                    .padding(.trailing, Constants.doneButtonHorizontalPadding)
+                }
+            }
         }
     }
     
@@ -74,13 +93,13 @@ public struct PaymentReviewContentView: View {
             }
         }
         .onAppear {
-            // On iOS 16/17, rotating to landscape destroys portraitLayout which
-            // dismisses the sheet and sets showBottomSheet to false. Restore it
-            // when portraitLayout reappears in documentCollection mode.
-            // Delay so the layout crossfade finishes before the sheet slides in.
+            /// On iOS 16/17, rotating to landscape destroys portraitLayout which
+            /// dismisses the sheet and sets showBottomSheet to false. Restore it
+            /// when portraitLayout reappears in documentCollection mode.
+            /// Delay so the layout crossfade finishes before the sheet slides in.
             if !viewModel.isBottomSheetMode && !showBottomSheet {
                 DispatchQueue.main.asyncAfter(deadline: .now() + Constants.layoutTransitionDuration) {
-                    // Re-check conditions in case the mode changed during the delay.
+                    /// Re-check conditions in case the mode changed during the delay.
                     if !viewModel.isBottomSheetMode && !showBottomSheet {
                         showBottomSheet = true
                     }
@@ -201,5 +220,6 @@ public struct PaymentReviewContentView: View {
         static let landscapeContainerSpacing: CGFloat = 8.0
         static let paymentInformationContainerTopCornerRadius: CGFloat = 12.0
         static let paymentInformationContainerBottomCornerRadius: CGFloat = 6.0
+        static let doneButtonHorizontalPadding: CGFloat = 16.0
     }
 }

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/Views/PaymentReviewContentView.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/Views/PaymentReviewContentView.swift
@@ -99,7 +99,7 @@ public struct PaymentReviewContentView: View {
             // Delay so the layout crossfade finishes before the sheet slides in.
             if !viewModel.isBottomSheetMode && !showBottomSheet {
                 DispatchQueue.main.asyncAfter(deadline: .now() + Constants.layoutTransitionDuration) {
-                    /// Re-check conditions in case the mode changed during the delay.
+                    // Re-check conditions in case the mode changed during the delay.
                     if !viewModel.isBottomSheetMode && !showBottomSheet {
                         showBottomSheet = true
                     }

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/Views/TextField/GiniTextFieldStyle.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/Views/TextField/GiniTextFieldStyle.swift
@@ -67,7 +67,7 @@ struct GiniTextFieldStyle: TextFieldStyle {
                 configuration
                     .foregroundStyle(Color(currentConfiguration.textColor))
                     .font(Font(giniFont: currentConfiguration.textFont))
-                    .frame(height: Constants.textFieldHeight)
+                    .frame(minHeight: Constants.textFieldHeight)
                     .accessibilityLabel(title)
             }
             .padding(.horizontal, Constants.horizontalPadding)
@@ -99,8 +99,9 @@ struct GiniTextFieldStyle: TextFieldStyle {
     private var titleView: some View {
         HStack {
             Text(title)
+                .font(Font(giniFont: currentConfiguration.textFont))
                 .foregroundStyle(Color(currentConfiguration.placeholderForegroundColor))
-            
+
             if let lockedIcon {
                 lockedIcon
                     .resizable()
@@ -109,10 +110,11 @@ struct GiniTextFieldStyle: TextFieldStyle {
                            height: Constants.lockedIconSize.height)
                     .accessibilityHidden(true)
             }
-            
+
             Spacer()
         }
         .frame(maxWidth: .infinity, alignment: .leading)
+        .accessibilityHidden(true)
     }
     
     @ViewBuilder


### PR DESCRIPTION
## Pull Request Description
 
 This PR closes two issues in the payment review screen:
 
 **HEAL-333** – Layout broken with increased Dynamic Type font sizes  
 **HEAL-324** – Keyboard handling regressions in portrait and landscape
 
 ---
 
 ## HEAL-333 · Dynamic Type layout fix
 
 The form's scroll view was not resizing correctly when the user had a
 large accessibility font size active. The landscape split view clipped
 content and the portrait bottom sheet could overflow its container.
 
 **Fix:** The `ScrollView` / content layout is now sized from the
 available geometry rather than from fixed content-height assumptions,
 so it adapts correctly across all Dynamic Type sizes in both
 orientations.
 
 ---
 
 ## HEAL-324 · Keyboard handling
 
 ### Bottom sheet snap in portrait
 The sheet had both a `.height(contentHeight)` and a `.large` detent.
 iOS auto-snapped to `.large` (full screen) whenever the keyboard
 appeared. Removed `.large`; the inner `ScrollView` scrolls to keep
 the focused field visible instead.
 
 ### "Done" button for the amount field
 `decimalPad` has no Return key, so the amount field always needs an
 explicit dismiss button.
 
 - **Portrait:** a 44 pt "Done" bar is injected via `safeAreaInset` at
   the bottom of the form's `ScrollView`, sitting just above the
   keyboard.
 - **Landscape:** `ToolbarItemGroup(placement: .keyboard)` is attached
   to `PaymentReviewContentView` so the button spans the full keyboard
   width. `safeAreaInset` on the outer `HStack` was tried first but
   renders behind the keyboard because the parent suppresses the
   keyboard safe area with `ignoresSafeArea`; `placement: .keyboard`
   hooks into UIKit's `inputAccessoryView` and always renders above it.
 
 ### Scroll content above the keyboard in landscape
 In landscape the form is an inline panel, not a sheet, so iOS does not
 automatically reposition it. Keyboard height is now tracked via
 `keyboardWillShow/Hide` notifications and re-injected as a
 `safeAreaInset` spacer, giving the `ScrollView` enough bottom inset to
 scroll every field (including the Pay button) above the keyboard.
 
 ### Rotation-safe focus restoration
 Rotating the device destroys and recreates the SwiftUI view. To
 preserve the open keyboard across rotations:
 - `activeField` in the observable model remembers which field was
   focused.
 - `isViewVisible` toggles on `onAppear`/`onDisappear`.
 - When `focusedField` becomes `nil` a 0.1 s async check decides:
   view still visible → user dismissed → clear `activeField`;
   view gone → rotation → keep `activeField`.
 - The new layout's `onAppear` calls `restoreFocusIfNeeded()` after a
   0.4 s delay (enough for the orientation crossfade to complete).
 
 ### Fix: keyboard reopening after Done + rotation
 If the user tapped Done and immediately rotated, the 0.1 s timer fired
 after the view had already disappeared, so `isViewVisible` was `false`
 and `activeField` was preserved — causing the keyboard to reopen in the
 new layout. `trackKeyboardDismissed()` now clears `activeField`
 synchronously on the Done tap, winning the race. Both the portrait and
 landscape Done button paths route through this method.
 
 ---
 
 ## Cleanup
 
 - Extracted `isLandscape` into `EnvironmentValues+Landscape.swift`,
   removing the duplicated `verticalSizeClass == .compact` computed
   property from both views.
 - Removed unreachable `#available(iOS 15/14)` guards; the package
   minimum is iOS 16.
 - Standardised comment style: `/** … */` for declaration docs, `//`
   for inline comments.
