### PR TITLE
fix(GiniInternalPaymentSDK):  Apply Dynamic Type runtime response to PaymentInfoViewController section labels

### DIFF
--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentInfo/PaymentInfoViewController.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentInfo/PaymentInfoViewController.swift
@@ -69,6 +69,7 @@ public final class PaymentInfoViewController: GiniBottomSheetViewController {
         paragraphStyle.lineHeightMultiple = Constants.payBillsTitleLineHeight
         label.attributedText = NSMutableAttributedString(string: viewModel.strings.payBillsTitleText,
                                                          attributes: [NSAttributedString.Key.paragraphStyle: paragraphStyle])
+        label.adjustsFontForContentSizeCategory = true
         return label
     }()
     
@@ -98,6 +99,7 @@ public final class PaymentInfoViewController: GiniBottomSheetViewController {
         paragraphStyle.lineHeightMultiple = Constants.questionsTitleLineHeight
         label.attributedText = NSMutableAttributedString(string: viewModel.strings.questionsTitleText,
                                                          attributes: [NSAttributedString.Key.paragraphStyle: paragraphStyle])
+        label.adjustsFontForContentSizeCategory = true
         return label
     }()
     


### PR DESCRIPTION
Add dynamic type support PaymentInfoViewController section labels

HEAL-327

