### PR TITLE
Fix/heal 336 unresponsive payment review

### DIFF
--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/GiniOverlayWindowPresenter.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/GiniOverlayWindowPresenter.swift
@@ -93,6 +93,20 @@ final class GiniOverlayWindowPresenter {
 }
 
 /**
+ A UIView subclass that passes touches through when nothing meaningful is hit.
+
+ When no presented sheet is covering the screen, `hitTest` returns `nil` so that
+ touch events fall through to the underlying main window instead of being silently
+ consumed by the transparent overlay window.
+ */
+private final class GiniPassthroughView: UIView {
+    override func hitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {
+        let hitView = super.hitTest(point, with: event)
+        return hitView === self ? nil : hitView
+    }
+}
+
+/**
  A transparent VC that serves as the rootViewController of the overlay window.
  Detects when the presented VC is dismissed (by close button or swipe) and
  calls the onDismiss callback to tear down the overlay window.
@@ -111,6 +125,10 @@ private final class GiniPassthroughViewController: UIViewController, UIAdaptiveP
     
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func loadView() {
+        view = GiniPassthroughView()
     }
     
     override func viewDidLoad() {

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/GiniOverlayWindowPresenter.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/GiniOverlayWindowPresenter.swift
@@ -99,7 +99,7 @@ final class GiniOverlayWindowPresenter {
  touch events fall through to the underlying main window instead of being silently
  consumed by the transparent overlay window.
  */
-private final class GiniPassthroughView: UIView {
+final class GiniPassthroughView: UIView {
     override func hitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {
         let hitView = super.hitTest(point, with: event)
         return hitView === self ? nil : hitView

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Tests/GiniInternalPaymentSDKTests/GiniPassthroughViewTests.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Tests/GiniInternalPaymentSDKTests/GiniPassthroughViewTests.swift
@@ -1,0 +1,58 @@
+//
+//  GiniPassthroughViewTests.swift
+//  GiniInternalPaymentSDKTests
+//
+//  Copyright © 2026 Gini GmbH. All rights reserved.
+
+import Testing
+import UIKit
+@testable import GiniInternalPaymentSDK
+
+@Suite("GiniPassthroughView — hitTest regression guard (HEAL-336)")
+@MainActor
+struct GiniPassthroughViewTests {
+
+    // MARK: - Pass-through
+
+    /// Tapping on the transparent background of the passthrough view must return
+    /// `nil` so the touch falls through to the main window below the overlay.
+    @Test("Returns nil when the hit view is the passthrough view itself")
+    func hitTestReturnsNilForBackground() {
+        let view = GiniPassthroughView(frame: CGRect(x: 0, y: 0, width: 200, height: 200))
+        let result = view.hitTest(CGPoint(x: 100, y: 100), with: nil)
+
+        #expect(result == nil,
+                "hitTest must return nil for the background so touches fall through to the main window")
+    }
+
+    // MARK: - Subview forwarding
+
+    /// Tapping on a subview (e.g. a presented bottom sheet) must return that
+    /// subview so the touch is delivered normally to the sheet's controls.
+    @Test("Returns the subview when a subview is hit")
+    func hitTestReturnsSubviewWhenHit() {
+        let view = GiniPassthroughView(frame: CGRect(x: 0, y: 0, width: 200, height: 200))
+        let subview = UIView(frame: CGRect(x: 50, y: 50, width: 100, height: 100))
+        view.addSubview(subview)
+
+        let result = view.hitTest(CGPoint(x: 100, y: 100), with: nil)
+
+        #expect(result === subview,
+                "hitTest must return the subview so touches on presented content are handled normally")
+    }
+
+    /// A point outside all subviews but still inside the passthrough view must
+    /// still return nil, confirming the background-passthrough behaviour holds
+    /// even when subviews are present.
+    @Test("Returns nil for background area when subviews are present")
+    func hitTestReturnsNilForBackgroundWhenSubviewsPresent() {
+        let view = GiniPassthroughView(frame: CGRect(x: 0, y: 0, width: 200, height: 200))
+        let subview = UIView(frame: CGRect(x: 50, y: 50, width: 100, height: 100))
+        view.addSubview(subview)
+
+        let result = view.hitTest(CGPoint(x: 10, y: 10), with: nil)
+
+        #expect(result == nil,
+                "hitTest must return nil for background areas even when subviews are present")
+    }
+}


### PR DESCRIPTION
## Pull Request Description

After dismissing the bank selection sheet, the payment review screen intermittently became unresponsive to all touch input. The overlay   
  UIWindow (at windowLevel = .normal + 1) remained visible for one run loop cycle after dismissal — necessary to avoid a UIKit crash
  mid-transition — but its root view was a plain UIView that silently consumed all touches during that gap.                                 
                                                            
  How

  Introduced GiniPassthroughView, a UIView subclass that overrides hitTest(_:with:) to return nil when the hit view is its own background,  
  letting touches fall through to the main window. Touches on the presented sheet resolve to subviews and are unaffected. Set as the root
  view of GiniPassthroughViewController via loadView().                                                                                     
                                                            
  Notes for Reviewers

  How to verify:                                                                                                                            
  1. Open the Payment Review screen.
  2. Tap the bank selector button.                                                                                                          
  3. Select a different bank from the list and dismiss the sheet.
  4. Interact with any button on the payment review screen.      
                                                                                                                                            
  Before: Screen fully unresponsive after dismissal, no console output.                                                                     
  After: All buttons respond normally.                                                                                                      
                                                                                                                                            
  The fix is one small class — no logic changes to presentation or teardown. The deferred window.isHidden = true in tearDown() is           
  intentionally kept to prevent EXC_BAD_ACCESS mid-transition; GiniPassthroughView handles the touch side effect of that deferral.
  
  [HEAL-336](https://ginis.atlassian.net/browse/HEAL-336)

[HEAL-336]: https://ginis.atlassian.net/browse/HEAL-336?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ