### PR TITLE
fix(GiniInternalPaymentSDK): Show field-specific validation errors on Payment Review screen

### DIFF
--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/Views/PaymentInformation/PaymentReviewContainerConfiguration.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/Views/PaymentInformation/PaymentReviewContainerConfiguration.swift
@@ -88,20 +88,17 @@ public struct PaymentReviewContainerConfiguration {
  Error messages used for field validation in the payment review screen.
  */
 public struct PaymentReviewFieldErrors {
-    let emptyCheck: String
     let ibanCheck: String
     let recipient: String
     let iban: String
     let amount: String
     let purpose: String
-    
-    public init(emptyCheck: String,
-                ibanCheck: String,
+
+    public init(ibanCheck: String,
                 recipient: String,
                 iban: String,
                 amount: String,
                 purpose: String) {
-        self.emptyCheck = emptyCheck
         self.ibanCheck = ibanCheck
         self.recipient = recipient
         self.iban = iban

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/Views/PaymentInformation/PaymentReviewPaymentInformationObservableModel.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/Views/PaymentInformation/PaymentReviewPaymentInformationObservableModel.swift
@@ -90,7 +90,7 @@ final class PaymentReviewPaymentInformationObservableModel: ObservableObject {
     
     func validateRecipient(_ text: String) -> Bool {
         guard !text.trimmingCharacters(in: .whitespaces).isEmpty else {
-            recipientError = model.strings.fieldErrors.emptyCheck
+            recipientError = model.strings.fieldErrors.recipient
             return false
         }
         recipientError = nil
@@ -114,7 +114,7 @@ final class PaymentReviewPaymentInformationObservableModel: ObservableObject {
     
     func validateAmount(_ text: String, amount: Decimal) -> Bool {
         if text.trimmingCharacters(in: .whitespaces).isEmpty || amount <= 0 {
-            amountError = model.strings.fieldErrors.emptyCheck
+            amountError = model.strings.fieldErrors.amount
             return false
         }
         amountError = nil
@@ -123,7 +123,7 @@ final class PaymentReviewPaymentInformationObservableModel: ObservableObject {
     
     func validatePaymentPurpose(_ text: String) -> Bool {
         guard !text.trimmingCharacters(in: .whitespaces).isEmpty else {
-            paymentPurposeError = model.strings.fieldErrors.emptyCheck
+            paymentPurposeError = model.strings.fieldErrors.purpose
             return false
         }
         paymentPurposeError = nil

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Tests/GiniInternalPaymentSDKTests/PaymentReviewTestHelpers.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Tests/GiniInternalPaymentSDKTests/PaymentReviewTestHelpers.swift
@@ -102,8 +102,7 @@ extension PaymentReviewContainerStrings {
                                                           iban: "IBAN",
                                                           amount: "Amount",
                                                           usage: "Usage")
-        let errors = PaymentReviewFieldErrors(emptyCheck: "Field is empty",
-                                              ibanCheck: "Invalid IBAN",
+        let errors = PaymentReviewFieldErrors(ibanCheck: "Invalid IBAN",
                                               recipient: "Invalid recipient",
                                               iban: "IBAN required",
                                               amount: "Amount required",

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Tests/GiniInternalPaymentSDKTests/PaymentReviewValidationTests.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Tests/GiniInternalPaymentSDKTests/PaymentReviewValidationTests.swift
@@ -15,18 +15,20 @@ struct PaymentReviewValidationTests {
 
     // MARK: validateRecipient
 
-    @Test("empty recipient is invalid and sets error")
+    @Test("empty recipient is invalid and sets field-specific error")
     func emptyRecipientIsInvalid() {
-        let sut = PaymentReviewPaymentInformationObservableModel(model: .test())
+        let model = PaymentReviewContainerViewModel.test()
+        let sut = PaymentReviewPaymentInformationObservableModel(model: model)
         #expect(sut.validateRecipient("") == false, "validateRecipient must return false for an empty string")
-        #expect(sut.recipientError != nil, "validateRecipient must set recipientError for an empty string")
+        #expect(sut.recipientError == model.strings.fieldErrors.recipient, "validateRecipient must set the field-specific recipient error, not the generic emptyCheck")
     }
 
-    @Test("whitespace-only recipient is invalid")
+    @Test("whitespace-only recipient is invalid and sets field-specific error")
     func whitespaceRecipientIsInvalid() {
-        let sut = PaymentReviewPaymentInformationObservableModel(model: .test())
+        let model = PaymentReviewContainerViewModel.test()
+        let sut = PaymentReviewPaymentInformationObservableModel(model: model)
         #expect(sut.validateRecipient("   ") == false, "validateRecipient must return false for a whitespace-only string")
-        #expect(sut.recipientError != nil, "validateRecipient must set recipientError for a whitespace-only string")
+        #expect(sut.recipientError == model.strings.fieldErrors.recipient, "validateRecipient must set the field-specific recipient error for a whitespace-only string")
     }
 
     @Test("non-empty recipient is valid and clears error")
@@ -63,18 +65,20 @@ struct PaymentReviewValidationTests {
 
     // MARK: validateAmount
 
-    @Test("empty amount string is invalid")
+    @Test("empty amount string is invalid and sets field-specific error")
     func emptyAmountIsInvalid() {
-        let sut = PaymentReviewPaymentInformationObservableModel(model: .test())
+        let model = PaymentReviewContainerViewModel.test()
+        let sut = PaymentReviewPaymentInformationObservableModel(model: model)
         #expect(sut.validateAmount("", amount: 0) == false, "validateAmount must return false for an empty amount string")
-        #expect(sut.amountError != nil, "validateAmount must set amountError for an empty amount string")
+        #expect(sut.amountError == model.strings.fieldErrors.amount, "validateAmount must set the field-specific amount error, not the generic emptyCheck")
     }
 
-    @Test("zero decimal amount is invalid")
+    @Test("zero decimal amount is invalid and sets field-specific error")
     func zeroAmountIsInvalid() {
-        let sut = PaymentReviewPaymentInformationObservableModel(model: .test())
+        let model = PaymentReviewContainerViewModel.test()
+        let sut = PaymentReviewPaymentInformationObservableModel(model: model)
         #expect(sut.validateAmount("0.00", amount: 0) == false, "validateAmount must return false for a zero amount")
-        #expect(sut.amountError != nil, "validateAmount must set amountError for a zero amount")
+        #expect(sut.amountError == model.strings.fieldErrors.amount, "validateAmount must set the field-specific amount error, not the generic emptyCheck")
     }
 
     @Test("positive amount is valid and clears error")
@@ -87,11 +91,12 @@ struct PaymentReviewValidationTests {
 
     // MARK: validatePaymentPurpose
 
-    @Test("empty purpose is invalid")
+    @Test("empty purpose is invalid and sets field-specific error")
     func emptyPurposeIsInvalid() {
-        let sut = PaymentReviewPaymentInformationObservableModel(model: .test())
+        let model = PaymentReviewContainerViewModel.test()
+        let sut = PaymentReviewPaymentInformationObservableModel(model: model)
         #expect(sut.validatePaymentPurpose("") == false, "validatePaymentPurpose must return false for an empty string")
-        #expect(sut.paymentPurposeError != nil, "validatePaymentPurpose must set paymentPurposeError for an empty string")
+        #expect(sut.paymentPurposeError == model.strings.fieldErrors.purpose, "validatePaymentPurpose must set the field-specific purpose error, not the generic emptyCheck")
     }
 
     @Test("non-empty purpose is valid and clears error")

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Tests/GiniInternalPaymentSDKTests/PaymentReviewValidationTests.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Tests/GiniInternalPaymentSDKTests/PaymentReviewValidationTests.swift
@@ -20,7 +20,7 @@ struct PaymentReviewValidationTests {
         let model = PaymentReviewContainerViewModel.test()
         let sut = PaymentReviewPaymentInformationObservableModel(model: model)
         #expect(sut.validateRecipient("") == false, "validateRecipient must return false for an empty string")
-        #expect(sut.recipientError == model.strings.fieldErrors.recipient, "validateRecipient must set the field-specific recipient error, not the generic emptyCheck")
+        #expect(sut.recipientError == model.strings.fieldErrors.recipient, "validateRecipient must set the field-specific recipient error")
     }
 
     @Test("whitespace-only recipient is invalid and sets field-specific error")
@@ -70,7 +70,7 @@ struct PaymentReviewValidationTests {
         let model = PaymentReviewContainerViewModel.test()
         let sut = PaymentReviewPaymentInformationObservableModel(model: model)
         #expect(sut.validateAmount("", amount: 0) == false, "validateAmount must return false for an empty amount string")
-        #expect(sut.amountError == model.strings.fieldErrors.amount, "validateAmount must set the field-specific amount error, not the generic emptyCheck")
+        #expect(sut.amountError == model.strings.fieldErrors.amount, "validateAmount must set the field-specific amount error, using the field-specific error")
     }
 
     @Test("zero decimal amount is invalid and sets field-specific error")
@@ -78,7 +78,7 @@ struct PaymentReviewValidationTests {
         let model = PaymentReviewContainerViewModel.test()
         let sut = PaymentReviewPaymentInformationObservableModel(model: model)
         #expect(sut.validateAmount("0.00", amount: 0) == false, "validateAmount must return false for a zero amount")
-        #expect(sut.amountError == model.strings.fieldErrors.amount, "validateAmount must set the field-specific amount error, not the generic emptyCheck")
+        #expect(sut.amountError == model.strings.fieldErrors.amount, "validateAmount must set the field-specific amount error, using the field-specific error")
     }
 
     @Test("positive amount is valid and clears error")
@@ -96,7 +96,7 @@ struct PaymentReviewValidationTests {
         let model = PaymentReviewContainerViewModel.test()
         let sut = PaymentReviewPaymentInformationObservableModel(model: model)
         #expect(sut.validatePaymentPurpose("") == false, "validatePaymentPurpose must return false for an empty string")
-        #expect(sut.paymentPurposeError == model.strings.fieldErrors.purpose, "validatePaymentPurpose must set the field-specific purpose error, not the generic emptyCheck")
+        #expect(sut.paymentPurposeError == model.strings.fieldErrors.purpose, "validatePaymentPurpose must set the field-specific purpose error, using the field-specific error")
     }
 
     @Test("non-empty purpose is valid and clears error")

--- a/HealthSDK/GiniHealthSDK/Sources/GiniHealthSDK/Core/GiniHealth+PaymentComponentsStringsProvider.swift
+++ b/HealthSDK/GiniHealthSDK/Sources/GiniHealthSDK/Core/GiniHealth+PaymentComponentsStringsProvider.swift
@@ -21,8 +21,6 @@ extension GiniHealth: PaymentComponentsStringsProvider {
                                                         comment: "placeholder text for usage input field")
             ),
             fieldErrors: .init(
-                emptyCheck: NSLocalizedStringPreferredFormat("gini.health.errors.failed.default.textfield.validation.check",
-                                                             comment: "the field failed non empty check"),
                 ibanCheck: NSLocalizedStringPreferredFormat("gini.health.errors.failed.iban.validation.check",
                                                             comment: "iban failed validation check"),
                 recipient: NSLocalizedStringPreferredFormat("gini.health.errors.failed.recipient.non.empty.check",

--- a/MerchantSDK/GiniMerchantSDK/Sources/GiniMerchantSDK/Core/GiniMerchant+PaymentComponentsStringsProvider.swift
+++ b/MerchantSDK/GiniMerchantSDK/Sources/GiniMerchantSDK/Core/GiniMerchant+PaymentComponentsStringsProvider.swift
@@ -21,8 +21,6 @@ extension GiniMerchant: PaymentComponentsStringsProvider {
                                                         comment: "placeholder text for usage input field")
             ),
             fieldErrors: .init(
-                emptyCheck: NSLocalizedStringPreferredFormat("gini.merchant.errors.failed.default.textfield.validation.check",
-                                                             comment: "the field failed non empty check"),
                 ibanCheck: NSLocalizedStringPreferredFormat("gini.merchant.errors.failed.iban.validation.check",
                                                             comment: "iban failed validation check"),
                 recipient: NSLocalizedStringPreferredFormat("gini.merchant.errors.failed.recipient.non.empty.check",


### PR DESCRIPTION
## Pull Request Description

[HEAL-361] Fix field-specific validation errors on Payment Review screen

`validateRecipient`, `validateAmount`, and `validatePaymentPurpose` in `PaymentReviewPaymentInformationObservableModel` all used the generic `fieldErrors.emptyCheck` string instead of their dedicated per-field strings (`fieldErrors.recipient`, `fieldErrors.amount`, `fieldErrors.purpose`) which already existed in `PaymentReviewFieldErrors` but were never wired up.

3-line fix — one per validation method. IBAN was already correct and is unchanged. Tests updated to assert the exact field-specific string instead of just `!= nil` to prevent regression.

## Notes for Reviewers

Tested on iPhone 16 Pro, iOS 18.4 simulator.

- Triggered validation with all fields empty — Recipient shows "Recipient is required." / "Empfänger ist notwendig.", Amount shows "Amount is required." / "Betrag ist notwendig.", Reference shows "Reference is required." / "Verwendungszweck ist notwendig."
- IBAN empty/invalid error messages unchanged
- All 11 `PaymentReviewValidationTests` pass

[HEAL-361]: https://ginis.atlassian.net/browse/HEAL-361?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ