### PR TITLE
Fix layout on ShareWIthScreen when dynamic font is on 

### DIFF
--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/ShareInvoice/ShareInvoiceBottomView.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/ShareInvoice/ShareInvoiceBottomView.swift
@@ -377,7 +377,7 @@ public final class ShareInvoiceBottomView: GiniBottomSheetViewController {
         NSLayoutConstraint.activate([
             continueButton.leadingAnchor.constraint(equalTo: continueView.leadingAnchor, constant: Constants.viewPaddingConstraint),
             continueButton.trailingAnchor.constraint(equalTo: continueView.trailingAnchor, constant: -Constants.viewPaddingConstraint),
-            continueButton.heightAnchor.constraint(equalToConstant: Constants.continueButtonViewHeight),
+            continueButton.heightAnchor.constraint(greaterThanOrEqualToConstant: Constants.continueButtonViewHeight),
             continueButton.topAnchor.constraint(equalTo: continueView.topAnchor, constant: Constants.topBottomPaddingConstraint),
             continueButton.bottomAnchor.constraint(equalTo: continueView.bottomAnchor)
         ])


### PR DESCRIPTION
Fix truncated "Share with [Bank]" button text when Dynamic Type is enabled on the QR payment share screen.
                                                                                                                                            
  [HEAL-335]                                                
                                                                                                                                            
  The continueButton in ShareInvoiceBottomView had a fixed height constraint of 56pt. With large Dynamic Type sizes the label text could not grow beyond that height, causing it to be clipped (e.g. "Share with Gi…"). Changed the constraint from equalToConstant to greaterThanOrEqualToConstant so the button height is driven by its label content at any font size, while still respecting the 56pt minimum at default sizes. No layout refactoring was needed — the label already had numberOfLines = 0 and adjustsFontForContentSizeCategory = true.

  Notes for Reviewers

  How to verify:
  1. On a simulator or device, go to Settings → Accessibility → Display & Text Size → Larger Text and drag the slider to the largest
  accessibility size.                                                                                                                       
  2. Open the QR payment share bottom sheet (the screen that shows "Share this QR payment code with your banking app").
  3. Observe the "Share with [Bank Name]" button — text should wrap and the button should grow taller instead of truncating.                
                                                                                                                                            
  - Tested on: iPhone 16 Pro simulator                                                                                                      
  - iOS versions: 18.x                                                                                                                      
  - No unit tests required — pure layout constraint change.                                                                                 
                                                                                                                                            
  Before: Button clipped to 56pt height → "Share with Gi…"                                                                                  
  After: Button grows to fit full text at all Dynamic Type sizes.                                                                           
                                                                          

[HEAL-335]: https://ginis.atlassian.net/browse/HEAL-335?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ