### PR TITLE
fix(GiniHealthSDK): Add dark mode variant to Feedback01 for WCAG 2.1 AA

### DIFF
--- a/HealthSDK/GiniHealthSDK/Sources/GiniHealthSDK/Resources/GiniColors.xcassets/Feedback01.colorset/Contents.json
+++ b/HealthSDK/GiniHealthSDK/Sources/GiniHealthSDK/Resources/GiniColors.xcassets/Feedback01.colorset/Contents.json
@@ -11,6 +11,24 @@
         }
       },
       "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x1C",
+          "green" : "0x1C",
+          "red" : "0xFA"
+        }
+      },
+      "idiom" : "universal"
     }
   ],
   "info" : {


### PR DESCRIPTION
## Summary

- `Feedback01` was defined as a single universal colour (`#C0000A`) that passes WCAG 2.1 AA on light backgrounds but fails in dark mode
- Added a dark-mode appearance (`#FA1C1C`) to `Feedback01.colorset` so the error colour meets AA in all contexts

## Contrast ratios

| Mode | Colour | Background | Ratio | WCAG 2.1 |
|---|---|---|---|---|
| Light (universal) | `#C0000A` | `#F2F2F2` | 5.78:1 | ✅ AA |
| Dark (new) | `#FA1C1C` | `#161616` | 4.52:1 | ✅ AA |
| Dark (new) | `#FA1C1C` | `#000000` | 5.25:1 | ✅ AA |

## Files changed

- `HealthSDK/GiniHealthSDK/Sources/GiniHealthSDK/Resources/GiniColors.xcassets/Feedback01.colorset/Contents.json`

## Test plan

- [ ] Build GiniHealthSDK in light mode — error labels render in dark red (`#C0000A`)
- [ ] Build GiniHealthSDK in dark mode — error labels render in bright red (`#FA1C1C`)
- [ ] Verify contrast with a colour-contrast tool against the dark background surfaces used in the payment review screen

🤖 Generated with [Claude Code](https://claude.com/claude-code)