### PR TITLE
Fix Bank Selection Bottom Sheet (proceed to the overview button)  to support Dynamic Type

### DIFF
--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentComponents/PaymentComponentView.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentComponents/PaymentComponentView.swift
@@ -184,7 +184,7 @@ public final class PaymentComponentView: UIView {
             buttonsStackView.trailingAnchor.constraint(equalTo: buttonsView.trailingAnchor),
             buttonsStackView.topAnchor.constraint(equalTo: buttonsView.topAnchor, constant: Constants.buttonsTopBottomSpacing),
             buttonsStackView.bottomAnchor.constraint(equalTo: buttonsView.bottomAnchor, constant: -Constants.buttonsTopBottomSpacing),
-            payInvoiceButton.heightAnchor.constraint(equalToConstant: viewModel.minimumButtonsHeight)
+            payInvoiceButton.heightAnchor.constraint(greaterThanOrEqualToConstant: viewModel.minimumButtonsHeight)
         ])
     }
     


### PR DESCRIPTION

HEAL-334

## Pull Request Description

  Fix truncated "Continue to [Bank]" button text on the Bank Selection / Payment Component screen when Dynamic Type is enabled. The  payInvoiceButton had a fixed height constraint equal to minimumButtonsHeight, preventing the button from growing when large font sizes  were active, causing the label to be clipped.                                                                                             
                                                                                                                                                                                                                                                                                  Changed equalToConstant → greaterThanOrEqualToConstant on the payInvoiceButton height constraint in PaymentComponentView. The button now  grows to fit its label content at any font size while respecting the minimum height at default sizes. No refactoring needed                                                                                                                                                                                                                                                                        PaymentPrimaryButton already had numberOfLines = 0 and adjustsFontForContentSizeCategory = true on its label, so wrapping works out of the
   box. Note: selectBankButton already used greaterThanOrEqualToConstant, so only the pay button needed this fix.                           
                                                                                                                                            
  Notes for Reviewers                                                                                                                       
                                                                                                                                            
  How to verify:                                                                                                                            
  1. Go to Settings → Accessibility → Display & Text Size → Larger Text, drag to the largest accessibility size.
  2. Open the Payment Component bottom sheet (the screen showing "Select your bank to pay" with the bank picker and "Continue to…" button). 
  3. Select a bank — the "Continue to [Bank]" button should appear with fully visible, wrapped text instead of being clipped.              
                                                                                                                                            
  - Tested on: iPhone 16 Pro simulator                                                                                                      
  - iOS versions: 18.x                                                                                                                      
  - No unit tests required — pure layout constraint change.                                                                                 
                                                                                                                                            
  Before: Button clipped at fixed height → "Continue t…"                                                                                    
  After: Button grows to fit full label text at all Dynamic Type sizes.  