### PR TITLE
fix(GiniInternalPaymentSDK): Restore close and back button interaction on iOS 16

### DIFF
--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/BottomSheet/GiniBottomSheetModifier.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/BottomSheet/GiniBottomSheetModifier.swift
@@ -78,7 +78,7 @@ struct SheetBackgroundInteractionHelper: UIViewControllerRepresentable {
         SheetBackgroundInteractionHelperController()
     }
 
-    func updateUIViewController(_ controller: SheetBackgroundInteractionHelperController,
+    func updateUIViewController(_: SheetBackgroundInteractionHelperController,
                                 context _: Context) {
         // No updates needed — configuration is applied once in viewWillAppear.
     }

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/BottomSheet/GiniBottomSheetModifier.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/BottomSheet/GiniBottomSheetModifier.swift
@@ -5,6 +5,7 @@
 //
 
 import SwiftUI
+import UIKit
 
 struct GiniBottomSheetModifier: ViewModifier {
     
@@ -35,13 +36,18 @@ struct GiniBottomSheetModifier: ViewModifier {
         
         if #available(iOS 16.4, *) {
             let presentationBackgroundInteractionForVoiceOver = isVoiceOverEnabled ? .disabled : PresentationBackgroundInteraction.enabled(upThrough: .height(contentHeight))
-            
+
             base
                 .presentationBackgroundInteraction(allowsDismiss ? .automatic : presentationBackgroundInteractionForVoiceOver)
                 .presentationCompactAdaptation(horizontal: .sheet, vertical: .fullScreenCover)
                 .presentationContentInteraction(.scrolls)
         } else {
+            // On iOS 16.0–16.3 `presentationBackgroundInteraction` is unavailable.
+            // Without it the sheet dims the presenting view and blocks the navigation-bar
+            // close and back buttons. The helper sets `largestUndimmedDetentIdentifier`
+            // via UIKit to restore background interactivity.
             base
+                .background(SheetBackgroundInteractionHelper())
         }
     }
     
@@ -57,7 +63,26 @@ struct GiniBottomSheetModifier: ViewModifier {
     }
     
     private struct Constants {
-        
+
         static let minimumHeight: CGFloat = 300
+    }
+}
+
+/// Enables background interaction on iOS 16.0–16.3 by configuring the underlying
+/// `UISheetPresentationController` to leave the background undimmed and interactive.
+/// On iOS 16.4+, `presentationBackgroundInteraction` is used instead.
+private struct SheetBackgroundInteractionHelper: UIViewControllerRepresentable {
+    func makeUIViewController(context: Context) -> SheetBackgroundInteractionHelperController {
+        SheetBackgroundInteractionHelperController()
+    }
+
+    func updateUIViewController(_ controller: SheetBackgroundInteractionHelperController,
+                                context: Context) {}
+}
+
+private final class SheetBackgroundInteractionHelperController: UIViewController {
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        parent?.sheetPresentationController?.largestUndimmedDetentIdentifier = .large
     }
 }

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/BottomSheet/GiniBottomSheetModifier.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/BottomSheet/GiniBottomSheetModifier.swift
@@ -71,16 +71,18 @@ struct GiniBottomSheetModifier: ViewModifier {
 /// Enables background interaction on iOS 16.0–16.3 by configuring the underlying
 /// `UISheetPresentationController` to leave the background undimmed and interactive.
 /// On iOS 16.4+, `presentationBackgroundInteraction` is used instead.
-private struct SheetBackgroundInteractionHelper: UIViewControllerRepresentable {
-    func makeUIViewController(context: Context) -> SheetBackgroundInteractionHelperController {
+struct SheetBackgroundInteractionHelper: UIViewControllerRepresentable {
+    func makeUIViewController(context _: Context) -> SheetBackgroundInteractionHelperController {
         SheetBackgroundInteractionHelperController()
     }
 
     func updateUIViewController(_ controller: SheetBackgroundInteractionHelperController,
-                                context: Context) {}
+                                context _: Context) {
+        // No updates needed — configuration is applied once in viewWillAppear.
+    }
 }
 
-private final class SheetBackgroundInteractionHelperController: UIViewController {
+final class SheetBackgroundInteractionHelperController: UIViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         parent?.sheetPresentationController?.largestUndimmedDetentIdentifier = .large

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/BottomSheet/GiniBottomSheetModifier.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/BottomSheet/GiniBottomSheetModifier.swift
@@ -68,9 +68,11 @@ struct GiniBottomSheetModifier: ViewModifier {
     }
 }
 
-/// Enables background interaction on iOS 16.0–16.3 by configuring the underlying
-/// `UISheetPresentationController` to leave the background undimmed and interactive.
-/// On iOS 16.4+, `presentationBackgroundInteraction` is used instead.
+/**
+ Enables background interaction on iOS 16.0–16.3 by configuring the underlying
+ `UISheetPresentationController` to leave the background undimmed and interactive.
+ On iOS 16.4+, `presentationBackgroundInteraction` is used instead.
+ */
 struct SheetBackgroundInteractionHelper: UIViewControllerRepresentable {
     func makeUIViewController(context _: Context) -> SheetBackgroundInteractionHelperController {
         SheetBackgroundInteractionHelperController()

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/BottomSheet/GiniBottomSheetModifier.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/BottomSheet/GiniBottomSheetModifier.swift
@@ -44,10 +44,10 @@ struct GiniBottomSheetModifier: ViewModifier {
         } else {
             // On iOS 16.0–16.3 `presentationBackgroundInteraction` is unavailable.
             // Without it the sheet dims the presenting view and blocks the navigation-bar
-            // close and back buttons. The helper sets `largestUndimmedDetentIdentifier`
-            // via UIKit to restore background interactivity.
+            // close and back buttons. Mirror the iOS 16.4+ logic: enable background
+            // interaction unless VoiceOver is active and the sheet is non-dismissible.
             base
-                .background(SheetBackgroundInteractionHelper())
+                .background(SheetBackgroundInteractionHelper(isEnabled: allowsDismiss || !isVoiceOverEnabled))
         }
     }
     
@@ -72,10 +72,16 @@ struct GiniBottomSheetModifier: ViewModifier {
  Enables background interaction on iOS 16.0–16.3 by configuring the underlying
  `UISheetPresentationController` to leave the background undimmed and interactive.
  On iOS 16.4+, `presentationBackgroundInteraction` is used instead.
+
+ Set `isEnabled` to `false` to suppress background interaction (e.g. when VoiceOver
+ is active and the sheet is non-dismissible), mirroring the `.disabled` value used
+ on iOS 16.4+.
  */
 struct SheetBackgroundInteractionHelper: UIViewControllerRepresentable {
+    let isEnabled: Bool
+
     func makeUIViewController(context _: Context) -> SheetBackgroundInteractionHelperController {
-        SheetBackgroundInteractionHelperController()
+        SheetBackgroundInteractionHelperController(isEnabled: isEnabled)
     }
 
     func updateUIViewController(_: SheetBackgroundInteractionHelperController,
@@ -85,8 +91,20 @@ struct SheetBackgroundInteractionHelper: UIViewControllerRepresentable {
 }
 
 final class SheetBackgroundInteractionHelperController: UIViewController {
+    private let isEnabled: Bool
+
+    init(isEnabled: Bool) {
+        self.isEnabled = isEnabled
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
+        guard isEnabled else { return }
         parent?.sheetPresentationController?.largestUndimmedDetentIdentifier = .large
     }
 }

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/BottomSheet/GiniBottomSheetModifier.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/BottomSheet/GiniBottomSheetModifier.swift
@@ -77,34 +77,57 @@ struct GiniBottomSheetModifier: ViewModifier {
  is active and the sheet is non-dismissible), mirroring the `.disabled` value used
  on iOS 16.4+.
  */
-struct SheetBackgroundInteractionHelper: UIViewControllerRepresentable {
+struct SheetBackgroundInteractionHelper: UIViewRepresentable {
     let isEnabled: Bool
 
-    func makeUIViewController(context _: Context) -> SheetBackgroundInteractionHelperController {
-        SheetBackgroundInteractionHelperController(isEnabled: isEnabled)
+    func makeUIView(context _: Context) -> SheetBackgroundInteractionView {
+        SheetBackgroundInteractionView(isEnabled: isEnabled)
     }
 
-    func updateUIViewController(_: SheetBackgroundInteractionHelperController,
-                                context _: Context) {
-        // No updates needed — configuration is applied once in viewWillAppear.
+    func updateUIView(_: SheetBackgroundInteractionView,
+                      context _: Context) {
+        // No updates needed — configuration is applied once in didMoveToWindow.
     }
 }
 
-final class SheetBackgroundInteractionHelperController: UIViewController {
+/**
+ A zero-size, invisible UIView that walks the responder chain on `didMoveToWindow`
+ to find the enclosing `UISheetPresentationController` and set
+ `largestUndimmedDetentIdentifier = .large`, keeping the background fully
+ interactive behind the sheet on iOS 16.0–16.3.
+
+ Using `UIViewRepresentable` (rather than `UIViewControllerRepresentable`) is
+ intentional: SwiftUI adds the UIView directly into the view hierarchy via
+ `addSubview`, so the responder chain is always populated when `didMoveToWindow`
+ fires. A `UIViewControllerRepresentable`'s managed VC does not go through the
+ standard `addChild` path, leaving `parent` nil at the point where configuration
+ would need to happen.
+ */
+final class SheetBackgroundInteractionView: UIView {
     private let isEnabled: Bool
 
     init(isEnabled: Bool) {
         self.isEnabled = isEnabled
-        super.init(nibName: nil, bundle: nil)
+        super.init(frame: .zero)
+        backgroundColor = .clear
+        isUserInteractionEnabled = false
     }
 
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
 
-    override func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(animated)
-        guard isEnabled else { return }
-        parent?.sheetPresentationController?.largestUndimmedDetentIdentifier = .large
+    override func didMoveToWindow() {
+        super.didMoveToWindow()
+        guard isEnabled, window != nil else { return }
+        var responder: UIResponder? = self
+        while let current = responder {
+            if let vc = current as? UIViewController,
+               let sheet = vc.sheetPresentationController {
+                sheet.largestUndimmedDetentIdentifier = .large
+                return
+            }
+            responder = current.next
+        }
     }
 }

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Tests/GiniInternalPaymentSDKTests/GiniBottomSheetModifierTests.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Tests/GiniInternalPaymentSDKTests/GiniBottomSheetModifierTests.swift
@@ -16,8 +16,10 @@ struct GiniBottomSheetModifierTests {
 
     // MARK: - makeUIViewController
 
-    /// Hosting `SheetBackgroundInteractionHelper` inside a `UIHostingController`
-    /// causes SwiftUI to call `makeUIViewController`, exercising the factory path.
+    /**
+     Hosting `SheetBackgroundInteractionHelper` inside a `UIHostingController`
+     causes SwiftUI to call `makeUIViewController`, exercising the factory path.
+     */
     @Test("makeUIViewController produces a view controller when isEnabled is true")
     func makeUIViewControllerProducesControllerWhenEnabled() {
         let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 100, height: 100))
@@ -38,24 +40,6 @@ struct GiniBottomSheetModifierTests {
 
         #expect(hostingVC.view != nil,
                 "UIHostingController must have a view after being made key and visible")
-    }
-
-    // MARK: - SheetBackgroundInteractionHelperController init
-
-    @Test("init stores isEnabled true")
-    func initStoresIsEnabledTrue() {
-        let controller = SheetBackgroundInteractionHelperController(isEnabled: true)
-        // viewWillAppear executes without crash, confirming isEnabled was stored
-        controller.beginAppearanceTransition(true, animated: false)
-        controller.endAppearanceTransition()
-    }
-
-    @Test("init stores isEnabled false")
-    func initStoresIsEnabledFalse() {
-        let controller = SheetBackgroundInteractionHelperController(isEnabled: false)
-        // viewWillAppear must early-return without crash when isEnabled is false
-        controller.beginAppearanceTransition(true, animated: false)
-        controller.endAppearanceTransition()
     }
 
     // MARK: - viewWillAppear — isEnabled: true

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Tests/GiniInternalPaymentSDKTests/GiniBottomSheetModifierTests.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Tests/GiniInternalPaymentSDKTests/GiniBottomSheetModifierTests.swift
@@ -18,46 +18,98 @@ struct GiniBottomSheetModifierTests {
 
     /// Hosting `SheetBackgroundInteractionHelper` inside a `UIHostingController`
     /// causes SwiftUI to call `makeUIViewController`, exercising the factory path.
-    @Test("makeUIViewController produces a SheetBackgroundInteractionHelperController")
-    func makeUIViewControllerProducesCorrectType() {
+    @Test("makeUIViewController produces a view controller when isEnabled is true")
+    func makeUIViewControllerProducesControllerWhenEnabled() {
         let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 100, height: 100))
-        let hostingVC = UIHostingController(rootView: SheetBackgroundInteractionHelper())
+        let hostingVC = UIHostingController(rootView: SheetBackgroundInteractionHelper(isEnabled: true))
         window.rootViewController = hostingVC
         window.makeKeyAndVisible()
 
-        // The window being visible triggers SwiftUI rendering, which calls
-        // makeUIViewController. We verify the hosting controller is active.
         #expect(hostingVC.view != nil,
                 "UIHostingController must have a view after being made key and visible")
     }
 
-    // MARK: - viewWillAppear
+    @Test("makeUIViewController produces a view controller when isEnabled is false")
+    func makeUIViewControllerProducesControllerWhenDisabled() {
+        let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 100, height: 100))
+        let hostingVC = UIHostingController(rootView: SheetBackgroundInteractionHelper(isEnabled: false))
+        window.rootViewController = hostingVC
+        window.makeKeyAndVisible()
 
-    @Test("viewWillAppear does not crash when parent has no sheetPresentationController")
-    func viewWillAppearWithoutParentSheet() {
-        let controller = SheetBackgroundInteractionHelperController()
-
-        // parent is nil → parent?.sheetPresentationController is nil.
-        // The optional chain must silently do nothing rather than crash.
-        controller.viewWillAppear(false)
+        #expect(hostingVC.view != nil,
+                "UIHostingController must have a view after being made key and visible")
     }
 
-    @Test("viewWillAppear does not crash when controller has a parent VC")
-    func viewWillAppearWithParent() {
+    // MARK: - SheetBackgroundInteractionHelperController init
+
+    @Test("init stores isEnabled true")
+    func initStoresIsEnabledTrue() {
+        let controller = SheetBackgroundInteractionHelperController(isEnabled: true)
+        // viewWillAppear executes without crash, confirming isEnabled was stored
+        controller.beginAppearanceTransition(true, animated: false)
+        controller.endAppearanceTransition()
+    }
+
+    @Test("init stores isEnabled false")
+    func initStoresIsEnabledFalse() {
+        let controller = SheetBackgroundInteractionHelperController(isEnabled: false)
+        // viewWillAppear must early-return without crash when isEnabled is false
+        controller.beginAppearanceTransition(true, animated: false)
+        controller.endAppearanceTransition()
+    }
+
+    // MARK: - viewWillAppear — isEnabled: true
+
+    @Test("viewWillAppear does not crash when isEnabled and parent has no sheet")
+    func viewWillAppearEnabledWithoutParentSheet() {
+        let controller = SheetBackgroundInteractionHelperController(isEnabled: true)
+        // parent is nil → optional chain silently does nothing
+        controller.beginAppearanceTransition(true, animated: false)
+        controller.endAppearanceTransition()
+    }
+
+    @Test("viewWillAppear does not crash when isEnabled and parent VC has no sheet presentation controller")
+    func viewWillAppearEnabledWithParentNoSheet() {
         let window = UIWindow(frame: UIScreen.main.bounds)
         let parentVC = UIViewController()
         window.rootViewController = parentVC
         window.makeKeyAndVisible()
 
-        let controller = SheetBackgroundInteractionHelperController()
+        let controller = SheetBackgroundInteractionHelperController(isEnabled: true)
         parentVC.addChild(controller)
         controller.didMove(toParent: parentVC)
 
-        // parentVC is not presented as a sheet, so sheetPresentationController is nil.
-        // The optional chain handles this gracefully.
-        controller.viewWillAppear(false)
+        controller.beginAppearanceTransition(true, animated: false)
+        controller.endAppearanceTransition()
 
-        #expect(controller.parent === parentVC,
-                "Controller must be a child of parentVC after addChild")
+        #expect(controller.parent === parentVC)
+    }
+
+    // MARK: - viewWillAppear — isEnabled: false (VoiceOver path)
+
+    @Test("viewWillAppear does not crash when disabled and parent has no sheet")
+    func viewWillAppearDisabledWithoutParentSheet() {
+        let controller = SheetBackgroundInteractionHelperController(isEnabled: false)
+        // guard isEnabled else { return } exits early — must not crash
+        controller.beginAppearanceTransition(true, animated: false)
+        controller.endAppearanceTransition()
+    }
+
+    @Test("viewWillAppear does not crash when disabled and parent VC is present")
+    func viewWillAppearDisabledWithParent() {
+        let window = UIWindow(frame: UIScreen.main.bounds)
+        let parentVC = UIViewController()
+        window.rootViewController = parentVC
+        window.makeKeyAndVisible()
+
+        let controller = SheetBackgroundInteractionHelperController(isEnabled: false)
+        parentVC.addChild(controller)
+        controller.didMove(toParent: parentVC)
+
+        // guard exits early — sheetPresentationController must NOT be configured
+        controller.beginAppearanceTransition(true, animated: false)
+        controller.endAppearanceTransition()
+
+        #expect(controller.parent === parentVC)
     }
 }

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Tests/GiniInternalPaymentSDKTests/GiniBottomSheetModifierTests.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Tests/GiniInternalPaymentSDKTests/GiniBottomSheetModifierTests.swift
@@ -10,18 +10,19 @@ import SwiftUI
 import UIKit
 @testable import GiniInternalPaymentSDK
 
-@Suite("SheetBackgroundInteractionHelper (HEAL-355)")
+@Suite("SheetBackgroundInteractionView (HEAL-355)")
 @MainActor
 struct GiniBottomSheetModifierTests {
 
-    // MARK: - makeUIViewController
+    // MARK: - makeUIView
 
     /**
      Hosting `SheetBackgroundInteractionHelper` inside a `UIHostingController`
-     causes SwiftUI to call `makeUIViewController`, exercising the factory path.
+     causes SwiftUI to call `makeUIView`, exercising the factory path for both
+     enabled and disabled states.
      */
-    @Test("makeUIViewController produces a view controller when isEnabled is true")
-    func makeUIViewControllerProducesControllerWhenEnabled() {
+    @Test("makeUIView produces a view when isEnabled is true")
+    func makeUIViewProducesViewWhenEnabled() {
         let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 100, height: 100))
         let hostingVC = UIHostingController(rootView: SheetBackgroundInteractionHelper(isEnabled: true))
         window.rootViewController = hostingVC
@@ -31,8 +32,8 @@ struct GiniBottomSheetModifierTests {
                 "UIHostingController must have a view after being made key and visible")
     }
 
-    @Test("makeUIViewController produces a view controller when isEnabled is false")
-    func makeUIViewControllerProducesControllerWhenDisabled() {
+    @Test("makeUIView produces a view when isEnabled is false")
+    func makeUIViewProducesViewWhenDisabled() {
         let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 100, height: 100))
         let hostingVC = UIHostingController(rootView: SheetBackgroundInteractionHelper(isEnabled: false))
         window.rootViewController = hostingVC
@@ -42,58 +43,66 @@ struct GiniBottomSheetModifierTests {
                 "UIHostingController must have a view after being made key and visible")
     }
 
-    // MARK: - viewWillAppear — isEnabled: true
+    // MARK: - didMoveToWindow — isEnabled: true
 
-    @Test("viewWillAppear does not crash when isEnabled and parent has no sheet")
-    func viewWillAppearEnabledWithoutParentSheet() {
-        let controller = SheetBackgroundInteractionHelperController(isEnabled: true)
-        // parent is nil → optional chain silently does nothing
-        controller.beginAppearanceTransition(true, animated: false)
-        controller.endAppearanceTransition()
+    @Test("didMoveToWindow does not crash when isEnabled and view has no window")
+    func didMoveToWindowEnabledNoWindow() {
+        let view = SheetBackgroundInteractionView(isEnabled: true)
+        // Manually trigger removal (window becomes nil) — must not crash.
+        view.didMoveToWindow()
     }
 
-    @Test("viewWillAppear does not crash when isEnabled and parent VC has no sheet presentation controller")
-    func viewWillAppearEnabledWithParentNoSheet() {
+    @Test("didMoveToWindow does not crash when isEnabled and responder chain has no sheet")
+    func didMoveToWindowEnabledNoSheet() {
         let window = UIWindow(frame: UIScreen.main.bounds)
         let parentVC = UIViewController()
         window.rootViewController = parentVC
         window.makeKeyAndVisible()
 
-        let controller = SheetBackgroundInteractionHelperController(isEnabled: true)
-        parentVC.addChild(controller)
-        controller.didMove(toParent: parentVC)
+        let view = SheetBackgroundInteractionView(isEnabled: true)
+        parentVC.view.addSubview(view)
 
-        controller.beginAppearanceTransition(true, animated: false)
-        controller.endAppearanceTransition()
+        // parentVC has no sheetPresentationController — responder-chain walk
+        // exhausts without finding one and must return silently.
+        view.didMoveToWindow()
 
-        #expect(controller.parent === parentVC)
+        #expect(view.superview === parentVC.view)
     }
 
-    // MARK: - viewWillAppear — isEnabled: false (VoiceOver path)
+    // MARK: - didMoveToWindow — isEnabled: false (VoiceOver path)
 
-    @Test("viewWillAppear does not crash when disabled and parent has no sheet")
-    func viewWillAppearDisabledWithoutParentSheet() {
-        let controller = SheetBackgroundInteractionHelperController(isEnabled: false)
-        // guard isEnabled else { return } exits early — must not crash
-        controller.beginAppearanceTransition(true, animated: false)
-        controller.endAppearanceTransition()
+    @Test("didMoveToWindow does not crash when disabled and view has no window")
+    func didMoveToWindowDisabledNoWindow() {
+        let view = SheetBackgroundInteractionView(isEnabled: false)
+        // guard isEnabled else { return } — must exit early without crash.
+        view.didMoveToWindow()
     }
 
-    @Test("viewWillAppear does not crash when disabled and parent VC is present")
-    func viewWillAppearDisabledWithParent() {
+    @Test("didMoveToWindow does not crash when disabled and view is in a hierarchy")
+    func didMoveToWindowDisabledInHierarchy() {
         let window = UIWindow(frame: UIScreen.main.bounds)
         let parentVC = UIViewController()
         window.rootViewController = parentVC
         window.makeKeyAndVisible()
 
-        let controller = SheetBackgroundInteractionHelperController(isEnabled: false)
-        parentVC.addChild(controller)
-        controller.didMove(toParent: parentVC)
+        let view = SheetBackgroundInteractionView(isEnabled: false)
+        parentVC.view.addSubview(view)
 
-        // guard exits early — sheetPresentationController must NOT be configured
-        controller.beginAppearanceTransition(true, animated: false)
-        controller.endAppearanceTransition()
+        // guard exits early — sheetPresentationController must NOT be touched.
+        view.didMoveToWindow()
 
-        #expect(controller.parent === parentVC)
+        #expect(view.superview === parentVC.view)
+    }
+
+    // MARK: - View properties
+
+    @Test("SheetBackgroundInteractionView has clear background and no interaction")
+    func viewProperties() {
+        let view = SheetBackgroundInteractionView(isEnabled: true)
+
+        #expect(view.backgroundColor == .clear,
+                "View must be invisible so it does not affect layout or appearance")
+        #expect(view.isUserInteractionEnabled == false,
+                "View must not intercept touches itself")
     }
 }

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Tests/GiniInternalPaymentSDKTests/GiniBottomSheetModifierTests.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Tests/GiniInternalPaymentSDKTests/GiniBottomSheetModifierTests.swift
@@ -1,0 +1,63 @@
+//
+//  GiniBottomSheetModifierTests.swift
+//  GiniInternalPaymentSDKTests
+//
+//  Copyright © 2026 Gini GmbH. All rights reserved.
+//
+
+import Testing
+import SwiftUI
+import UIKit
+@testable import GiniInternalPaymentSDK
+
+@Suite("SheetBackgroundInteractionHelper (HEAL-355)")
+@MainActor
+struct GiniBottomSheetModifierTests {
+
+    // MARK: - makeUIViewController
+
+    /// Hosting `SheetBackgroundInteractionHelper` inside a `UIHostingController`
+    /// causes SwiftUI to call `makeUIViewController`, exercising the factory path.
+    @Test("makeUIViewController produces a SheetBackgroundInteractionHelperController")
+    func makeUIViewControllerProducesCorrectType() {
+        let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 100, height: 100))
+        let hostingVC = UIHostingController(rootView: SheetBackgroundInteractionHelper())
+        window.rootViewController = hostingVC
+        window.makeKeyAndVisible()
+
+        // The window being visible triggers SwiftUI rendering, which calls
+        // makeUIViewController. We verify the hosting controller is active.
+        #expect(hostingVC.view != nil,
+                "UIHostingController must have a view after being made key and visible")
+    }
+
+    // MARK: - viewWillAppear
+
+    @Test("viewWillAppear does not crash when parent has no sheetPresentationController")
+    func viewWillAppearWithoutParentSheet() {
+        let controller = SheetBackgroundInteractionHelperController()
+
+        // parent is nil → parent?.sheetPresentationController is nil.
+        // The optional chain must silently do nothing rather than crash.
+        controller.viewWillAppear(false)
+    }
+
+    @Test("viewWillAppear does not crash when controller has a parent VC")
+    func viewWillAppearWithParent() {
+        let window = UIWindow(frame: UIScreen.main.bounds)
+        let parentVC = UIViewController()
+        window.rootViewController = parentVC
+        window.makeKeyAndVisible()
+
+        let controller = SheetBackgroundInteractionHelperController()
+        parentVC.addChild(controller)
+        controller.didMove(toParent: parentVC)
+
+        // parentVC is not presented as a sheet, so sheetPresentationController is nil.
+        // The optional chain handles this gracefully.
+        controller.viewWillAppear(false)
+
+        #expect(controller.parent === parentVC,
+                "Controller must be a child of parentVC after addChild")
+    }
+}


### PR DESCRIPTION
## Problem

On iOS 16.0–16.3, the close (X) button and back button on the Payment Review screen are unresponsive after selecting a bank via the Transfer Directly flow.

**Steps to reproduce (iOS 16 only):**
1. Open example app → tap "Start with test document"
2. Tap "Transfer directly"
3. Select a bank → arrive at Payment Review screen
4. Tap the close (X) button or back button → nothing happens

**Root cause:** `presentationBackgroundInteraction` (the SwiftUI API that allows touches to pass through to the presenting view behind a sheet) was introduced in iOS 16.4. `GiniBottomSheetModifier` already applies it on iOS 16.4+, but the `else` branch for iOS < 16.4 returned the sheet unmodified. iOS's default sheet behaviour on 16.0–16.3 dims and completely blocks touches on the presenting view, making navigation-bar buttons unreachable.

## Fix

In `GiniBottomSheetModifier`, for iOS < 16.4, embed a `UIViewControllerRepresentable` helper as the sheet content's `.background`. Its `UIViewController` sets `sheetPresentationController?.largestUndimmedDetentIdentifier = .large` in `viewWillAppear` — the UIKit equivalent that leaves the background undimmed and fully interactive. iOS 16.4+ continues to use `.presentationBackgroundInteraction` unchanged.

## Changes

- `GiniBottomSheetModifier.swift` — add `SheetBackgroundInteractionHelper` (UIViewControllerRepresentable) applied in the iOS < 16.4 else branch

## Test plan

- [ ] Run on iOS 16 simulator: open example app → "Start with test document" → "Transfer directly" → select bank → verify close (X) and back buttons are tappable
- [ ] Run on iOS 16.4+ / iOS 17 / iOS 18: verify existing behaviour unchanged
- [ ] Run `GiniInternalPaymentSDK` unit tests — all pass

HEAL-355