### PR TITLE
Increase test coverage

### DIFF
--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentInfo/PaymentInfoViewModel.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentInfo/PaymentInfoViewModel.swift
@@ -55,7 +55,7 @@ public final class PaymentInfoViewModel {
     }
     
     private func setupQuestions() {
-        for index in 0 ... strings.questions.count-1 {
+        for index in strings.questions.indices {
             let answerAttributedString = answerWithAttributes(answer: strings.answers[index])
             let questionSection = FAQSection(title: strings.questions[index],
                                              description: textWithLinks(linkFont: configuration.linksFont, attributedString: answerAttributedString),

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentInfo/PaymentInfoViewModel.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentInfo/PaymentInfoViewModel.swift
@@ -55,12 +55,11 @@ public final class PaymentInfoViewModel {
     }
     
     private func setupQuestions() {
-        for index in strings.questions.indices {
-            let answerAttributedString = answerWithAttributes(answer: strings.answers[index])
-            let questionSection = FAQSection(title: strings.questions[index],
-                                             description: textWithLinks(linkFont: configuration.linksFont, attributedString: answerAttributedString),
-                                             isExtended: false)
-            questions.append(questionSection)
+        questions = zip(strings.questions, strings.answers).map { question, answer in
+            let answerAttributedString = answerWithAttributes(answer: answer)
+            return FAQSection(title: question,
+                              description: textWithLinks(linkFont: configuration.linksFont, attributedString: answerAttributedString),
+                              isExtended: false)
         }
     }
     

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Tests/GiniInternalPaymentSDKTests/AccessibilityTests.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Tests/GiniInternalPaymentSDKTests/AccessibilityTests.swift
@@ -17,66 +17,6 @@ import Testing
 import UIKit
 @testable import GiniInternalPaymentSDK
 
-// MARK: - Test factories
-
-private extension InstallAppConfiguration {
-    static var test: InstallAppConfiguration {
-        InstallAppConfiguration(titleAccentColor: .label,
-                                titleFont: .systemFont(ofSize: 18, weight: .bold),
-                                moreInformationFont: .systemFont(ofSize: 14),
-                                moreInformationTextColor: .label,
-                                moreInformationAccentColor: .systemBlue,
-                                moreInformationIcon: UIImage(),
-                                appStoreIcon: UIImage(),
-                                bankIconBorderColor: .systemGray4,
-                                closeIcon: UIImage(),
-                                closeIconAccentColor: .label)
-    }
-}
-
-private extension InstallAppStrings {
-    static var test: InstallAppStrings {
-        InstallAppStrings(titlePattern: "Install [BANK]",
-                          moreInformationTipPattern: "Tip: open [BANK]",
-                          moreInformationNotePattern: "Note: install [BANK]",
-                          continueLabelText: "Continue",
-                          accessibilityAppStoreText: "App Store",
-                          accessibilityBankLogoText: "Bank logo",
-                          accessibilityCloseIconText: "Close")
-    }
-}
-
-private extension ShareInvoiceConfiguration {
-    static var test: ShareInvoiceConfiguration {
-        ShareInvoiceConfiguration(titleFont: .systemFont(ofSize: 18, weight: .bold),
-                                  titleAccentColor: .label,
-                                  descriptionFont: .systemFont(ofSize: 14),
-                                  descriptionTextColor: .label,
-                                  descriptionAccentColor: .systemBlue,
-                                  paymentInfoBorderColor: .systemGray4,
-                                  titlePaymentInfoTextColor: .label,
-                                  subtitlePaymentInfoTextColor: .secondaryLabel,
-                                  titlepaymentInfoFont: .systemFont(ofSize: 14, weight: .semibold),
-                                  subtitlePaymentInfoFont: .systemFont(ofSize: 12),
-                                  closeIcon: UIImage(),
-                                  closeIconAccentColor: .label)
-    }
-}
-
-private extension ShareInvoiceStrings {
-    static var test: ShareInvoiceStrings {
-        ShareInvoiceStrings(continueLabelText: "Continue",
-                            titleTextPattern: "Share invoice with [BANK]",
-                            descriptionTextPattern: "Description for [BANK]",
-                            recipientLabelText: "Recipient",
-                            amountLabelText: "Amount",
-                            ibanLabelText: "IBAN",
-                            purposeLabelText: "Purpose",
-                            accessibilityQRCodeImageText: "QR code",
-                            accessibilityCloseIconText: "Close")
-    }
-}
-
 // MARK: - View controller factories
 
 private func makeInstallAppBottomView() -> InstallAppBottomView {

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Tests/GiniInternalPaymentSDKTests/BanksBottomViewModelTests.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Tests/GiniInternalPaymentSDKTests/BanksBottomViewModelTests.swift
@@ -131,10 +131,10 @@ struct BanksBottomViewModelTests {
 
     @Test("shouldShowBrandedView is true for paymentComponent and fullVisible, false for invisible",
           arguments: zip(
-            [IngredientBrandTypeEnum.paymentComponent, .fullVisible, .invisible],
+            [GiniHealthAPILibrary.IngredientBrandTypeEnum.paymentComponent, .fullVisible, .invisible],
             [true, true, false]
           ))
-    func shouldShowBrandedView(brandType: IngredientBrandTypeEnum, expected: Bool) {
+    func shouldShowBrandedView(brandType: GiniHealthAPILibrary.IngredientBrandTypeEnum, expected: Bool) {
         let sut = makeSUT(clientConfiguration: .test(ingredientBrandType: brandType))
 
         #expect(sut.shouldShowBrandedView == expected,
@@ -161,7 +161,7 @@ struct BanksBottomViewModelTests {
         }
         let cellModel = sut.paymentProvidersViewModel(paymentProvider: entry)
 
-        #expect(cellModel.paymentProvider.paymentProvider.name == "My Bank",
+        #expect(cellModel.bankName == "My Bank",
                 "Cell model must expose the payment provider's name")
     }
 

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Tests/GiniInternalPaymentSDKTests/BanksBottomViewModelTests.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Tests/GiniInternalPaymentSDKTests/BanksBottomViewModelTests.swift
@@ -17,7 +17,7 @@ struct BanksBottomViewModelTests {
 
     // MARK: - Helpers
 
-    private func makeSUT(providers: [PaymentProvider] = [.stub()],
+    private func makeSUT(providers: [PaymentProvider] = [.fixture()],
                          selectedProvider: PaymentProvider? = nil,
                          urlOpener: MockURLOpener = MockURLOpener(),
                          clientConfiguration: ClientConfiguration? = nil) -> BanksBottomViewModel {
@@ -39,7 +39,7 @@ struct BanksBottomViewModelTests {
 
     @Test("Filters out android-only providers with no iOS platform support")
     func androidOnlyProviderIsExcluded() {
-        let androidOnly = PaymentProvider.stub(id: "android-only",
+        let androidOnly = PaymentProvider.fixture(id: "android-only",
                                                gpcSupportedPlatforms: [.android],
                                                openWithSupportedPlatforms: [])
         let sut = makeSUT(providers: [androidOnly])
@@ -50,7 +50,7 @@ struct BanksBottomViewModelTests {
 
     @Test("Includes provider with iOS in gpcSupportedPlatforms")
     func gpcIosProviderIsIncluded() {
-        let provider = PaymentProvider.stub(gpcSupportedPlatforms: [.ios])
+        let provider = PaymentProvider.fixture(gpcSupportedPlatforms: [.ios])
         let sut = makeSUT(providers: [provider])
 
         #expect(sut.paymentProviders.count == 1,
@@ -59,7 +59,7 @@ struct BanksBottomViewModelTests {
 
     @Test("Includes provider with iOS in openWithSupportedPlatforms")
     func openWithIosProviderIsIncluded() {
-        let provider = PaymentProvider.stub(gpcSupportedPlatforms: [],
+        let provider = PaymentProvider.fixture(gpcSupportedPlatforms: [],
                                             openWithSupportedPlatforms: [.ios])
         let sut = makeSUT(providers: [provider])
 
@@ -71,8 +71,8 @@ struct BanksBottomViewModelTests {
 
     @Test("Duplicate provider ids produce a single entry")
     func duplicateIdsAreDeduped() {
-        let p1 = PaymentProvider.stub(id: "same-id", name: "Bank A")
-        let p2 = PaymentProvider.stub(id: "same-id", name: "Bank B")
+        let p1 = PaymentProvider.fixture(id: "same-id", name: "Bank A")
+        let p2 = PaymentProvider.fixture(id: "same-id", name: "Bank B")
         let sut = makeSUT(providers: [p1, p2])
 
         #expect(sut.paymentProviders.count == 1,
@@ -83,10 +83,10 @@ struct BanksBottomViewModelTests {
 
     @Test("Installed provider appears before uninstalled provider")
     func installedProviderSortsFirst() {
-        let installed = PaymentProvider.stub(id: "installed",
+        let installed = PaymentProvider.fixture(id: "installed",
                                              name: "Installed Bank",
                                              appSchemeIOS: "installedbank://")
-        let notInstalled = PaymentProvider.stub(id: "not-installed",
+        let notInstalled = PaymentProvider.fixture(id: "not-installed",
                                                 name: "Not Installed",
                                                 appSchemeIOS: "notinstalled://")
         let mockOpener = MockURLOpener(installedScheme: "installedbank")
@@ -98,8 +98,8 @@ struct BanksBottomViewModelTests {
 
     @Test("Among uninstalled providers, lower index sorts first")
     func lowerIndexSortsFirst() {
-        let high = PaymentProvider.stub(id: "high", index: 5)
-        let low = PaymentProvider.stub(id: "low", index: 1)
+        let high = PaymentProvider.fixture(id: "high", index: 5)
+        let low = PaymentProvider.fixture(id: "low", index: 1)
         let sut = makeSUT(providers: [high, low])
 
         #expect(sut.paymentProviders.first?.paymentProvider.id == "low",
@@ -110,7 +110,7 @@ struct BanksBottomViewModelTests {
 
     @Test("Provider matching selectedPaymentProvider is marked isSelected")
     func selectedProviderIsMarked() {
-        let selected = PaymentProvider.stub(id: "selected-id")
+        let selected = PaymentProvider.fixture(id: "selected-id")
         let sut = makeSUT(providers: [selected], selectedProvider: selected)
 
         #expect(sut.paymentProviders.first?.isSelected == true,
@@ -119,8 +119,8 @@ struct BanksBottomViewModelTests {
 
     @Test("Provider not matching selectedPaymentProvider has isSelected = false")
     func nonSelectedProviderIsNotMarked() {
-        let provider = PaymentProvider.stub(id: "other-id")
-        let selected = PaymentProvider.stub(id: "selected-id")
+        let provider = PaymentProvider.fixture(id: "other-id")
+        let selected = PaymentProvider.fixture(id: "selected-id")
         let sut = makeSUT(providers: [provider], selectedProvider: selected)
 
         #expect(sut.paymentProviders.first?.isSelected == false,
@@ -153,7 +153,7 @@ struct BanksBottomViewModelTests {
 
     @Test("paymentProvidersViewModel exposes the payment provider name")
     func paymentProvidersViewModelBankName() {
-        let provider = PaymentProvider.stub(name: "My Bank")
+        let provider = PaymentProvider.fixture(name: "My Bank")
         let sut = makeSUT(providers: [provider])
         guard let entry = sut.paymentProviders.first else {
             Issue.record("paymentProviders must not be empty")

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Tests/GiniInternalPaymentSDKTests/BanksBottomViewModelTests.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Tests/GiniInternalPaymentSDKTests/BanksBottomViewModelTests.swift
@@ -19,7 +19,7 @@ struct BanksBottomViewModelTests {
 
     private func makeSUT(providers: [PaymentProvider] = [.make()],
                          selectedProvider: PaymentProvider? = nil,
-                         urlOpener: MockURLOpenerProtocol = MockURLOpenerProtocol(),
+                         urlOpener: MockURLOpener = MockURLOpener(),
                          clientConfiguration: ClientConfiguration? = nil) -> BanksBottomViewModel {
         BanksBottomViewModel(paymentProviders: providers,
                              selectedPaymentProvider: selectedProvider,
@@ -89,7 +89,7 @@ struct BanksBottomViewModelTests {
         let notInstalled = PaymentProvider.make(id: "not-installed",
                                                 name: "Not Installed",
                                                 appSchemeIOS: "notinstalled://")
-        let mockOpener = MockURLOpenerProtocol(installedScheme: "installedbank")
+        let mockOpener = MockURLOpener(installedScheme: "installedbank")
         let sut = makeSUT(providers: [notInstalled, installed], urlOpener: mockOpener)
 
         #expect(sut.paymentProviders.first?.paymentProvider.id == "installed",

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Tests/GiniInternalPaymentSDKTests/BanksBottomViewModelTests.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Tests/GiniInternalPaymentSDKTests/BanksBottomViewModelTests.swift
@@ -1,0 +1,181 @@
+//
+//  BanksBottomViewModelTests.swift
+//  GiniInternalPaymentSDKTests
+//
+//  Copyright © 2026 Gini GmbH. All rights reserved.
+//
+
+import Testing
+import UIKit
+import GiniHealthAPILibrary
+import GiniUtilites
+@testable import GiniInternalPaymentSDK
+
+@Suite("BanksBottomViewModel")
+@MainActor
+struct BanksBottomViewModelTests {
+
+    // MARK: - Helpers
+
+    private func makeSUT(providers: [PaymentProvider] = [.make()],
+                         selectedProvider: PaymentProvider? = nil,
+                         urlOpener: MockURLOpenerProtocol = MockURLOpenerProtocol(),
+                         clientConfiguration: ClientConfiguration? = nil) -> BanksBottomViewModel {
+        BanksBottomViewModel(paymentProviders: providers,
+                             selectedPaymentProvider: selectedProvider,
+                             configuration: .test,
+                             strings: .test,
+                             poweredByGiniConfiguration: .test,
+                             poweredByGiniStrings: .test,
+                             moreInformationConfiguration: .test,
+                             moreInformationStrings: .test,
+                             paymentInfoConfiguration: .test,
+                             paymentInfoStrings: .test,
+                             urlOpener: URLOpener(urlOpener),
+                             clientConfiguration: clientConfiguration)
+    }
+
+    // MARK: - Filtering
+
+    @Test("Filters out android-only providers with no iOS platform support")
+    func androidOnlyProviderIsExcluded() {
+        let androidOnly = PaymentProvider.make(id: "android-only",
+                                               gpcSupportedPlatforms: [.android],
+                                               openWithSupportedPlatforms: [])
+        let sut = makeSUT(providers: [androidOnly])
+
+        #expect(sut.paymentProviders.isEmpty,
+                "Provider with no iOS platform support must be excluded from the list")
+    }
+
+    @Test("Includes provider with iOS in gpcSupportedPlatforms")
+    func gpcIosProviderIsIncluded() {
+        let provider = PaymentProvider.make(gpcSupportedPlatforms: [.ios])
+        let sut = makeSUT(providers: [provider])
+
+        #expect(sut.paymentProviders.count == 1,
+                "Provider with iOS in gpcSupportedPlatforms must be included")
+    }
+
+    @Test("Includes provider with iOS in openWithSupportedPlatforms")
+    func openWithIosProviderIsIncluded() {
+        let provider = PaymentProvider.make(gpcSupportedPlatforms: [],
+                                            openWithSupportedPlatforms: [.ios])
+        let sut = makeSUT(providers: [provider])
+
+        #expect(sut.paymentProviders.count == 1,
+                "Provider with iOS in openWithSupportedPlatforms must be included")
+    }
+
+    // MARK: - Deduplication
+
+    @Test("Duplicate provider ids produce a single entry")
+    func duplicateIdsAreDeduped() {
+        let p1 = PaymentProvider.make(id: "same-id", name: "Bank A")
+        let p2 = PaymentProvider.make(id: "same-id", name: "Bank B")
+        let sut = makeSUT(providers: [p1, p2])
+
+        #expect(sut.paymentProviders.count == 1,
+                "Duplicate provider ids must be deduplicated to a single entry")
+    }
+
+    // MARK: - Sorting
+
+    @Test("Installed provider appears before uninstalled provider")
+    func installedProviderSortsFirst() {
+        let installed = PaymentProvider.make(id: "installed",
+                                             name: "Installed Bank",
+                                             appSchemeIOS: "installedbank://")
+        let notInstalled = PaymentProvider.make(id: "not-installed",
+                                                name: "Not Installed",
+                                                appSchemeIOS: "notinstalled://")
+        let mockOpener = MockURLOpenerProtocol(installedScheme: "installedbank")
+        let sut = makeSUT(providers: [notInstalled, installed], urlOpener: mockOpener)
+
+        #expect(sut.paymentProviders.first?.paymentProvider.id == "installed",
+                "Installed provider must sort before uninstalled provider")
+    }
+
+    @Test("Among uninstalled providers, lower index sorts first")
+    func lowerIndexSortsFirst() {
+        let high = PaymentProvider.make(id: "high", index: 5)
+        let low = PaymentProvider.make(id: "low", index: 1)
+        let sut = makeSUT(providers: [high, low])
+
+        #expect(sut.paymentProviders.first?.paymentProvider.id == "low",
+                "Among equally uninstalled providers, lower index must sort first")
+    }
+
+    // MARK: - Selection state
+
+    @Test("Provider matching selectedPaymentProvider is marked isSelected")
+    func selectedProviderIsMarked() {
+        let selected = PaymentProvider.make(id: "selected-id")
+        let sut = makeSUT(providers: [selected], selectedProvider: selected)
+
+        #expect(sut.paymentProviders.first?.isSelected == true,
+                "Provider whose id matches selectedPaymentProvider must have isSelected = true")
+    }
+
+    @Test("Provider not matching selectedPaymentProvider has isSelected = false")
+    func nonSelectedProviderIsNotMarked() {
+        let provider = PaymentProvider.make(id: "other-id")
+        let selected = PaymentProvider.make(id: "selected-id")
+        let sut = makeSUT(providers: [provider], selectedProvider: selected)
+
+        #expect(sut.paymentProviders.first?.isSelected == false,
+                "Provider whose id does not match selectedPaymentProvider must have isSelected = false")
+    }
+
+    // MARK: - shouldShowBrandedView
+
+    @Test("shouldShowBrandedView is true for paymentComponent and fullVisible, false for invisible",
+          arguments: zip(
+            [IngredientBrandTypeEnum.paymentComponent, .fullVisible, .invisible],
+            [true, true, false]
+          ))
+    func shouldShowBrandedView(brandType: IngredientBrandTypeEnum, expected: Bool) {
+        let sut = makeSUT(clientConfiguration: .test(ingredientBrandType: brandType))
+
+        #expect(sut.shouldShowBrandedView == expected,
+                "shouldShowBrandedView must be \(expected) for brandType \(brandType)")
+    }
+
+    @Test("shouldShowBrandedView is false when clientConfiguration is nil")
+    func shouldShowBrandedViewNilConfig() {
+        let sut = makeSUT(clientConfiguration: nil)
+
+        #expect(sut.shouldShowBrandedView == false,
+                "shouldShowBrandedView must be false when clientConfiguration is nil")
+    }
+
+    // MARK: - paymentProvidersViewModel
+
+    @Test("paymentProvidersViewModel exposes the payment provider name")
+    func paymentProvidersViewModelBankName() {
+        let provider = PaymentProvider.make(name: "My Bank")
+        let sut = makeSUT(providers: [provider])
+        guard let entry = sut.paymentProviders.first else {
+            Issue.record("paymentProviders must not be empty")
+            return
+        }
+        let cellModel = sut.paymentProvidersViewModel(paymentProvider: entry)
+
+        #expect(cellModel.paymentProvider.paymentProvider.name == "My Bank",
+                "Cell model must expose the payment provider's name")
+    }
+
+    // MARK: - Delegate forwarding
+
+    @Test("didTapOnClose forwards the tap to viewDelegate")
+    func didTapOnCloseNotifiesDelegate() {
+        let sut = makeSUT()
+        let delegate = MockBanksSelectionDelegate()
+        sut.viewDelegate = delegate
+
+        sut.didTapOnClose()
+
+        #expect(delegate.didTapCloseCalled == true,
+                "didTapOnClose must call didTapOnClose on viewDelegate")
+    }
+}

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Tests/GiniInternalPaymentSDKTests/BanksBottomViewModelTests.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Tests/GiniInternalPaymentSDKTests/BanksBottomViewModelTests.swift
@@ -40,8 +40,8 @@ struct BanksBottomViewModelTests {
     @Test("Filters out android-only providers with no iOS platform support")
     func androidOnlyProviderIsExcluded() {
         let androidOnly = PaymentProvider.fixture(id: "android-only",
-                                               gpcSupportedPlatforms: [.android],
-                                               openWithSupportedPlatforms: [])
+                                                  gpcSupportedPlatforms: [.android],
+                                                  openWithSupportedPlatforms: [])
         let sut = makeSUT(providers: [androidOnly])
 
         #expect(sut.paymentProviders.isEmpty,
@@ -60,7 +60,7 @@ struct BanksBottomViewModelTests {
     @Test("Includes provider with iOS in openWithSupportedPlatforms")
     func openWithIosProviderIsIncluded() {
         let provider = PaymentProvider.fixture(gpcSupportedPlatforms: [],
-                                            openWithSupportedPlatforms: [.ios])
+                                               openWithSupportedPlatforms: [.ios])
         let sut = makeSUT(providers: [provider])
 
         #expect(sut.paymentProviders.count == 1,

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Tests/GiniInternalPaymentSDKTests/BanksBottomViewModelTests.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Tests/GiniInternalPaymentSDKTests/BanksBottomViewModelTests.swift
@@ -152,13 +152,11 @@ struct BanksBottomViewModelTests {
     // MARK: - paymentProvidersViewModel
 
     @Test("paymentProvidersViewModel exposes the payment provider name")
-    func paymentProvidersViewModelBankName() {
+    func paymentProvidersViewModelBankName() throws {
         let provider = PaymentProvider.fixture(name: "My Bank")
         let sut = makeSUT(providers: [provider])
-        guard let entry = sut.paymentProviders.first else {
-            Issue.record("paymentProviders must not be empty")
-            return
-        }
+        let entry = try #require(sut.paymentProviders.first,
+                                 "paymentProviders must not be empty")
         let cellModel = sut.paymentProvidersViewModel(paymentProvider: entry)
 
         #expect(cellModel.bankName == "My Bank",

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Tests/GiniInternalPaymentSDKTests/BanksBottomViewModelTests.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Tests/GiniInternalPaymentSDKTests/BanksBottomViewModelTests.swift
@@ -17,7 +17,7 @@ struct BanksBottomViewModelTests {
 
     // MARK: - Helpers
 
-    private func makeSUT(providers: [PaymentProvider] = [.make()],
+    private func makeSUT(providers: [PaymentProvider] = [.stub()],
                          selectedProvider: PaymentProvider? = nil,
                          urlOpener: MockURLOpener = MockURLOpener(),
                          clientConfiguration: ClientConfiguration? = nil) -> BanksBottomViewModel {
@@ -39,7 +39,7 @@ struct BanksBottomViewModelTests {
 
     @Test("Filters out android-only providers with no iOS platform support")
     func androidOnlyProviderIsExcluded() {
-        let androidOnly = PaymentProvider.make(id: "android-only",
+        let androidOnly = PaymentProvider.stub(id: "android-only",
                                                gpcSupportedPlatforms: [.android],
                                                openWithSupportedPlatforms: [])
         let sut = makeSUT(providers: [androidOnly])
@@ -50,7 +50,7 @@ struct BanksBottomViewModelTests {
 
     @Test("Includes provider with iOS in gpcSupportedPlatforms")
     func gpcIosProviderIsIncluded() {
-        let provider = PaymentProvider.make(gpcSupportedPlatforms: [.ios])
+        let provider = PaymentProvider.stub(gpcSupportedPlatforms: [.ios])
         let sut = makeSUT(providers: [provider])
 
         #expect(sut.paymentProviders.count == 1,
@@ -59,7 +59,7 @@ struct BanksBottomViewModelTests {
 
     @Test("Includes provider with iOS in openWithSupportedPlatforms")
     func openWithIosProviderIsIncluded() {
-        let provider = PaymentProvider.make(gpcSupportedPlatforms: [],
+        let provider = PaymentProvider.stub(gpcSupportedPlatforms: [],
                                             openWithSupportedPlatforms: [.ios])
         let sut = makeSUT(providers: [provider])
 
@@ -71,8 +71,8 @@ struct BanksBottomViewModelTests {
 
     @Test("Duplicate provider ids produce a single entry")
     func duplicateIdsAreDeduped() {
-        let p1 = PaymentProvider.make(id: "same-id", name: "Bank A")
-        let p2 = PaymentProvider.make(id: "same-id", name: "Bank B")
+        let p1 = PaymentProvider.stub(id: "same-id", name: "Bank A")
+        let p2 = PaymentProvider.stub(id: "same-id", name: "Bank B")
         let sut = makeSUT(providers: [p1, p2])
 
         #expect(sut.paymentProviders.count == 1,
@@ -83,10 +83,10 @@ struct BanksBottomViewModelTests {
 
     @Test("Installed provider appears before uninstalled provider")
     func installedProviderSortsFirst() {
-        let installed = PaymentProvider.make(id: "installed",
+        let installed = PaymentProvider.stub(id: "installed",
                                              name: "Installed Bank",
                                              appSchemeIOS: "installedbank://")
-        let notInstalled = PaymentProvider.make(id: "not-installed",
+        let notInstalled = PaymentProvider.stub(id: "not-installed",
                                                 name: "Not Installed",
                                                 appSchemeIOS: "notinstalled://")
         let mockOpener = MockURLOpener(installedScheme: "installedbank")
@@ -98,8 +98,8 @@ struct BanksBottomViewModelTests {
 
     @Test("Among uninstalled providers, lower index sorts first")
     func lowerIndexSortsFirst() {
-        let high = PaymentProvider.make(id: "high", index: 5)
-        let low = PaymentProvider.make(id: "low", index: 1)
+        let high = PaymentProvider.stub(id: "high", index: 5)
+        let low = PaymentProvider.stub(id: "low", index: 1)
         let sut = makeSUT(providers: [high, low])
 
         #expect(sut.paymentProviders.first?.paymentProvider.id == "low",
@@ -110,7 +110,7 @@ struct BanksBottomViewModelTests {
 
     @Test("Provider matching selectedPaymentProvider is marked isSelected")
     func selectedProviderIsMarked() {
-        let selected = PaymentProvider.make(id: "selected-id")
+        let selected = PaymentProvider.stub(id: "selected-id")
         let sut = makeSUT(providers: [selected], selectedProvider: selected)
 
         #expect(sut.paymentProviders.first?.isSelected == true,
@@ -119,8 +119,8 @@ struct BanksBottomViewModelTests {
 
     @Test("Provider not matching selectedPaymentProvider has isSelected = false")
     func nonSelectedProviderIsNotMarked() {
-        let provider = PaymentProvider.make(id: "other-id")
-        let selected = PaymentProvider.make(id: "selected-id")
+        let provider = PaymentProvider.stub(id: "other-id")
+        let selected = PaymentProvider.stub(id: "selected-id")
         let sut = makeSUT(providers: [provider], selectedProvider: selected)
 
         #expect(sut.paymentProviders.first?.isSelected == false,
@@ -153,7 +153,7 @@ struct BanksBottomViewModelTests {
 
     @Test("paymentProvidersViewModel exposes the payment provider name")
     func paymentProvidersViewModelBankName() {
-        let provider = PaymentProvider.make(name: "My Bank")
+        let provider = PaymentProvider.stub(name: "My Bank")
         let sut = makeSUT(providers: [provider])
         guard let entry = sut.paymentProviders.first else {
             Issue.record("paymentProviders must not be empty")

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Tests/GiniInternalPaymentSDKTests/InstallAppBottomViewModelTests.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Tests/GiniInternalPaymentSDKTests/InstallAppBottomViewModelTests.swift
@@ -67,13 +67,15 @@ struct InstallAppBottomViewModelTests {
 
     // MARK: - bankImageIcon
 
-    @Test("bankImageIcon is a UIImage (empty) when provider has no icon data")
+    @Test("bankImageIcon falls back to an empty UIImage when provider has no icon data")
     func bankImageIconIsImageWithEmptyData() {
         let sut = makeSUT(provider: .make())
 
         // UIImage(data: Data()) returns nil, so iconData.toImage ?? UIImage() resolves to UIImage()
-        #expect(sut.bankImageIcon != nil,
-                "bankImageIcon must not be nil even when the provider has no icon data")
+        #expect(sut.bankImageIcon.size == .zero,
+                "bankImageIcon must fall back to an empty UIImage with zero size when the provider has no icon data")
+        #expect(sut.bankImageIcon.cgImage == nil,
+                "bankImageIcon fallback image must not have backing CGImage data when the provider has no icon data")
     }
 
     // MARK: - shouldShowBrandedView

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Tests/GiniInternalPaymentSDKTests/InstallAppBottomViewModelTests.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Tests/GiniInternalPaymentSDKTests/InstallAppBottomViewModelTests.swift
@@ -80,10 +80,10 @@ struct InstallAppBottomViewModelTests {
 
     @Test("shouldShowBrandedView is true only for fullVisible",
           arguments: zip(
-            [IngredientBrandTypeEnum.fullVisible, .paymentComponent, .invisible],
+            [GiniHealthAPILibrary.IngredientBrandTypeEnum.fullVisible, .paymentComponent, .invisible],
             [true, false, false]
           ))
-    func shouldShowBrandedView(brandType: IngredientBrandTypeEnum, expected: Bool) {
+    func shouldShowBrandedView(brandType: GiniHealthAPILibrary.IngredientBrandTypeEnum, expected: Bool) {
         let sut = makeSUT(clientConfiguration: .test(ingredientBrandType: brandType))
 
         #expect(sut.shouldShowBrandedView == expected,

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Tests/GiniInternalPaymentSDKTests/InstallAppBottomViewModelTests.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Tests/GiniInternalPaymentSDKTests/InstallAppBottomViewModelTests.swift
@@ -1,0 +1,114 @@
+//
+//  InstallAppBottomViewModelTests.swift
+//  GiniInternalPaymentSDKTests
+//
+//  Copyright © 2026 Gini GmbH. All rights reserved.
+//
+
+import Testing
+import UIKit
+import GiniHealthAPILibrary
+@testable import GiniInternalPaymentSDK
+
+@Suite("InstallAppBottomViewModel")
+@MainActor
+struct InstallAppBottomViewModelTests {
+
+    // MARK: - Helpers
+
+    private func makeSUT(provider: PaymentProvider? = .make(name: "Test Bank"),
+                         clientConfiguration: ClientConfiguration? = nil) -> InstallAppBottomViewModel {
+        InstallAppBottomViewModel(selectedPaymentProvider: provider,
+                                  installAppConfiguration: .test,
+                                  strings: .test,
+                                  primaryButtonConfiguration: .test,
+                                  poweredByGiniConfiguration: .test,
+                                  poweredByGiniStrings: .test,
+                                  clientConfiguration: clientConfiguration)
+    }
+
+    // MARK: - [BANK] substitution in titleText
+
+    @Test("titleText substitutes [BANK] with the provider name")
+    func titleTextSubstitutesBankName() {
+        let sut = makeSUT(provider: .make(name: "N26"))
+
+        #expect(sut.titleText == "Install N26",
+                "titleText must replace [BANK] with the selected payment provider's name")
+    }
+
+    @Test("titleText substitutes [BANK] with empty string when provider is nil")
+    func titleTextWithNilProvider() {
+        let sut = makeSUT(provider: nil)
+
+        #expect(sut.titleText == "Install ",
+                "titleText must replace [BANK] with an empty string when no provider is given")
+    }
+
+    // MARK: - moreInformationLabelText
+
+    /// In a unit-test environment, no custom URL scheme can be opened, so `isBankInstalled` is always false.
+    /// The note pattern is therefore always selected in tests.
+    @Test("moreInformationLabelText uses notePattern because bank is not installed in test environment")
+    func moreInformationLabelTextUsesNotePattern() {
+        let sut = makeSUT(provider: .make(name: "DKB"))
+
+        #expect(sut.moreInformationLabelText == "Note: install DKB",
+                "moreInformationLabelText must use moreInformationNotePattern when bank is not installed")
+    }
+
+    @Test("moreInformationLabelText substitutes [BANK] with empty string when provider is nil")
+    func moreInformationLabelTextNilProvider() {
+        let sut = makeSUT(provider: nil)
+
+        #expect(sut.moreInformationLabelText == "Note: install ",
+                "moreInformationLabelText must replace [BANK] with empty string when no provider is given")
+    }
+
+    // MARK: - bankImageIcon
+
+    @Test("bankImageIcon is a UIImage (empty) when provider has no icon data")
+    func bankImageIconIsImageWithEmptyData() {
+        let sut = makeSUT(provider: .make())
+
+        // UIImage(data: Data()) returns nil, so iconData.toImage ?? UIImage() resolves to UIImage()
+        #expect(sut.bankImageIcon != nil,
+                "bankImageIcon must not be nil even when the provider has no icon data")
+    }
+
+    // MARK: - shouldShowBrandedView
+
+    @Test("shouldShowBrandedView is true only for fullVisible",
+          arguments: zip(
+            [IngredientBrandTypeEnum.fullVisible, .paymentComponent, .invisible],
+            [true, false, false]
+          ))
+    func shouldShowBrandedView(brandType: IngredientBrandTypeEnum, expected: Bool) {
+        let sut = makeSUT(clientConfiguration: .test(ingredientBrandType: brandType))
+
+        #expect(sut.shouldShowBrandedView == expected,
+                "shouldShowBrandedView must be \(expected) for brandType \(brandType)")
+    }
+
+    @Test("shouldShowBrandedView is false when clientConfiguration is nil")
+    func shouldShowBrandedViewNilConfig() {
+        let sut = makeSUT(clientConfiguration: nil)
+
+        #expect(sut.shouldShowBrandedView == false,
+                "shouldShowBrandedView must be false when clientConfiguration is nil")
+    }
+
+    // MARK: - Delegate forwarding
+
+    @Test("didTapOnContinue notifies the delegate")
+    func didTapOnContinueNotifiesDelegate() {
+        let sut = makeSUT()
+        let delegate = MockInstallAppDelegate()
+        sut.viewDelegate = delegate
+
+        sut.didTapOnContinue()
+
+        #expect(delegate.didTapContinueCalled == true,
+                "didTapOnContinue must call didTapOnContinue on the viewDelegate")
+    }
+}

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Tests/GiniInternalPaymentSDKTests/InstallAppBottomViewModelTests.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Tests/GiniInternalPaymentSDKTests/InstallAppBottomViewModelTests.swift
@@ -16,7 +16,7 @@ struct InstallAppBottomViewModelTests {
 
     // MARK: - Helpers
 
-    private func makeSUT(provider: PaymentProvider? = .make(name: "Test Bank"),
+    private func makeSUT(provider: PaymentProvider? = nil,
                          clientConfiguration: ClientConfiguration? = nil) -> InstallAppBottomViewModel {
         InstallAppBottomViewModel(selectedPaymentProvider: provider,
                                   installAppConfiguration: .test,

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Tests/GiniInternalPaymentSDKTests/InstallAppBottomViewModelTests.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Tests/GiniInternalPaymentSDKTests/InstallAppBottomViewModelTests.swift
@@ -31,7 +31,7 @@ struct InstallAppBottomViewModelTests {
 
     @Test("titleText substitutes [BANK] with the provider name")
     func titleTextSubstitutesBankName() {
-        let sut = makeSUT(provider: .make(name: "N26"))
+        let sut = makeSUT(provider: .stub(name: "N26"))
 
         #expect(sut.titleText == "Install N26",
                 "titleText must replace [BANK] with the selected payment provider's name")
@@ -51,7 +51,7 @@ struct InstallAppBottomViewModelTests {
     /// The note pattern is therefore always selected in tests.
     @Test("moreInformationLabelText uses notePattern because bank is not installed in test environment")
     func moreInformationLabelTextUsesNotePattern() {
-        let sut = makeSUT(provider: .make(name: "DKB"))
+        let sut = makeSUT(provider: .stub(name: "DKB"))
 
         #expect(sut.moreInformationLabelText == "Note: install DKB",
                 "moreInformationLabelText must use moreInformationNotePattern when bank is not installed")
@@ -69,7 +69,7 @@ struct InstallAppBottomViewModelTests {
 
     @Test("bankImageIcon falls back to an empty UIImage when provider has no icon data")
     func bankImageIconIsImageWithEmptyData() {
-        let sut = makeSUT(provider: .make())
+        let sut = makeSUT(provider: .stub())
 
         // UIImage(data: Data()) returns nil, so iconData.toImage ?? UIImage() resolves to UIImage()
         #expect(sut.bankImageIcon.size == .zero,

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Tests/GiniInternalPaymentSDKTests/InstallAppBottomViewModelTests.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Tests/GiniInternalPaymentSDKTests/InstallAppBottomViewModelTests.swift
@@ -31,7 +31,7 @@ struct InstallAppBottomViewModelTests {
 
     @Test("titleText substitutes [BANK] with the provider name")
     func titleTextSubstitutesBankName() {
-        let sut = makeSUT(provider: .stub(name: "N26"))
+        let sut = makeSUT(provider: .fixture(name: "N26"))
 
         #expect(sut.titleText == "Install N26",
                 "titleText must replace [BANK] with the selected payment provider's name")
@@ -51,7 +51,7 @@ struct InstallAppBottomViewModelTests {
     /// The note pattern is therefore always selected in tests.
     @Test("moreInformationLabelText uses notePattern because bank is not installed in test environment")
     func moreInformationLabelTextUsesNotePattern() {
-        let sut = makeSUT(provider: .stub(name: "DKB"))
+        let sut = makeSUT(provider: .fixture(name: "DKB"))
 
         #expect(sut.moreInformationLabelText == "Note: install DKB",
                 "moreInformationLabelText must use moreInformationNotePattern when bank is not installed")
@@ -69,7 +69,7 @@ struct InstallAppBottomViewModelTests {
 
     @Test("bankImageIcon falls back to an empty UIImage when provider has no icon data")
     func bankImageIconIsImageWithEmptyData() {
-        let sut = makeSUT(provider: .stub())
+        let sut = makeSUT(provider: .fixture())
 
         // UIImage(data: Data()) returns nil, so iconData.toImage ?? UIImage() resolves to UIImage()
         #expect(sut.bankImageIcon.size == .zero,

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Tests/GiniInternalPaymentSDKTests/PaymentComponentViewModelTests.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Tests/GiniInternalPaymentSDKTests/PaymentComponentViewModelTests.swift
@@ -151,43 +151,47 @@ struct PaymentComponentViewModelTests {
 
     // MARK: - isPaymentComponentUsed / tapOnPayInvoiceView
 
-    @Test("isPaymentComponentUsed is false when the key has not been set")
-    func isPaymentComponentUsedFalseInitially() {
+    /// Removes the payment-component-used flag before the body runs and restores
+    /// a clean state afterwards, so each test starts and ends with no persisted value.
+    private func withCleanPaymentComponentKey(_ body: () -> Void) {
         let key = "kPaymentComponentViewUsed"
         UserDefaults.standard.removeObject(forKey: key)
         defer { UserDefaults.standard.removeObject(forKey: key) }
+        body()
+    }
 
-        let sut = makeSUT()
+    @Test("isPaymentComponentUsed is false when the key has not been set")
+    func isPaymentComponentUsedFalseInitially() {
+        withCleanPaymentComponentKey {
+            let sut = makeSUT()
 
-        #expect(sut.isPaymentComponentUsed() == false,
-                "isPaymentComponentUsed must return false before tapOnPayInvoiceView is called")
+            #expect(sut.isPaymentComponentUsed() == false,
+                    "isPaymentComponentUsed must return false before tapOnPayInvoiceView is called")
+        }
     }
 
     @Test("tapOnPayInvoiceView marks the component as used in UserDefaults")
     func tapOnPayInvoiceViewMarksAsUsed() {
-        let key = "kPaymentComponentViewUsed"
-        UserDefaults.standard.removeObject(forKey: key)
-        defer { UserDefaults.standard.removeObject(forKey: key) }
+        withCleanPaymentComponentKey {
+            let sut = makeSUT()
+            sut.tapOnPayInvoiceView()
 
-        let sut = makeSUT()
-        sut.tapOnPayInvoiceView()
-
-        #expect(sut.isPaymentComponentUsed() == true,
-                "tapOnPayInvoiceView must set the UserDefaults usage flag to true")
+            #expect(sut.isPaymentComponentUsed() == true,
+                    "tapOnPayInvoiceView must set the UserDefaults usage flag to true")
+        }
     }
 
     @Test("tapOnPayInvoiceView notifies delegate")
     func tapOnPayInvoiceViewNotifiesDelegate() {
-        let key = "kPaymentComponentViewUsed"
-        defer { UserDefaults.standard.removeObject(forKey: key) }
+        withCleanPaymentComponentKey {
+            let sut = makeSUT()
+            let delegate = MockPaymentComponentDelegate()
+            sut.delegate = delegate
 
-        let sut = makeSUT()
-        let delegate = MockPaymentComponentDelegate()
-        sut.delegate = delegate
+            sut.tapOnPayInvoiceView()
 
-        sut.tapOnPayInvoiceView()
-
-        #expect(delegate.didTapPayInvoiceCalled == true,
-                "tapOnPayInvoiceView must call didTapOnPayInvoice on the delegate")
+            #expect(delegate.didTapPayInvoiceCalled == true,
+                    "tapOnPayInvoiceView must call didTapOnPayInvoice on the delegate")
+        }
     }
 }

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Tests/GiniInternalPaymentSDKTests/PaymentComponentViewModelTests.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Tests/GiniInternalPaymentSDKTests/PaymentComponentViewModelTests.swift
@@ -194,4 +194,30 @@ struct PaymentComponentViewModelTests {
                     "tapOnPayInvoiceView must call didTapOnPayInvoice on the delegate")
         }
     }
+
+    // MARK: - Delegate forwarding — tapOnMoreInformation / tapOnBankPicker
+
+    @Test("tapOnMoreInformation notifies delegate")
+    func tapOnMoreInformationNotifiesDelegate() {
+        let sut = makeSUT()
+        let delegate = MockPaymentComponentDelegate()
+        sut.delegate = delegate
+
+        sut.tapOnMoreInformation()
+
+        #expect(delegate.didTapMoreInfoCalled == true,
+                "tapOnMoreInformation must call didTapOnMoreInformation on the delegate")
+    }
+
+    @Test("tapOnBankPicker notifies delegate")
+    func tapOnBankPickerNotifiesDelegate() {
+        let sut = makeSUT()
+        let delegate = MockPaymentComponentDelegate()
+        sut.delegate = delegate
+
+        sut.tapOnBankPicker()
+
+        #expect(delegate.didTapBankPickerCalled == true,
+                "tapOnBankPicker must call didTapOnBankPicker on the delegate")
+    }
 }

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Tests/GiniInternalPaymentSDKTests/PaymentComponentViewModelTests.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Tests/GiniInternalPaymentSDKTests/PaymentComponentViewModelTests.swift
@@ -1,0 +1,193 @@
+//
+//  PaymentComponentViewModelTests.swift
+//  GiniInternalPaymentSDKTests
+//
+//  Copyright © 2026 Gini GmbH. All rights reserved.
+//
+
+import Testing
+import UIKit
+import GiniHealthAPILibrary
+@testable import GiniInternalPaymentSDK
+
+@Suite("PaymentComponentViewModel")
+@MainActor
+struct PaymentComponentViewModelTests {
+
+    // MARK: - Helpers
+
+    private func makeSUT(provider: PaymentProvider? = .make(),
+                         paymentComponentConfiguration: PaymentComponentConfiguration? = nil,
+                         clientConfiguration: ClientConfiguration? = nil) -> PaymentComponentViewModel {
+        PaymentComponentViewModel(paymentProvider: provider,
+                                  primaryButtonConfiguration: .test,
+                                  secondaryButtonConfiguration: .test,
+                                  configuration: .test,
+                                  strings: .test,
+                                  poweredByGiniConfiguration: .test,
+                                  poweredByGiniStrings: .test,
+                                  moreInformationConfiguration: .test,
+                                  moreInformationStrings: .test,
+                                  minimumButtonsHeight: 44,
+                                  paymentComponentConfiguration: paymentComponentConfiguration,
+                                  clientConfiguration: clientConfiguration)
+    }
+
+    // MARK: - hasBankSelected
+
+    @Test("hasBankSelected is true when a payment provider is given")
+    func hasBankSelectedTrueWithProvider() {
+        let sut = makeSUT(provider: .make())
+
+        #expect(sut.hasBankSelected == true,
+                "hasBankSelected must be true when a non-nil payment provider is supplied")
+    }
+
+    @Test("hasBankSelected is false when payment provider is nil")
+    func hasBankSelectedFalseWithNilProvider() {
+        let sut = makeSUT(provider: nil)
+
+        #expect(sut.hasBankSelected == false,
+                "hasBankSelected must be false when no payment provider is supplied")
+    }
+
+    // MARK: - bankName
+
+    @Test("bankName reflects the payment provider name")
+    func bankNameReflectsProviderName() {
+        let sut = makeSUT(provider: .make(name: "Sparkasse"))
+
+        #expect(sut.bankName == "Sparkasse",
+                "bankName must equal the payment provider's name")
+    }
+
+    @Test("bankName is nil when payment provider is nil")
+    func bankNameNilWithNilProvider() {
+        let sut = makeSUT(provider: nil)
+
+        #expect(sut.bankName == nil,
+                "bankName must be nil when no payment provider is supplied")
+    }
+
+    // MARK: - selectBankButtonText
+
+    @Test("selectBankButtonText shows placeholder when showPaymentComponentInOneRow is true")
+    func selectBankButtonTextOneRow() {
+        let config = PaymentComponentConfiguration(showPaymentComponentInOneRow: true)
+        let sut = makeSUT(provider: .make(name: "ING"), paymentComponentConfiguration: config)
+
+        #expect(sut.selectBankButtonText == "Select bank",
+                "selectBankButtonText must return the placeholder when showPaymentComponentInOneRow is true")
+    }
+
+    @Test("selectBankButtonText shows bank name when showPaymentComponentInOneRow is false and bank is selected")
+    func selectBankButtonTextTwoRowWithBank() {
+        let config = PaymentComponentConfiguration(showPaymentComponentInOneRow: false)
+        let sut = makeSUT(provider: .make(name: "ING"), paymentComponentConfiguration: config)
+
+        #expect(sut.selectBankButtonText == "ING",
+                "selectBankButtonText must return the bank name when in two-row mode and a bank is selected")
+    }
+
+    @Test("selectBankButtonText shows placeholder when showPaymentComponentInOneRow is false and no bank is selected")
+    func selectBankButtonTextTwoRowNoBank() {
+        let config = PaymentComponentConfiguration(showPaymentComponentInOneRow: false)
+        let sut = makeSUT(provider: nil, paymentComponentConfiguration: config)
+
+        #expect(sut.selectBankButtonText == "Select bank",
+                "selectBankButtonText must return the placeholder when no bank is selected")
+    }
+
+    // MARK: - showPaymentComponentInOneRow
+
+    @Test("showPaymentComponentInOneRow defaults to false when paymentComponentConfiguration is nil")
+    func showPaymentComponentInOneRowDefaultsFalse() {
+        let sut = makeSUT(paymentComponentConfiguration: nil)
+
+        #expect(sut.showPaymentComponentInOneRow == false,
+                "showPaymentComponentInOneRow must default to false when paymentComponentConfiguration is nil")
+    }
+
+    // MARK: - hideInfoForReturningUser
+
+    @Test("hideInfoForReturningUser defaults to false when paymentComponentConfiguration is nil")
+    func hideInfoForReturningUserDefaultsFalse() {
+        let sut = makeSUT(paymentComponentConfiguration: nil)
+
+        #expect(sut.hideInfoForReturningUser == false,
+                "hideInfoForReturningUser must default to false when paymentComponentConfiguration is nil")
+    }
+
+    @Test("hideInfoForReturningUser reflects the paymentComponentConfiguration value")
+    func hideInfoForReturningUserReflectsConfig() {
+        let config = PaymentComponentConfiguration(hideInfoForReturningUser: true)
+        let sut = makeSUT(paymentComponentConfiguration: config)
+
+        #expect(sut.hideInfoForReturningUser == true,
+                "hideInfoForReturningUser must reflect the value set in paymentComponentConfiguration")
+    }
+
+    // MARK: - shouldShowBrandedView
+
+    @Test("shouldShowBrandedView is true for paymentComponent and fullVisible, false for invisible",
+          arguments: zip(
+            [IngredientBrandTypeEnum.paymentComponent, .fullVisible, .invisible],
+            [true, true, false]
+          ))
+    func shouldShowBrandedView(brandType: IngredientBrandTypeEnum, expected: Bool) {
+        let sut = makeSUT(clientConfiguration: .test(ingredientBrandType: brandType))
+
+        #expect(sut.shouldShowBrandedView == expected,
+                "shouldShowBrandedView must be \(expected) for brandType \(brandType)")
+    }
+
+    @Test("shouldShowBrandedView is false when clientConfiguration is nil")
+    func shouldShowBrandedViewNilConfig() {
+        let sut = makeSUT(clientConfiguration: nil)
+
+        #expect(sut.shouldShowBrandedView == false,
+                "shouldShowBrandedView must be false when clientConfiguration is nil")
+    }
+
+    // MARK: - isPaymentComponentUsed / tapOnPayInvoiceView
+
+    @Test("isPaymentComponentUsed is false when the key has not been set")
+    func isPaymentComponentUsedFalseInitially() {
+        let key = "kPaymentComponentViewUsed"
+        UserDefaults.standard.removeObject(forKey: key)
+        defer { UserDefaults.standard.removeObject(forKey: key) }
+
+        let sut = makeSUT()
+
+        #expect(sut.isPaymentComponentUsed() == false,
+                "isPaymentComponentUsed must return false before tapOnPayInvoiceView is called")
+    }
+
+    @Test("tapOnPayInvoiceView marks the component as used in UserDefaults")
+    func tapOnPayInvoiceViewMarksAsUsed() {
+        let key = "kPaymentComponentViewUsed"
+        UserDefaults.standard.removeObject(forKey: key)
+        defer { UserDefaults.standard.removeObject(forKey: key) }
+
+        let sut = makeSUT()
+        sut.tapOnPayInvoiceView()
+
+        #expect(sut.isPaymentComponentUsed() == true,
+                "tapOnPayInvoiceView must set the UserDefaults usage flag to true")
+    }
+
+    @Test("tapOnPayInvoiceView notifies delegate")
+    func tapOnPayInvoiceViewNotifiesDelegate() {
+        let key = "kPaymentComponentViewUsed"
+        defer { UserDefaults.standard.removeObject(forKey: key) }
+
+        let sut = makeSUT()
+        let delegate = MockPaymentComponentDelegate()
+        sut.delegate = delegate
+
+        sut.tapOnPayInvoiceView()
+
+        #expect(delegate.didTapPayInvoiceCalled == true,
+                "tapOnPayInvoiceView must call didTapOnPayInvoice on the delegate")
+    }
+}

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Tests/GiniInternalPaymentSDKTests/PaymentComponentViewModelTests.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Tests/GiniInternalPaymentSDKTests/PaymentComponentViewModelTests.swift
@@ -16,7 +16,7 @@ struct PaymentComponentViewModelTests {
 
     // MARK: - Helpers
 
-    private func makeSUT(provider: PaymentProvider? = .make(),
+    private func makeSUT(provider: PaymentProvider? = .stub(),
                          paymentComponentConfiguration: PaymentComponentConfiguration? = nil,
                          clientConfiguration: ClientConfiguration? = nil) -> PaymentComponentViewModel {
         PaymentComponentViewModel(paymentProvider: provider,
@@ -55,7 +55,7 @@ struct PaymentComponentViewModelTests {
 
     @Test("bankName reflects the payment provider name")
     func bankNameReflectsProviderName() {
-        let sut = makeSUT(provider: .make(name: "Sparkasse"))
+        let sut = makeSUT(provider: .stub(name: "Sparkasse"))
 
         #expect(sut.bankName == "Sparkasse",
                 "bankName must equal the payment provider's name")
@@ -74,7 +74,7 @@ struct PaymentComponentViewModelTests {
     @Test("selectBankButtonText shows placeholder when showPaymentComponentInOneRow is true")
     func selectBankButtonTextOneRow() {
         let config = PaymentComponentConfiguration(showPaymentComponentInOneRow: true)
-        let sut = makeSUT(provider: .make(name: "ING"), paymentComponentConfiguration: config)
+        let sut = makeSUT(provider: .stub(name: "ING"), paymentComponentConfiguration: config)
 
         #expect(sut.selectBankButtonText == "Select bank",
                 "selectBankButtonText must return the placeholder when showPaymentComponentInOneRow is true")
@@ -83,7 +83,7 @@ struct PaymentComponentViewModelTests {
     @Test("selectBankButtonText shows bank name when showPaymentComponentInOneRow is false and bank is selected")
     func selectBankButtonTextTwoRowWithBank() {
         let config = PaymentComponentConfiguration(showPaymentComponentInOneRow: false)
-        let sut = makeSUT(provider: .make(name: "ING"), paymentComponentConfiguration: config)
+        let sut = makeSUT(provider: .stub(name: "ING"), paymentComponentConfiguration: config)
 
         #expect(sut.selectBankButtonText == "ING",
                 "selectBankButtonText must return the bank name when in two-row mode and a bank is selected")

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Tests/GiniInternalPaymentSDKTests/PaymentComponentViewModelTests.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Tests/GiniInternalPaymentSDKTests/PaymentComponentViewModelTests.swift
@@ -131,10 +131,10 @@ struct PaymentComponentViewModelTests {
 
     @Test("shouldShowBrandedView is true for paymentComponent and fullVisible, false for invisible",
           arguments: zip(
-            [IngredientBrandTypeEnum.paymentComponent, .fullVisible, .invisible],
+            [GiniHealthAPILibrary.IngredientBrandTypeEnum.paymentComponent, .fullVisible, .invisible],
             [true, true, false]
           ))
-    func shouldShowBrandedView(brandType: IngredientBrandTypeEnum, expected: Bool) {
+    func shouldShowBrandedView(brandType: GiniHealthAPILibrary.IngredientBrandTypeEnum, expected: Bool) {
         let sut = makeSUT(clientConfiguration: .test(ingredientBrandType: brandType))
 
         #expect(sut.shouldShowBrandedView == expected,

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Tests/GiniInternalPaymentSDKTests/PaymentComponentViewModelTests.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Tests/GiniInternalPaymentSDKTests/PaymentComponentViewModelTests.swift
@@ -16,7 +16,7 @@ struct PaymentComponentViewModelTests {
 
     // MARK: - Helpers
 
-    private func makeSUT(provider: PaymentProvider? = .stub(),
+    private func makeSUT(provider: PaymentProvider? = .fixture(),
                          paymentComponentConfiguration: PaymentComponentConfiguration? = nil,
                          clientConfiguration: ClientConfiguration? = nil) -> PaymentComponentViewModel {
         PaymentComponentViewModel(paymentProvider: provider,
@@ -55,7 +55,7 @@ struct PaymentComponentViewModelTests {
 
     @Test("bankName reflects the payment provider name")
     func bankNameReflectsProviderName() {
-        let sut = makeSUT(provider: .stub(name: "Sparkasse"))
+        let sut = makeSUT(provider: .fixture(name: "Sparkasse"))
 
         #expect(sut.bankName == "Sparkasse",
                 "bankName must equal the payment provider's name")
@@ -74,7 +74,7 @@ struct PaymentComponentViewModelTests {
     @Test("selectBankButtonText shows placeholder when showPaymentComponentInOneRow is true")
     func selectBankButtonTextOneRow() {
         let config = PaymentComponentConfiguration(showPaymentComponentInOneRow: true)
-        let sut = makeSUT(provider: .stub(name: "ING"), paymentComponentConfiguration: config)
+        let sut = makeSUT(provider: .fixture(name: "ING"), paymentComponentConfiguration: config)
 
         #expect(sut.selectBankButtonText == "Select bank",
                 "selectBankButtonText must return the placeholder when showPaymentComponentInOneRow is true")
@@ -83,7 +83,7 @@ struct PaymentComponentViewModelTests {
     @Test("selectBankButtonText shows bank name when showPaymentComponentInOneRow is false and bank is selected")
     func selectBankButtonTextTwoRowWithBank() {
         let config = PaymentComponentConfiguration(showPaymentComponentInOneRow: false)
-        let sut = makeSUT(provider: .stub(name: "ING"), paymentComponentConfiguration: config)
+        let sut = makeSUT(provider: .fixture(name: "ING"), paymentComponentConfiguration: config)
 
         #expect(sut.selectBankButtonText == "ING",
                 "selectBankButtonText must return the bank name when in two-row mode and a bank is selected")

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Tests/GiniInternalPaymentSDKTests/PaymentComponentViewModelTests.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Tests/GiniInternalPaymentSDKTests/PaymentComponentViewModelTests.swift
@@ -37,7 +37,7 @@ struct PaymentComponentViewModelTests {
 
     @Test("hasBankSelected is true when a payment provider is given")
     func hasBankSelectedTrueWithProvider() {
-        let sut = makeSUT(provider: .make())
+        let sut = makeSUT()
 
         #expect(sut.hasBankSelected == true,
                 "hasBankSelected must be true when a non-nil payment provider is supplied")

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Tests/GiniInternalPaymentSDKTests/PaymentInfoViewModelTests.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Tests/GiniInternalPaymentSDKTests/PaymentInfoViewModelTests.swift
@@ -1,0 +1,170 @@
+//
+//  PaymentInfoViewModelTests.swift
+//  GiniInternalPaymentSDKTests
+//
+//  Copyright © 2026 Gini GmbH. All rights reserved.
+//
+
+import Testing
+import UIKit
+import GiniHealthAPILibrary
+@testable import GiniInternalPaymentSDK
+
+@Suite("PaymentInfoViewModel")
+@MainActor
+struct PaymentInfoViewModelTests {
+
+    // MARK: - Helpers
+
+    private func makeSUT(providers: [PaymentProvider] = [],
+                         strings: PaymentInfoStrings = .test,
+                         clientConfiguration: ClientConfiguration? = nil) -> PaymentInfoViewModel {
+        PaymentInfoViewModel(paymentProviders: providers,
+                             configuration: .test,
+                             strings: strings,
+                             poweredByGiniConfiguration: .test,
+                             poweredByGiniStrings: .test,
+                             clientConfiguration: clientConfiguration)
+    }
+
+    /** Builds a `PaymentInfoStrings` with the given questions and answers and no link placeholders in the body text. */
+    private func makeStrings(questions: [String] = [],
+                             answers: [String] = [],
+                             supportedBanksFormat: String = "Banks") -> PaymentInfoStrings {
+        PaymentInfoStrings(accessibilityCloseText: "Close",
+                           giniWebsiteText: "Gini",
+                           giniURLText: "https://gini.net",
+                           supportedBanksText: supportedBanksFormat,
+                           questionsTitleText: "Questions",
+                           answerPrivacyPolicyText: "Policy",
+                           privacyPolicyURLText: "https://gini.net/privacy",
+                           titleText: "Info",
+                           payBillsTitleText: "Bills",
+                           payBillsDescriptionText: "Description",
+                           answers: answers,
+                           questions: questions)
+    }
+
+    // MARK: - shouldShowBrandedView
+
+    @Test("shouldShowBrandedView is true only for fullVisible",
+          arguments: zip(
+            [GiniHealthAPILibrary.IngredientBrandTypeEnum.fullVisible, .paymentComponent, .invisible],
+            [true, false, false]
+          ))
+    func shouldShowBrandedView(brandType: GiniHealthAPILibrary.IngredientBrandTypeEnum, expected: Bool) {
+        let sut = makeSUT(clientConfiguration: .test(ingredientBrandType: brandType))
+
+        #expect(sut.shouldShowBrandedView == expected,
+                "shouldShowBrandedView must be \(expected) for brandType \(brandType)")
+    }
+
+    @Test("shouldShowBrandedView is false when clientConfiguration is nil")
+    func shouldShowBrandedViewNilConfig() {
+        let sut = makeSUT(clientConfiguration: nil)
+
+        #expect(sut.shouldShowBrandedView == false,
+                "shouldShowBrandedView must be false when clientConfiguration is nil")
+    }
+
+    // MARK: - accessibilityBankListText
+
+    @Test("accessibilityBankListText joins provider names using the format string")
+    func accessibilityBankListTextJoinsProviderNames() {
+        let p1 = PaymentProvider.fixture(id: "ing", name: "ING")
+        let p2 = PaymentProvider.fixture(id: "dkb", name: "DKB")
+        let strings = makeStrings(supportedBanksFormat: "Banks: %@")
+        let sut = makeSUT(providers: [p1, p2], strings: strings)
+
+        #expect(sut.accessibilityBankListText == "Banks: ING, DKB",
+                "accessibilityBankListText must join all provider names separated by \", \"")
+    }
+
+    @Test("accessibilityBankListText is empty substitution when no providers are given")
+    func accessibilityBankListTextNoProviders() {
+        let strings = makeStrings(supportedBanksFormat: "Banks: %@")
+        let sut = makeSUT(providers: [], strings: strings)
+
+        #expect(sut.accessibilityBankListText == "Banks: ",
+                "accessibilityBankListText must substitute an empty string when there are no providers")
+    }
+
+    // MARK: - questions setup
+
+    @Test("questions array count matches the input questions count")
+    func questionsCountMatchesInput() {
+        let strings = makeStrings(questions: ["Q1", "Q2"], answers: ["A1", "A2"])
+        let sut = makeSUT(strings: strings)
+
+        #expect(sut.questions.count == 2,
+                "questions must have the same count as the input questions array")
+    }
+
+    @Test("questions are not extended on initialization")
+    func questionsAreNotExtendedByDefault() {
+        let strings = makeStrings(questions: ["Q"], answers: ["A"])
+        let sut = makeSUT(strings: strings)
+
+        #expect(sut.questions.first?.isExtended == false,
+                "every question must have isExtended = false after initialization")
+    }
+
+    @Test("questions array is empty when no questions are provided")
+    func questionsEmptyWhenNoneProvided() {
+        let sut = makeSUT(strings: .test)
+
+        #expect(sut.questions.isEmpty,
+                "questions must be empty when the strings fixture supplies no questions")
+    }
+
+    // MARK: - infoQuestionHeaderViewModel
+
+    @Test("infoQuestionHeaderViewModel returns model with the correct title")
+    func infoQuestionHeaderViewModelTitle() {
+        let strings = makeStrings(questions: ["FAQ Title"], answers: ["FAQ Answer"])
+        let sut = makeSUT(strings: strings)
+
+        let headerVM = sut.infoQuestionHeaderViewModel(at: 0)
+
+        #expect(headerVM.titleText == "FAQ Title",
+                "infoQuestionHeaderViewModel must expose the question title at the requested index")
+    }
+
+    // MARK: - infoAnswerCellModel
+
+    @Test("infoAnswerCellModel returns model with the configured text color")
+    func infoAnswerCellModelTextColor() {
+        let strings = makeStrings(questions: ["Q"], answers: ["Some answer text"])
+        let sut = makeSUT(strings: strings)
+
+        let answerVM = sut.infoAnswerCellModel(at: 0)
+
+        #expect(answerVM.answerTextColor == .label,
+                "infoAnswerCellModel must use the answerCellTextColor from the configuration")
+    }
+
+    // MARK: - infoBankCellModel
+
+    @Test("infoBankCellModel exposes the configured border color")
+    func infoBankCellModelBorderColor() {
+        let providers = [PaymentProvider.fixture()]
+        let sut = makeSUT(providers: providers)
+
+        let cellModel = sut.infoBankCellModel(at: 0)
+
+        #expect(cellModel.borderColor == .systemGray4,
+                "infoBankCellModel must use the bankCellBorderColor from the configuration")
+    }
+
+    @Test("infoBankCellModel falls back to an empty UIImage when provider has no icon data")
+    func infoBankCellModelEmptyIcon() {
+        let providers = [PaymentProvider.fixture()]
+        let sut = makeSUT(providers: providers)
+
+        let cellModel = sut.infoBankCellModel(at: 0)
+
+        // Provider fixture uses empty Data(), so toImage returns nil → UIImage() fallback
+        #expect(cellModel.bankImageIcon.size == .zero,
+                "infoBankCellModel must fall back to an empty UIImage when the provider has no icon data")
+    }
+}

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Tests/GiniInternalPaymentSDKTests/PaymentReviewTestHelpers.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Tests/GiniInternalPaymentSDKTests/PaymentReviewTestHelpers.swift
@@ -386,7 +386,7 @@ extension InstallAppStrings {
 }
 
 extension ClientConfiguration {
-    static func test(ingredientBrandType: IngredientBrandTypeEnum = .invisible) -> ClientConfiguration {
+    static func test(ingredientBrandType: GiniHealthAPILibrary.IngredientBrandTypeEnum = .invisible) -> ClientConfiguration {
         ClientConfiguration(ingredientBrandType: ingredientBrandType)
     }
 }

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Tests/GiniInternalPaymentSDKTests/PaymentReviewTestHelpers.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Tests/GiniInternalPaymentSDKTests/PaymentReviewTestHelpers.swift
@@ -28,7 +28,7 @@ extension PaymentProvider {
                         openWithSupportedPlatforms: [])
     }
 
-    static func make(id: String = "provider-id",
+    static func stub(id: String = "provider-id",
                      name: String = "Test Bank",
                      appSchemeIOS: String = "testbank://",
                      index: Int? = nil,

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Tests/GiniInternalPaymentSDKTests/PaymentReviewTestHelpers.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Tests/GiniInternalPaymentSDKTests/PaymentReviewTestHelpers.swift
@@ -28,7 +28,7 @@ extension PaymentProvider {
                         openWithSupportedPlatforms: [])
     }
 
-    static func stub(id: String = "provider-id",
+    static func fixture(id: String = "provider-id",
                      name: String = "Test Bank",
                      appSchemeIOS: String = "testbank://",
                      index: Int? = nil,

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Tests/GiniInternalPaymentSDKTests/PaymentReviewTestHelpers.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Tests/GiniInternalPaymentSDKTests/PaymentReviewTestHelpers.swift
@@ -7,71 +7,9 @@
 
 import Testing
 import UIKit
-import SwiftUI
 import GiniHealthAPILibrary
 import GiniUtilites
 @testable import GiniInternalPaymentSDK
-
-// MARK: - Mock implementations
-
-final class MockPaymentReviewDelegate: PaymentReviewProtocol {
-    var closeKeyboardClickedCalled = false
-
-    // PaymentReviewAPIProtocol
-    func createPaymentRequest(paymentInfo: PaymentInfo, completion: @escaping (Result<String, GiniError>) -> Void) {
-        // This method will remain empty; no implementation is needed.
-    }
-    func shouldHandleErrorInternally(error: GiniError) -> Bool { true }
-    func openPaymentProviderApp(requestId: String, universalLink: String) {
-        // This method will remain empty; no implementation is needed.
-    }
-    func submitFeedback(for document: Document,
-                        updatedExtractions: [Extraction],
-                        completion: ((Result<Void, GiniError>) -> Void)?) {
-        // This method will remain empty; no implementation is needed.
-    }
-    func preview(for documentId: String, pageNumber: Int, completion: @escaping (Result<Data, GiniError>) -> Void) {
-        // This method will remain empty; no implementation is needed.
-    }
-    func obtainPDFURLFromPaymentRequest(viewController: UIViewController, paymentRequestId: String) {
-        // This method will remain empty; no implementation is needed.
-    }
-
-    // PaymentReviewTrackingProtocol
-    func trackOnPaymentReviewCloseKeyboardClicked() { closeKeyboardClickedCalled = true }
-    func trackOnPaymentReviewCloseButtonClicked() {
-        // This method will remain empty; no implementation is needed.
-    }
-    func trackOnPaymentReviewBankButtonClicked(providerName: String) {
-        // This method will remain empty; no implementation is needed.
-    }
-
-    // PaymentReviewSupportedFormatsProtocol
-    func supportsGPC() -> Bool { false }
-    func supportsOpenWith() -> Bool { false }
-
-    // PaymentReviewActionProtocol
-    func updatedPaymentProvider(_ paymentProvider: PaymentProvider) {
-        // This method will remain empty; no implementation is needed.
-    }
-    func openMoreInformationViewController() {
-        // This method will remain empty; no implementation is needed.
-    }
-    func paymentReviewClosed(with previousPresentedView: PaymentComponentScreenType?) {
-        // This method will remain empty; no implementation is needed.
-    }
-    func presentShareInvoiceBottomSheet(paymentRequestId: String,
-                                        paymentInfo: PaymentInfo,
-                                        completion: @escaping (UIViewController) -> Void) {
-        // This method will remain empty; no implementation is needed.
-    }
-}
-
-final class MockBottomSheetsProvider: BottomSheetsProviderProtocol {
-    func installAppBottomSheet() -> UIViewController { UIViewController() }
-    func shareInvoiceBottomSheet(qrCodeData: Data, paymentRequestId: String) -> UIViewController { UIViewController() }
-    func bankSelectionBottomSheet() -> UIViewController { UIViewController() }
-}
 
 // MARK: - Test factories
 
@@ -88,6 +26,25 @@ extension PaymentProvider {
                         index: 0,
                         gpcSupportedPlatforms: [],
                         openWithSupportedPlatforms: [])
+    }
+
+    static func make(id: String = "provider-id",
+                     name: String = "Test Bank",
+                     appSchemeIOS: String = "testbank://",
+                     index: Int? = nil,
+                     gpcSupportedPlatforms: [PlatformSupported] = [.ios],
+                     openWithSupportedPlatforms: [PlatformSupported] = []) -> PaymentProvider {
+        PaymentProvider(id: id,
+                        name: name,
+                        appSchemeIOS: appSchemeIOS,
+                        minAppVersion: nil,
+                        colors: ProviderColors(background: "#FFFFFF", text: "#000000"),
+                        iconData: Data(),
+                        appStoreUrlIOS: nil,
+                        universalLinkIOS: "https://testbank.example",
+                        index: index,
+                        gpcSupportedPlatforms: gpcSupportedPlatforms,
+                        openWithSupportedPlatforms: openWithSupportedPlatforms)
     }
 }
 
@@ -265,4 +222,171 @@ func makePaymentReviewModel(delegate: MockPaymentReviewDelegate,
                        showPaymentReviewCloseButton: true,
                        previousPaymentComponentScreenType: nil,
                        clientConfiguration: nil)
+}
+
+// MARK: - Configuration and string test factories
+
+extension BankSelectionConfiguration {
+    static var test: BankSelectionConfiguration {
+        BankSelectionConfiguration(descriptionAccentColor: .label,
+                                   descriptionFont: .systemFont(ofSize: 14),
+                                   selectBankAccentColor: .label,
+                                   selectBankFont: .systemFont(ofSize: 16, weight: .semibold),
+                                   closeTitleIcon: UIImage(),
+                                   closeIconAccentColor: .label,
+                                   bankCellBackgroundColor: .systemBackground,
+                                   bankCellIconBorderColor: .systemGray4,
+                                   bankCellNameFont: .systemFont(ofSize: 14),
+                                   bankCellNameAccentColor: .label,
+                                   bankCellSelectedBorderColor: .systemBlue,
+                                   bankCellNotSelectedBorderColor: .systemGray4,
+                                   bankCellSelectionIndicatorImage: UIImage())
+    }
+}
+
+extension BanksBottomStrings {
+    static var test: BanksBottomStrings {
+        BanksBottomStrings(selectBankTitleText: "Select your bank",
+                           descriptionText: "Description",
+                           closeButtonAccessibilityLabel: "Close")
+    }
+}
+
+extension MoreInformationConfiguration {
+    static var test: MoreInformationConfiguration {
+        MoreInformationConfiguration(moreInformationAccentColor: .systemBlue,
+                                     moreInformationTextColor: .label,
+                                     moreInformationLinkFont: .systemFont(ofSize: 12),
+                                     moreInformationIcon: UIImage())
+    }
+}
+
+extension MoreInformationStrings {
+    static var test: MoreInformationStrings {
+        MoreInformationStrings(moreInformationActionablePartText: "More information")
+    }
+}
+
+extension PaymentInfoConfiguration {
+    static var test: PaymentInfoConfiguration {
+        PaymentInfoConfiguration(giniFont: .systemFont(ofSize: 14),
+                                 answersFont: .systemFont(ofSize: 12),
+                                 answerCellTextColor: .label,
+                                 answerCellLinkColor: .systemBlue,
+                                 questionsTitleFont: .systemFont(ofSize: 16, weight: .semibold),
+                                 questionsTitleColor: .label,
+                                 questionHeaderFont: .systemFont(ofSize: 14, weight: .medium),
+                                 questionHeaderTitleColor: .label,
+                                 questionHeaderMinusIcon: UIImage(),
+                                 questionHeaderPlusIcon: UIImage(),
+                                 bankCellBorderColor: .systemGray4,
+                                 payBillsTitleFont: .systemFont(ofSize: 18, weight: .bold),
+                                 payBillsTitleColor: .label,
+                                 payBillsDescriptionFont: .systemFont(ofSize: 14),
+                                 linksFont: .systemFont(ofSize: 12),
+                                 linksColor: .systemBlue,
+                                 separatorColor: .systemGray5,
+                                 backgroundColor: .systemBackground,
+                                 questionHeaderIconTintColor: .label)
+    }
+}
+
+extension PaymentInfoStrings {
+    static var test: PaymentInfoStrings {
+        PaymentInfoStrings(accessibilityCloseText: "Close",
+                           giniWebsiteText: "Gini website",
+                           giniURLText: "https://gini.net",
+                           supportedBanksText: "Supported banks",
+                           questionsTitleText: "Questions",
+                           answerPrivacyPolicyText: "Privacy policy",
+                           privacyPolicyURLText: "https://gini.net/privacy",
+                           titleText: "Payment information",
+                           payBillsTitleText: "Pay bills",
+                           payBillsDescriptionText: "Description",
+                           answers: [],
+                           questions: [])
+    }
+}
+
+extension PaymentComponentsConfiguration {
+    static var test: PaymentComponentsConfiguration {
+        PaymentComponentsConfiguration(selectYourBankLabelFont: .systemFont(ofSize: 14),
+                                       selectYourBankAccentColor: .label,
+                                       chevronDownIcon: UIImage(),
+                                       chevronDownIconColor: .label,
+                                       notInstalledBankTextColor: .secondaryLabel)
+    }
+}
+
+extension PaymentComponentsStrings {
+    static var test: PaymentComponentsStrings {
+        PaymentComponentsStrings(selectYourBankLabelText: "Select your bank",
+                                 placeholderBankNameText: "Select bank",
+                                 ctaLabelText: "Continue",
+                                 selectYourBankAccessibilityHint: "Tap to select")
+    }
+}
+
+extension ShareInvoiceConfiguration {
+    static var test: ShareInvoiceConfiguration {
+        ShareInvoiceConfiguration(titleFont: .systemFont(ofSize: 18, weight: .bold),
+                                  titleAccentColor: .label,
+                                  descriptionFont: .systemFont(ofSize: 14),
+                                  descriptionTextColor: .label,
+                                  descriptionAccentColor: .systemBlue,
+                                  paymentInfoBorderColor: .systemGray4,
+                                  titlePaymentInfoTextColor: .label,
+                                  subtitlePaymentInfoTextColor: .secondaryLabel,
+                                  titlepaymentInfoFont: .systemFont(ofSize: 14, weight: .semibold),
+                                  subtitlePaymentInfoFont: .systemFont(ofSize: 12),
+                                  closeIcon: UIImage(),
+                                  closeIconAccentColor: .label)
+    }
+}
+
+extension ShareInvoiceStrings {
+    static var test: ShareInvoiceStrings {
+        ShareInvoiceStrings(continueLabelText: "Continue with [BANK]",
+                            titleTextPattern: "Share with [BANK]",
+                            descriptionTextPattern: "Open [BANK] to pay",
+                            recipientLabelText: "Recipient",
+                            amountLabelText: "Amount",
+                            ibanLabelText: "IBAN",
+                            purposeLabelText: "Purpose",
+                            accessibilityQRCodeImageText: "QR code",
+                            accessibilityCloseIconText: "Close")
+    }
+}
+
+extension InstallAppConfiguration {
+    static var test: InstallAppConfiguration {
+        InstallAppConfiguration(titleAccentColor: .label,
+                                titleFont: .systemFont(ofSize: 18, weight: .bold),
+                                moreInformationFont: .systemFont(ofSize: 14),
+                                moreInformationTextColor: .label,
+                                moreInformationAccentColor: .systemBlue,
+                                moreInformationIcon: UIImage(),
+                                appStoreIcon: UIImage(),
+                                bankIconBorderColor: .systemGray4,
+                                closeIcon: UIImage(),
+                                closeIconAccentColor: .label)
+    }
+}
+
+extension InstallAppStrings {
+    static var test: InstallAppStrings {
+        InstallAppStrings(titlePattern: "Install [BANK]",
+                          moreInformationTipPattern: "Tip: open [BANK]",
+                          moreInformationNotePattern: "Note: install [BANK]",
+                          continueLabelText: "Continue",
+                          accessibilityAppStoreText: "App Store",
+                          accessibilityBankLogoText: "Bank logo",
+                          accessibilityCloseIconText: "Close")
+    }
+}
+
+extension ClientConfiguration {
+    static func test(ingredientBrandType: IngredientBrandTypeEnum = .invisible) -> ClientConfiguration {
+        ClientConfiguration(ingredientBrandType: ingredientBrandType)
+    }
 }

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Tests/GiniInternalPaymentSDKTests/PaymentTestMocks.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Tests/GiniInternalPaymentSDKTests/PaymentTestMocks.swift
@@ -73,7 +73,7 @@ final class MockBottomSheetsProvider: BottomSheetsProviderProtocol {
 
 // MARK: - URL opener mock
 
-final class MockURLOpenerProtocol: URLOpenerProtocol {
+final class MockURLOpener: URLOpenerProtocol {
     private let installedSchemes: Set<String>
 
     init(installedSchemes: Set<String> = []) {

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Tests/GiniInternalPaymentSDKTests/PaymentTestMocks.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Tests/GiniInternalPaymentSDKTests/PaymentTestMocks.swift
@@ -1,0 +1,140 @@
+//
+//  PaymentTestMocks.swift
+//  GiniInternalPaymentSDKTests
+//
+//  Copyright © 2026 Gini GmbH. All rights reserved.
+//
+
+import UIKit
+import GiniHealthAPILibrary
+import GiniUtilites
+@testable import GiniInternalPaymentSDK
+
+// MARK: - PaymentReview mocks
+
+final class MockPaymentReviewDelegate: PaymentReviewProtocol {
+    var closeKeyboardClickedCalled = false
+
+    // PaymentReviewAPIProtocol
+    func createPaymentRequest(paymentInfo: PaymentInfo, completion: @escaping (Result<String, GiniError>) -> Void) {
+        // This method will remain empty; no implementation is needed.
+    }
+    func shouldHandleErrorInternally(error: GiniError) -> Bool { true }
+    func openPaymentProviderApp(requestId: String, universalLink: String) {
+        // This method will remain empty; no implementation is needed.
+    }
+    func submitFeedback(for document: Document,
+                        updatedExtractions: [Extraction],
+                        completion: ((Result<Void, GiniError>) -> Void)?) {
+        // This method will remain empty; no implementation is needed.
+    }
+    func preview(for documentId: String, pageNumber: Int, completion: @escaping (Result<Data, GiniError>) -> Void) {
+        // This method will remain empty; no implementation is needed.
+    }
+    func obtainPDFURLFromPaymentRequest(viewController: UIViewController, paymentRequestId: String) {
+        // This method will remain empty; no implementation is needed.
+    }
+
+    // PaymentReviewTrackingProtocol
+    func trackOnPaymentReviewCloseKeyboardClicked() { closeKeyboardClickedCalled = true }
+    func trackOnPaymentReviewCloseButtonClicked() {
+        // This method will remain empty; no implementation is needed.
+    }
+    func trackOnPaymentReviewBankButtonClicked(providerName: String) {
+        // This method will remain empty; no implementation is needed.
+    }
+
+    // PaymentReviewSupportedFormatsProtocol
+    func supportsGPC() -> Bool { false }
+    func supportsOpenWith() -> Bool { false }
+
+    // PaymentReviewActionProtocol
+    func updatedPaymentProvider(_ paymentProvider: PaymentProvider) {
+        // This method will remain empty; no implementation is needed.
+    }
+    func openMoreInformationViewController() {
+        // This method will remain empty; no implementation is needed.
+    }
+    func paymentReviewClosed(with previousPresentedView: PaymentComponentScreenType?) {
+        // This method will remain empty; no implementation is needed.
+    }
+    func presentShareInvoiceBottomSheet(paymentRequestId: String,
+                                        paymentInfo: PaymentInfo,
+                                        completion: @escaping (UIViewController) -> Void) {
+        // This method will remain empty; no implementation is needed.
+    }
+}
+
+final class MockBottomSheetsProvider: BottomSheetsProviderProtocol {
+    func installAppBottomSheet() -> UIViewController { UIViewController() }
+    func shareInvoiceBottomSheet(qrCodeData: Data, paymentRequestId: String) -> UIViewController { UIViewController() }
+    func bankSelectionBottomSheet() -> UIViewController { UIViewController() }
+}
+
+// MARK: - URL opener mock
+
+final class MockURLOpenerProtocol: URLOpenerProtocol {
+    private let installedSchemes: Set<String>
+
+    init(installedSchemes: Set<String> = []) {
+        self.installedSchemes = installedSchemes
+    }
+
+    convenience init(installedScheme: String) {
+        self.init(installedSchemes: [installedScheme])
+    }
+
+    func canOpenURL(_ url: URL) -> Bool {
+        installedSchemes.contains(url.scheme ?? "")
+    }
+
+    func open(_ url: URL,
+              options: [UIApplication.OpenExternalURLOptionsKey: Any],
+              completionHandler completion: GiniOpenLinkCompletionBlock?) {
+        // This method will remain empty; no implementation is needed.
+    }
+}
+
+// MARK: - View delegate mocks
+
+final class MockBanksSelectionDelegate: BanksSelectionProtocol {
+    var selectedProvider: PaymentProvider?
+    var didTapMoreInfoCalled = false
+    var didTapCloseCalled = false
+    var didTapContinueShareCalled = false
+    var didTapForwardInstallCalled = false
+    var didTapPayButtonCalled = false
+
+    func didSelectPaymentProvider(paymentProvider: PaymentProvider) { selectedProvider = paymentProvider }
+    func didTapOnMoreInformation() { didTapMoreInfoCalled = true }
+    func didTapOnClose() { didTapCloseCalled = true }
+    func didTapOnContinueOnShareBottomSheet() { didTapContinueShareCalled = true }
+    func didTapForwardOnInstallBottomSheet() { didTapForwardInstallCalled = true }
+    func didTapOnPayButton() { didTapPayButtonCalled = true }
+}
+
+final class MockPaymentComponentDelegate: PaymentComponentViewProtocol {
+    var didTapMoreInfoCalled = false
+    var didTapBankPickerCalled = false
+    var didTapPayInvoiceCalled = false
+    var didDismissCalled = false
+
+    func didTapOnMoreInformation(documentId: String?) { didTapMoreInfoCalled = true }
+    func didTapOnBankPicker(documentId: String?) { didTapBankPickerCalled = true }
+    func didTapOnPayInvoice(documentId: String?) { didTapPayInvoiceCalled = true }
+    func didDismissPaymentComponent() { didDismissCalled = true }
+}
+
+final class MockShareInvoiceDelegate: ShareInvoiceBottomViewProtocol {
+    var continueTappedRequestId: String?
+
+    func didTapOnContinueToShareInvoice(paymentRequestId: String) {
+        continueTappedRequestId = paymentRequestId
+    }
+}
+
+final class MockInstallAppDelegate: InstallAppBottomViewProtocol {
+    var didTapContinueCalled = false
+
+    func didTapOnContinue() { didTapContinueCalled = true }
+}

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Tests/GiniInternalPaymentSDKTests/ShareInvoiceBottomViewModelTests.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Tests/GiniInternalPaymentSDKTests/ShareInvoiceBottomViewModelTests.swift
@@ -89,10 +89,10 @@ struct ShareInvoiceBottomViewModelTests {
 
     @Test("shouldShowBrandedView is true only for fullVisible",
           arguments: zip(
-            [IngredientBrandTypeEnum.fullVisible, .paymentComponent, .invisible],
+            [GiniHealthAPILibrary.IngredientBrandTypeEnum.fullVisible, .paymentComponent, .invisible],
             [true, false, false]
           ))
-    func shouldShowBrandedView(brandType: IngredientBrandTypeEnum, expected: Bool) {
+    func shouldShowBrandedView(brandType: GiniHealthAPILibrary.IngredientBrandTypeEnum, expected: Bool) {
         let sut = makeSUT(clientConfiguration: .test(ingredientBrandType: brandType))
 
         #expect(sut.shouldShowBrandedView == expected,

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Tests/GiniInternalPaymentSDKTests/ShareInvoiceBottomViewModelTests.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Tests/GiniInternalPaymentSDKTests/ShareInvoiceBottomViewModelTests.swift
@@ -16,7 +16,7 @@ struct ShareInvoiceBottomViewModelTests {
 
     // MARK: - Helpers
 
-    private func makeSUT(provider: PaymentProvider? = .stub(name: "Test Bank"),
+    private func makeSUT(provider: PaymentProvider? = .fixture(name: "Test Bank"),
                          paymentRequestId: String = "request-123",
                          clientConfiguration: ClientConfiguration? = nil) -> ShareInvoiceBottomViewModel {
         ShareInvoiceBottomViewModel(selectedPaymentProvider: provider,
@@ -35,7 +35,7 @@ struct ShareInvoiceBottomViewModelTests {
 
     @Test("titleText substitutes [BANK] with the provider name")
     func titleTextSubstitutesBankName() {
-        let sut = makeSUT(provider: .stub(name: "Sparkasse"))
+        let sut = makeSUT(provider: .fixture(name: "Sparkasse"))
 
         #expect(sut.titleText == "Share with Sparkasse",
                 "titleText must replace [BANK] with the selected payment provider's name")
@@ -51,7 +51,7 @@ struct ShareInvoiceBottomViewModelTests {
 
     @Test("descriptionLabelText substitutes [BANK] with the provider name")
     func descriptionLabelTextSubstitutesBankName() {
-        let sut = makeSUT(provider: .stub(name: "ING"))
+        let sut = makeSUT(provider: .fixture(name: "ING"))
 
         #expect(sut.descriptionLabelText == "Open ING to pay",
                 "descriptionLabelText must replace [BANK] with the selected payment provider's name")
@@ -59,7 +59,7 @@ struct ShareInvoiceBottomViewModelTests {
 
     @Test("continueButtonText substitutes [BANK] with the provider name")
     func continueButtonTextSubstitutesBankName() {
-        let sut = makeSUT(provider: .stub(name: "DKB"))
+        let sut = makeSUT(provider: .fixture(name: "DKB"))
 
         #expect(sut.continueButtonText == "Continue with DKB",
                 "continueButtonText must replace [BANK] with the selected payment provider's name")

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Tests/GiniInternalPaymentSDKTests/ShareInvoiceBottomViewModelTests.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Tests/GiniInternalPaymentSDKTests/ShareInvoiceBottomViewModelTests.swift
@@ -1,0 +1,123 @@
+//
+//  ShareInvoiceBottomViewModelTests.swift
+//  GiniInternalPaymentSDKTests
+//
+//  Copyright © 2026 Gini GmbH. All rights reserved.
+//
+
+import Testing
+import UIKit
+import GiniHealthAPILibrary
+@testable import GiniInternalPaymentSDK
+
+@Suite("ShareInvoiceBottomViewModel")
+@MainActor
+struct ShareInvoiceBottomViewModelTests {
+
+    // MARK: - Helpers
+
+    private func makeSUT(provider: PaymentProvider? = .make(name: "Test Bank"),
+                         paymentRequestId: String = "request-123",
+                         clientConfiguration: ClientConfiguration? = nil) -> ShareInvoiceBottomViewModel {
+        ShareInvoiceBottomViewModel(selectedPaymentProvider: provider,
+                                    configuration: .test,
+                                    strings: .test,
+                                    primaryButtonConfiguration: .test,
+                                    poweredByGiniConfiguration: .test,
+                                    poweredByGiniStrings: .test,
+                                    qrCodeData: Data(),
+                                    paymentInfo: nil,
+                                    paymentRequestId: paymentRequestId,
+                                    clientConfiguration: clientConfiguration)
+    }
+
+    // MARK: - [BANK] substitution
+
+    @Test("titleText substitutes [BANK] with the provider name")
+    func titleTextSubstitutesBankName() {
+        let sut = makeSUT(provider: .make(name: "Sparkasse"))
+
+        #expect(sut.titleText == "Share with Sparkasse",
+                "titleText must replace [BANK] with the selected payment provider's name")
+    }
+
+    @Test("titleText substitutes [BANK] with empty string when provider is nil")
+    func titleTextWithNilProvider() {
+        let sut = makeSUT(provider: nil)
+
+        #expect(sut.titleText == "Share with ",
+                "titleText must replace [BANK] with an empty string when no provider is given")
+    }
+
+    @Test("descriptionLabelText substitutes [BANK] with the provider name")
+    func descriptionLabelTextSubstitutesBankName() {
+        let sut = makeSUT(provider: .make(name: "ING"))
+
+        #expect(sut.descriptionLabelText == "Open ING to pay",
+                "descriptionLabelText must replace [BANK] with the selected payment provider's name")
+    }
+
+    @Test("continueButtonText substitutes [BANK] with the provider name")
+    func continueButtonTextSubstitutesBankName() {
+        let sut = makeSUT(provider: .make(name: "DKB"))
+
+        #expect(sut.continueButtonText == "Continue with DKB",
+                "continueButtonText must replace [BANK] with the selected payment provider's name")
+    }
+
+    // MARK: - paymentRequestId
+
+    @Test("paymentRequestId is stored correctly")
+    func paymentRequestIdIsStored() {
+        let sut = makeSUT(paymentRequestId: "abc-456")
+
+        #expect(sut.paymentRequestId == "abc-456",
+                "paymentRequestId must equal the value passed to the initializer")
+    }
+
+    // MARK: - bankImageIcon
+
+    @Test("bankImageIcon is empty Data when provider is nil")
+    func bankImageIconEmptyWhenNilProvider() {
+        let sut = makeSUT(provider: nil)
+
+        #expect(sut.bankImageIcon == Data(),
+                "bankImageIcon must be empty Data when no provider is supplied")
+    }
+
+    // MARK: - shouldShowBrandedView
+
+    @Test("shouldShowBrandedView is true only for fullVisible",
+          arguments: zip(
+            [IngredientBrandTypeEnum.fullVisible, .paymentComponent, .invisible],
+            [true, false, false]
+          ))
+    func shouldShowBrandedView(brandType: IngredientBrandTypeEnum, expected: Bool) {
+        let sut = makeSUT(clientConfiguration: .test(ingredientBrandType: brandType))
+
+        #expect(sut.shouldShowBrandedView == expected,
+                "shouldShowBrandedView must be \(expected) for brandType \(brandType)")
+    }
+
+    @Test("shouldShowBrandedView is false when clientConfiguration is nil")
+    func shouldShowBrandedViewNilConfig() {
+        let sut = makeSUT(clientConfiguration: nil)
+
+        #expect(sut.shouldShowBrandedView == false,
+                "shouldShowBrandedView must be false when clientConfiguration is nil")
+    }
+
+    // MARK: - Delegate forwarding
+
+    @Test("didTapOnContinue forwards the paymentRequestId to the delegate")
+    func didTapOnContinueNotifiesDelegate() {
+        let sut = makeSUT(paymentRequestId: "req-789")
+        let delegate = MockShareInvoiceDelegate()
+        sut.viewDelegate = delegate
+
+        sut.didTapOnContinue()
+
+        #expect(delegate.continueTappedRequestId == "req-789",
+                "didTapOnContinue must call didTapOnContinueToShareInvoice with the correct paymentRequestId")
+    }
+}

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Tests/GiniInternalPaymentSDKTests/ShareInvoiceBottomViewModelTests.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Tests/GiniInternalPaymentSDKTests/ShareInvoiceBottomViewModelTests.swift
@@ -16,7 +16,7 @@ struct ShareInvoiceBottomViewModelTests {
 
     // MARK: - Helpers
 
-    private func makeSUT(provider: PaymentProvider? = .make(name: "Test Bank"),
+    private func makeSUT(provider: PaymentProvider? = .stub(name: "Test Bank"),
                          paymentRequestId: String = "request-123",
                          clientConfiguration: ClientConfiguration? = nil) -> ShareInvoiceBottomViewModel {
         ShareInvoiceBottomViewModel(selectedPaymentProvider: provider,
@@ -35,7 +35,7 @@ struct ShareInvoiceBottomViewModelTests {
 
     @Test("titleText substitutes [BANK] with the provider name")
     func titleTextSubstitutesBankName() {
-        let sut = makeSUT(provider: .make(name: "Sparkasse"))
+        let sut = makeSUT(provider: .stub(name: "Sparkasse"))
 
         #expect(sut.titleText == "Share with Sparkasse",
                 "titleText must replace [BANK] with the selected payment provider's name")
@@ -51,7 +51,7 @@ struct ShareInvoiceBottomViewModelTests {
 
     @Test("descriptionLabelText substitutes [BANK] with the provider name")
     func descriptionLabelTextSubstitutesBankName() {
-        let sut = makeSUT(provider: .make(name: "ING"))
+        let sut = makeSUT(provider: .stub(name: "ING"))
 
         #expect(sut.descriptionLabelText == "Open ING to pay",
                 "descriptionLabelText must replace [BANK] with the selected payment provider's name")
@@ -59,7 +59,7 @@ struct ShareInvoiceBottomViewModelTests {
 
     @Test("continueButtonText substitutes [BANK] with the provider name")
     func continueButtonTextSubstitutesBankName() {
-        let sut = makeSUT(provider: .make(name: "DKB"))
+        let sut = makeSUT(provider: .stub(name: "DKB"))
 
         #expect(sut.continueButtonText == "Continue with DKB",
                 "continueButtonText must replace [BANK] with the selected payment provider's name")


### PR DESCRIPTION
## Pull Request Description

Add BanksBottomViewModelTests, PaymentComponentViewModelTests, ShareInvoiceBottomViewModelTests, and InstallAppBottomViewModelTests covering filtering, sorting, deduplication, [BANK] substitution, shouldShowBrandedView (parameterised), UserDefaults usage tracking, and delegate forwarding.

Extract all mock classes into PaymentTestMocks.swift and consolidate shared test factories (configs, strings, ClientConfiguration, PaymentProvider.make) into PaymentReviewTestHelpers.swift; remove duplicate private extensions from AccessibilityTests.swift.


Will be merged in HEAL-336