### PR TITLE
Heal 328 medium priority issues

### DIFF
--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/Extensions/View+Accessibility.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/Extensions/View+Accessibility.swift
@@ -1,0 +1,26 @@
+//
+//  View+Accessibility.swift
+//
+//  Copyright © 2026 Gini GmbH. All rights reserved.
+//
+
+import SwiftUI
+
+extension View {
+    /**
+     Applies `.accessibilityHint` only when a non-nil, non-empty message is provided,
+     leaving the hint untouched otherwise.
+     Use this to surface validation errors without displacing the SwiftUI `TextField`'s
+     default accessibility value (the user-entered text).
+     - Parameters:
+       - message: The hint message to expose, or `nil` to leave the hint untouched.
+     */
+    @ViewBuilder
+    func accessibilityHintIfPresent(_ message: String?) -> some View {
+        if let message, !message.isEmpty {
+            self.accessibilityHint(message)
+        } else {
+            self
+        }
+    }
+}

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentInfo/PaymentInfoConfiguration.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentInfo/PaymentInfoConfiguration.swift
@@ -85,6 +85,8 @@ public struct PaymentInfoStrings {
     let titleText: String
     let payBillsTitleText: String
     let payBillsDescriptionText: String
+    let accessibilityExpandedText: String
+    let accessibilityCollapsedText: String
 
     let answers: [String]
     let questions: [String]
@@ -100,7 +102,9 @@ public struct PaymentInfoStrings {
                 payBillsTitleText: String,
                 payBillsDescriptionText: String,
                 answers: [String],
-                questions: [String]) {
+                questions: [String],
+                accessibilityExpandedText: String,
+                accessibilityCollapsedText: String) {
         self.accessibilityCloseText = accessibilityCloseText
         self.answers = answers
         self.questions = questions
@@ -113,5 +117,7 @@ public struct PaymentInfoStrings {
         self.answerPrivacyPolicyText = answerPrivacyPolicyText
         self.privacyPolicyURLText = privacyPolicyURLText
         self.questionsTitleText = questionsTitleText
+        self.accessibilityExpandedText = accessibilityExpandedText
+        self.accessibilityCollapsedText = accessibilityCollapsedText
     }
 }

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentInfo/PaymentInfoQuestionHeaderViewCell.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentInfo/PaymentInfoQuestionHeaderViewCell.swift
@@ -69,7 +69,7 @@ final class PaymentInfoQuestionHeaderViewCell: UIView {
         extendedImageView.image = viewModel.extendedIcon
         extendedImageView.tintColor = viewModel.iconTintColor
         accessibilityLabel = viewModel.titleText
-        accessibilityValue = viewModel.isExpanded ? viewModel.expandedAccessibilityText : viewModel.collapsedAccessibilityText
+        accessibilityValue = viewModel.isExpanded ? viewModel.toggleAccessibilityStrings.expanded : viewModel.toggleAccessibilityStrings.collapsed
     }
     
     private func setupConstraints() {
@@ -95,14 +95,19 @@ final class PaymentInfoQuestionHeaderViewCell: UIView {
 }
 
 struct PaymentInfoQuestionHeaderViewModel {
+
+    struct ToggleAccessibilityStrings {
+        let expanded: String
+        let collapsed: String
+    }
+
     let titleText: String
     let titleFont: UIFont
     let titleColor: UIColor
     let extendedIcon: UIImage
     let iconTintColor: UIColor
     let isExpanded: Bool
-    let expandedAccessibilityText: String
-    let collapsedAccessibilityText: String
+    let toggleAccessibilityStrings: ToggleAccessibilityStrings
 
     init(titleText: String,
          titleFont: UIFont,
@@ -110,16 +115,14 @@ struct PaymentInfoQuestionHeaderViewModel {
          extendedIcon: UIImage,
          iconTintColor: UIColor,
          isExpanded: Bool,
-         expandedAccessibilityText: String,
-         collapsedAccessibilityText: String) {
+         toggleAccessibilityStrings: ToggleAccessibilityStrings) {
         self.titleText = titleText
         self.titleFont = titleFont
         self.titleColor = titleColor
         self.extendedIcon = extendedIcon.withRenderingMode(.alwaysTemplate)
         self.iconTintColor = iconTintColor
         self.isExpanded = isExpanded
-        self.expandedAccessibilityText = expandedAccessibilityText
-        self.collapsedAccessibilityText = collapsedAccessibilityText
+        self.toggleAccessibilityStrings = toggleAccessibilityStrings
     }
 }
 

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentInfo/PaymentInfoQuestionHeaderViewCell.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentInfo/PaymentInfoQuestionHeaderViewCell.swift
@@ -69,6 +69,7 @@ final class PaymentInfoQuestionHeaderViewCell: UIView {
         extendedImageView.image = viewModel.extendedIcon
         extendedImageView.tintColor = viewModel.iconTintColor
         accessibilityLabel = viewModel.titleText
+        accessibilityValue = viewModel.isExpanded ? viewModel.expandedAccessibilityText : viewModel.collapsedAccessibilityText
     }
     
     private func setupConstraints() {
@@ -99,14 +100,26 @@ struct PaymentInfoQuestionHeaderViewModel {
     let titleColor: UIColor
     let extendedIcon: UIImage
     let iconTintColor: UIColor
+    let isExpanded: Bool
+    let expandedAccessibilityText: String
+    let collapsedAccessibilityText: String
 
-
-    init(titleText: String, titleFont: UIFont, titleColor: UIColor, extendedIcon: UIImage, iconTintColor: UIColor) {
+    init(titleText: String,
+         titleFont: UIFont,
+         titleColor: UIColor,
+         extendedIcon: UIImage,
+         iconTintColor: UIColor,
+         isExpanded: Bool,
+         expandedAccessibilityText: String,
+         collapsedAccessibilityText: String) {
         self.titleText = titleText
         self.titleFont = titleFont
         self.titleColor = titleColor
         self.extendedIcon = extendedIcon.withRenderingMode(.alwaysTemplate)
         self.iconTintColor = iconTintColor
+        self.isExpanded = isExpanded
+        self.expandedAccessibilityText = expandedAccessibilityText
+        self.collapsedAccessibilityText = collapsedAccessibilityText
     }
 }
 

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentInfo/PaymentInfoViewController.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentInfo/PaymentInfoViewController.swift
@@ -287,6 +287,7 @@ public final class PaymentInfoViewController: GiniBottomSheetViewController {
         viewModel.questions[section].isExtended = !isExtended
         questionsTableView.reloadData()
         questionsTableView.layoutIfNeeded()
+        UIAccessibility.post(notification: .layoutChanged, argument: questionsTableView.headerView(forSection: section))
     }
     
     private func bindToTableViewSizeUpdates() {

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentInfo/PaymentInfoViewModel.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentInfo/PaymentInfoViewModel.swift
@@ -108,11 +108,14 @@ public final class PaymentInfoViewModel {
     }
 
     func infoQuestionHeaderViewModel(at index: Int) -> PaymentInfoQuestionHeaderViewModel {
-        PaymentInfoQuestionHeaderViewModel(titleText: questions[index].title, 
+        PaymentInfoQuestionHeaderViewModel(titleText: questions[index].title,
                                            titleFont: configuration.questionHeaderFont,
                                            titleColor: configuration.questionHeaderTitleColor,
                                            extendedIcon: questions[index].isExtended ? configuration.questionHeaderMinusIcon : configuration.questionHeaderPlusIcon,
-                                           iconTintColor: configuration.questionHeaderIconTintColor)
+                                           iconTintColor: configuration.questionHeaderIconTintColor,
+                                           isExpanded: questions[index].isExtended,
+                                           expandedAccessibilityText: strings.accessibilityExpandedText,
+                                           collapsedAccessibilityText: strings.accessibilityCollapsedText)
     }
 
     func infoBankCellModel(at index: Int) -> PaymentInfoBankCollectionViewCellModel {

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentInfo/PaymentInfoViewModel.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentInfo/PaymentInfoViewModel.swift
@@ -114,8 +114,8 @@ public final class PaymentInfoViewModel {
                                            extendedIcon: questions[index].isExtended ? configuration.questionHeaderMinusIcon : configuration.questionHeaderPlusIcon,
                                            iconTintColor: configuration.questionHeaderIconTintColor,
                                            isExpanded: questions[index].isExtended,
-                                           expandedAccessibilityText: strings.accessibilityExpandedText,
-                                           collapsedAccessibilityText: strings.accessibilityCollapsedText)
+                                           toggleAccessibilityStrings: .init(expanded: strings.accessibilityExpandedText,
+                                                                             collapsed: strings.accessibilityCollapsedText))
     }
 
     func infoBankCellModel(at index: Int) -> PaymentInfoBankCollectionViewCellModel {

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/Views/PaymentInformation/PaymentReviewPaymentInformationView.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/Views/PaymentInformation/PaymentReviewPaymentInformationView.swift
@@ -320,6 +320,19 @@ struct PaymentReviewPaymentInformationView: View {
                 viewModel.updateFieldErrorStates()
                 if isValid {
                     onPayTapped(viewModel.buildPaymentInfo())
+                } else {
+                    let firstError = [viewModel.recipientError,
+                                      viewModel.ibanError,
+                                      viewModel.amountError,
+                                      viewModel.paymentPurposeError]
+                        .compactMap { $0 }.first
+                    if let firstError {
+                        /// Delay allows VoiceOver to finish announcing the button activation
+                        /// before the error announcement is posted, preventing it from being dropped.
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+                            UIAccessibility.post(notification: .announcement, argument: firstError)
+                        }
+                    }
                 }
             }) {
                 Text(viewModel.model.strings.payInvoiceLabelText)

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/Views/PaymentInformation/PaymentReviewPaymentInformationView.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/Views/PaymentInformation/PaymentReviewPaymentInformationView.swift
@@ -327,8 +327,8 @@ struct PaymentReviewPaymentInformationView: View {
                                       viewModel.paymentPurposeError]
                         .compactMap { $0 }.first
                     if let firstError {
-                        /// Delay allows VoiceOver to finish announcing the button activation
-                        /// before the error announcement is posted, preventing it from being dropped.
+                        // Delay allows VoiceOver to finish announcing the button activation
+                        // before the error announcement is posted, preventing it from being dropped.
                         DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
                             UIAccessibility.post(notification: .announcement, argument: firstError)
                         }

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/Views/TextField/GiniTextFieldStyle.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/Views/TextField/GiniTextFieldStyle.swift
@@ -69,6 +69,7 @@ struct GiniTextFieldStyle: TextFieldStyle {
                     .font(Font(giniFont: currentConfiguration.textFont))
                     .frame(minHeight: Constants.textFieldHeight)
                     .accessibilityLabel(title)
+                    .accessibilityValue(state == .error ? (errorMessage ?? "") : "") // — VoiceOver reads error alongside field label
             }
             .padding(.horizontal, Constants.horizontalPadding)
             .padding(.top, Constants.verticalPadding)
@@ -129,6 +130,7 @@ struct GiniTextFieldStyle: TextFieldStyle {
             .multilineTextAlignment(.leading)
             .transition(.asymmetric(insertion: .opacity.combined(with: .move(edge: .top)),
                                     removal: .opacity))
+            .accessibilityHidden(true) // prevents double-reading; error is already in field's accessibilityValue
             .animation(shouldAnimate ? Animation.easeInOut(duration: Constants.animationDuration) : nil,
                        value: errorMessage)
     }

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/Views/TextField/GiniTextFieldStyle.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/Views/TextField/GiniTextFieldStyle.swift
@@ -69,7 +69,7 @@ struct GiniTextFieldStyle: TextFieldStyle {
                     .font(Font(giniFont: currentConfiguration.textFont))
                     .frame(minHeight: Constants.textFieldHeight)
                     .accessibilityLabel(title)
-                    .accessibilityValue(state == .error ? (errorMessage ?? "") : "") // — VoiceOver reads error alongside field label
+                    .accessibilityHintIfPresent(state == .error ? errorMessage : nil)
             }
             .padding(.horizontal, Constants.horizontalPadding)
             .padding(.top, Constants.verticalPadding)

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/ShareInvoice/ShareInvoiceBottomView.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/ShareInvoice/ShareInvoiceBottomView.swift
@@ -446,7 +446,10 @@ public final class ShareInvoiceBottomView: GiniBottomSheetViewController {
         let placeholderLabel = createLabel(text: title, isTitle: true)
         let valueLabel = createLabel(text: subtitle ?? "", isTitle: false)
         valueLabel.adjustsFontSizeToFitWidth = true
-        
+
+        placeholderLabel.isAccessibilityElement = false
+        valueLabel.accessibilityLabel = "\(title), \(subtitle ?? "")"
+
         stackView.addArrangedSubview(placeholderLabel)
         stackView.addArrangedSubview(valueLabel)
         

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/ShareInvoice/ShareInvoiceBottomView.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/ShareInvoice/ShareInvoiceBottomView.swift
@@ -448,7 +448,11 @@ public final class ShareInvoiceBottomView: GiniBottomSheetViewController {
         valueLabel.adjustsFontSizeToFitWidth = true
 
         placeholderLabel.isAccessibilityElement = false
-        valueLabel.accessibilityLabel = "\(title), \(subtitle ?? "")"
+        if let subtitle = subtitle, !subtitle.isEmpty {
+            valueLabel.accessibilityLabel = "\(title), \(subtitle)"
+        } else {
+            valueLabel.accessibilityLabel = title
+        }
 
         stackView.addArrangedSubview(placeholderLabel)
         stackView.addArrangedSubview(valueLabel)

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Tests/GiniInternalPaymentSDKTests/PaymentInfoViewModelTests.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Tests/GiniInternalPaymentSDKTests/PaymentInfoViewModelTests.swift
@@ -42,7 +42,9 @@ struct PaymentInfoViewModelTests {
                            payBillsTitleText: "Bills",
                            payBillsDescriptionText: "Description",
                            answers: answers,
-                           questions: questions)
+                           questions: questions,
+                           accessibilityExpandedText: "Expanded",
+                           accessibilityCollapsedText: "Collapsed")
     }
 
     // MARK: - shouldShowBrandedView

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Tests/GiniInternalPaymentSDKTests/PaymentInfoViewModelTests.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Tests/GiniInternalPaymentSDKTests/PaymentInfoViewModelTests.swift
@@ -145,6 +145,74 @@ struct PaymentInfoViewModelTests {
                 "infoAnswerCellModel must use the answerCellTextColor from the configuration")
     }
 
+    // MARK: - infoQuestionHeaderViewModel — toggle accessibility strings
+
+    @Test("infoQuestionHeaderViewModel exposes the configured expanded accessibility text")
+    func infoQuestionHeaderViewModelExpandedText() {
+        let strings = makeStrings(questions: ["Q"], answers: ["A"])
+        let sut = makeSUT(strings: strings)
+
+        let header = sut.infoQuestionHeaderViewModel(at: 0)
+
+        #expect(header.toggleAccessibilityStrings.expanded == "Expanded",
+                "toggleAccessibilityStrings.expanded must match the strings fixture value")
+    }
+
+    @Test("infoQuestionHeaderViewModel exposes the configured collapsed accessibility text")
+    func infoQuestionHeaderViewModelCollapsedText() {
+        let strings = makeStrings(questions: ["Q"], answers: ["A"])
+        let sut = makeSUT(strings: strings)
+
+        let header = sut.infoQuestionHeaderViewModel(at: 0)
+
+        #expect(header.toggleAccessibilityStrings.collapsed == "Collapsed",
+                "toggleAccessibilityStrings.collapsed must match the strings fixture value")
+    }
+
+    @Test("infoQuestionHeaderViewModel returns isExpanded false when question is not extended")
+    func infoQuestionHeaderViewModelIsNotExpandedByDefault() {
+        let strings = makeStrings(questions: ["Q"], answers: ["A"])
+        let sut = makeSUT(strings: strings)
+
+        let header = sut.infoQuestionHeaderViewModel(at: 0)
+
+        #expect(header.isExpanded == false,
+                "isExpanded must be false when the question has not been toggled open")
+    }
+
+    @Test("infoQuestionHeaderViewModel returns isExpanded true after question is extended")
+    func infoQuestionHeaderViewModelIsExpandedAfterToggle() {
+        let strings = makeStrings(questions: ["Q"], answers: ["A"])
+        let sut = makeSUT(strings: strings)
+        sut.questions[0].isExtended = true
+
+        let header = sut.infoQuestionHeaderViewModel(at: 0)
+
+        #expect(header.isExpanded == true,
+                "isExpanded must be true when the question has been marked as extended")
+    }
+
+    @Test("infoQuestionHeaderViewModel reflects title at the given index")
+    func infoQuestionHeaderViewModelTitleAtIndex() {
+        let strings = makeStrings(questions: ["First", "Second"], answers: ["A1", "A2"])
+        let sut = makeSUT(strings: strings)
+
+        #expect(sut.infoQuestionHeaderViewModel(at: 0).titleText == "First")
+        #expect(sut.infoQuestionHeaderViewModel(at: 1).titleText == "Second")
+    }
+
+    @Test("infoQuestionHeaderViewModel for multiple questions each reports its own isExpanded state")
+    func infoQuestionHeaderViewModelPerQuestionExpansion() {
+        let strings = makeStrings(questions: ["Q1", "Q2"], answers: ["A1", "A2"])
+        let sut = makeSUT(strings: strings)
+        sut.questions[1].isExtended = true
+
+        #expect(sut.infoQuestionHeaderViewModel(at: 0).isExpanded == false,
+                "question 0 must remain collapsed")
+        #expect(sut.infoQuestionHeaderViewModel(at: 1).isExpanded == true,
+                "question 1 must be expanded after setting isExtended")
+    }
+
     // MARK: - infoBankCellModel
 
     @Test("infoBankCellModel exposes the configured border color")

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Tests/GiniInternalPaymentSDKTests/PaymentReviewTestHelpers.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Tests/GiniInternalPaymentSDKTests/PaymentReviewTestHelpers.swift
@@ -317,7 +317,9 @@ extension PaymentInfoStrings {
                            payBillsTitleText: "Pay bills",
                            payBillsDescriptionText: "Description",
                            answers: [],
-                           questions: [])
+                           questions: [],
+                           accessibilityExpandedText: "Expanded",
+                           accessibilityCollapsedText: "Collapsed")
     }
 }
 

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Tests/GiniInternalPaymentSDKTests/View+AccessibilityTests.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Tests/GiniInternalPaymentSDKTests/View+AccessibilityTests.swift
@@ -1,0 +1,77 @@
+//
+//  View+AccessibilityTests.swift
+//  GiniInternalPaymentSDKTests
+//
+//  Copyright © 2026 Gini GmbH. All rights reserved.
+//
+
+import Testing
+import SwiftUI
+import UIKit
+@testable import GiniInternalPaymentSDK
+
+/**
+ Tests for `View.accessibilityHintIfPresent(_:)`.
+ */
+@Suite("View+Accessibility — accessibilityHintIfPresent")
+@MainActor
+struct ViewAccessibilityTests {
+
+    // MARK: - Helpers
+
+    /** Recursively searches a UIView subtree for any accessibility hint that matches `target`. */
+    private func containsHint(_ target: String, in view: UIView) -> Bool {
+        if view.accessibilityHint == target { return true }
+        if let elements = view.accessibilityElements {
+            for element in elements {
+                if let element = element as? NSObject,
+                   element.accessibilityHint == target { return true }
+            }
+        }
+        return view.subviews.contains { containsHint(target, in: $0) }
+    }
+
+    private func makeHostingView<V: View>(_ content: V) -> UIView {
+        let vc = UIHostingController(rootView: content)
+        vc.view.frame = CGRect(x: 0, y: 0, width: 300, height: 50)
+        vc.loadViewIfNeeded()
+        vc.view.layoutIfNeeded()
+        return vc.view
+    }
+
+    // MARK: - nil message
+
+    @Test("nil message does not inject any accessibility hint into the view tree")
+    func nilMessageDoesNotAddHint() {
+        let view = makeHostingView(
+            Text("Test").accessibilityHintIfPresent(nil)
+        )
+
+        #expect(!containsHint("sentinel", in: view),
+                "accessibilityHintIfPresent(nil) must not add a hint to the accessibility tree")
+    }
+
+    // MARK: - empty string message
+
+    @Test("empty string message does not inject any accessibility hint into the view tree")
+    func emptyStringMessageDoesNotAddHint() {
+        let view = makeHostingView(
+            Text("Test").accessibilityHintIfPresent("")
+        )
+
+        #expect(!containsHint("sentinel", in: view),
+                "accessibilityHintIfPresent(\"\") must not add a hint to the accessibility tree")
+    }
+
+    // MARK: - non-empty message
+
+    @Test("non-empty message applies the accessibility hint without error")
+    func nonEmptyMessageAppliesHintModifier() {
+        let view = makeHostingView(
+            Text("Test").accessibilityHintIfPresent("Validation error")
+        )
+
+        #expect(view != nil,
+                "accessibilityHintIfPresent with a non-empty message must produce a renderable view")
+    }
+}

--- a/HealthSDK/GiniHealthSDK/Sources/GiniHealthSDK/Core/GiniHealth+PaymentComponentsStringsProvider.swift
+++ b/HealthSDK/GiniHealthSDK/Sources/GiniHealthSDK/Core/GiniHealth+PaymentComponentsStringsProvider.swift
@@ -150,7 +150,11 @@ extension GiniHealth: PaymentComponentsStringsProvider {
                         NSLocalizedStringPreferredFormat("gini.health.paymentcomponent.payment.info.questions.question.5",
                                                          comment: "Questions titles for question 5"),
                         NSLocalizedStringPreferredFormat("gini.health.paymentcomponent.payment.info.questions.question.6",
-                                                         comment: "Questions titles for question 6")]
+                                                         comment: "Questions titles for question 6")],
+            accessibilityExpandedText: NSLocalizedStringPreferredFormat("gini.health.paymentcomponent.payment.info.questions.accessibility.expanded",
+                                                comment: "Accessibility label for an expanded FAQ question header"),
+            accessibilityCollapsedText: NSLocalizedStringPreferredFormat("gini.health.paymentcomponent.payment.info.questions.accessibility.collapsed",
+                                                comment: "Accessibility label for a collapsed FAQ question header")
         )
     }
 

--- a/HealthSDK/GiniHealthSDK/Sources/GiniHealthSDK/Resources/de.lproj/Localizable.strings
+++ b/HealthSDK/GiniHealthSDK/Sources/GiniHealthSDK/Resources/de.lproj/Localizable.strings
@@ -45,6 +45,9 @@
 "gini.health.paymentcomponent.payment.info.questions.question.4" = "Wer oder Was ist Gini?";
 "gini.health.paymentcomponent.payment.info.questions.question.5" = "Welches Format muss die eingereichte Rechnung haben?";
 "gini.health.paymentcomponent.payment.info.questions.question.6" = "Wie erkenne ich, welche Banken unterstützt werden?";
+"gini.health.paymentcomponent.payment.info.questions.accessibility.expanded" = "Erweitert";
+"gini.health.paymentcomponent.payment.info.questions.accessibility.collapsed" = "Reduziert";
+
 "gini.health.paymentcomponent.payment.info.title.label" = "Mehr Informationen";
 "gini.health.paymentcomponent.payment.providers.list.description" = "Sie können die Rechnung nur bezahlen, wenn Sie ein Konto bei einer der unten aufgeführten Banken haben.";
 "gini.health.paymentcomponent.powered.by.gini.label" = "Powered by";
@@ -111,6 +114,10 @@
 "gini.health.paymentcomponent.payment.info.questions.question.4.informal" = "Wer oder Was ist Gini?";
 "gini.health.paymentcomponent.payment.info.questions.question.5.informal" = "Welches Format muss die eingereichte Rechnung haben?";
 "gini.health.paymentcomponent.payment.info.questions.question.6.informal" = "Wie erkenne ich, welche Banken unterstützt werden?";
+
+"gini.health.paymentcomponent.payment.info.questions.accessibility.expanded.informal" = "Erweitert";
+"gini.health.paymentcomponent.payment.info.questions.accessibility.collapsed.informal" = "Reduziert";
+
 "gini.health.paymentcomponent.payment.info.title.label.informal" = "Mehr Informationen";
 "gini.health.paymentcomponent.payment.info.supported.banks.label.informal" = "Unterstützte Banken %@";
 "gini.health.paymentcomponent.payment.providers.list.description.informal" = "Du kannst die Rechnung nur bezahlen, wenn du ein Konto bei einer der unten aufgeführten Banken hast.";

--- a/HealthSDK/GiniHealthSDK/Sources/GiniHealthSDK/Resources/en.lproj/Localizable.strings
+++ b/HealthSDK/GiniHealthSDK/Sources/GiniHealthSDK/Resources/en.lproj/Localizable.strings
@@ -58,6 +58,9 @@
 "gini.health.paymentcomponent.payment.info.questions.answer.5" = "Whether a photo of an invoice, screenshot or digital PDF - any format is suitable. Please just make sure that all payment information such as IBAN, recipient, purpose and amount are visible and not cut off.";
 "gini.health.paymentcomponent.payment.info.questions.answer.6" = "The banks that support the Gini payment function are displayed in the bank selection menu. To use it, you must have installed your bank's mobile banking app on the same smartphone or tablet on which you use the insurance app. If you have not installed any of the banking apps, you can download them from the Apple App Store or Google Playstore. Subsequent activation of the banking app may be necessary.";
 "gini.health.paymentcomponent.payment.info.questions.answer.clickable.text" = "privacy policy[LINK]";
+"gini.health.paymentcomponent.payment.info.questions.accessibility.expanded" = "Expanded";
+"gini.health.paymentcomponent.payment.info.questions.accessibility.collapsed" = "Collapsed";
+
 "gini.health.paymentcomponent.payment.info.gini.link" = "https://gini.net/en/";
 "gini.health.paymentcomponent.payment.info.gini.privacypolicy.link" = "";
 "gini.health.paymentcomponent.install.app.bottom.sheet.title" = "Invoice data ready to share with the [BANK] bank";


### PR DESCRIPTION
## Pull Request Description

<!-- Briefly explain **what** this PR does and **why**. Mention the motivation, feature, or issue it's addressing. -->

[HEAL-328](https://ginis.atlassian.net/browse/HEAL-328)<!-- Closes ticket number PP-####; Replace with JIRA ticket if relevant -->

This PR focuses on addressing medium-priority UX/accessibility issues in the Health SDK payment components and the InternalPaymentSDK, primarily improving VoiceOver behavior in the payment review flow, share-invoice sheet, and payment info FAQ (expand/collapse).

**Changes:**
- Add localized strings and model plumbing for announcing FAQ expanded/collapsed state via accessibility.
- Improve VoiceOver output for payment review validation errors and text-field error messaging.
- Adjust accessibility labeling in the Share Invoice bottom sheet’s payment info fields.

<!--

Some description of HOW you achieved it. Perhaps give a high level description of the chnages you did. Did you need to refactor something? What tradeoffs did you take?

-->


[HEAL-328]: https://ginis.atlassian.net/browse/HEAL-328?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ