### PR TITLE
ci: Fix SonarQube quality gates and coverage conversion for all SDKs

### DIFF
--- a/.github/workflows/bank-api-library.check.yml
+++ b/.github/workflows/bank-api-library.check.yml
@@ -62,7 +62,7 @@ jobs:
       if: ${{ matrix.target == 'GiniBankAPILibrary' }}
       run: |
         bash scripts/xccov-to-sonarqube-generic.sh sonar-coverage.xcresult \
-          | sed 's|path="[^"]*BankAPILibrary/|path="|g' \
+          | sed 's|path="[^"]*/BankAPILibrary/|path="|g' \
           > BankAPILibrary/coverage.xml
 
     - name: Upload coverage report

--- a/.github/workflows/bank-sdk.check.yml
+++ b/.github/workflows/bank-sdk.check.yml
@@ -70,7 +70,7 @@ jobs:
       if: ${{ matrix.target == 'GiniBankSDK' }}
       run: |
         bash scripts/xccov-to-sonarqube-generic.sh sonar-coverage.xcresult \
-          | sed 's|path="[^"]*BankSDK/|path="|g' \
+          | sed 's|path="[^"]*/BankSDK/|path="|g' \
           > BankSDK/coverage.xml
 
     - name: Upload coverage report

--- a/.github/workflows/capture-sdk.check.yml
+++ b/.github/workflows/capture-sdk.check.yml
@@ -63,7 +63,7 @@ jobs:
       if: ${{ matrix.target == 'GiniCaptureSDK' }}
       run: |
         bash scripts/xccov-to-sonarqube-generic.sh sonar-coverage.xcresult \
-          | sed 's|path="[^"]*CaptureSDK/|path="|g' \
+          | sed 's|path="[^"]*/CaptureSDK/|path="|g' \
           > CaptureSDK/coverage.xml
 
     - name: Upload coverage report

--- a/.github/workflows/health-api-library.check.yml
+++ b/.github/workflows/health-api-library.check.yml
@@ -66,7 +66,7 @@ jobs:
       if: ${{ matrix.target == 'GiniHealthAPILibrary' }}
       run: |
         bash scripts/xccov-to-sonarqube-generic.sh sonar-coverage.xcresult \
-          | sed 's|path="[^"]*HealthAPILibrary/|path="|g' \
+          | sed 's|path="[^"]*/HealthAPILibrary/|path="|g' \
           > HealthAPILibrary/coverage.xml
 
     - name: Upload coverage report

--- a/.github/workflows/health-sdk.check.yml
+++ b/.github/workflows/health-sdk.check.yml
@@ -68,7 +68,7 @@ jobs:
       if: ${{ matrix.target == 'GiniHealthSDK' }}
       run: |
         bash scripts/xccov-to-sonarqube-generic.sh sonar-coverage.xcresult \
-          | sed 's|path="[^"]*HealthSDK/|path="|g' \
+          | sed 's|path="[^"]*/HealthSDK/|path="|g' \
           > HealthSDK/coverage.xml
 
     - name: Upload coverage report

--- a/.github/workflows/utilites.check.yml
+++ b/.github/workflows/utilites.check.yml
@@ -32,12 +32,36 @@ jobs:
            cd GiniComponents/Utilities/GiniUtilites
            swift package update
   
-  # Build the GiniUtilities target to verify compilation
+  # Run unit tests and collect coverage for GiniUtilitesTests
     - name: Setup ruby
       uses: ruby/setup-ruby@dffc446db9ba5a0c4446edb5bca1c5c473a806c5 # v1.245.0
       with:
         ruby-version: '3.2.0'
         bundler-cache: true
+
+    - name: Build and run tests for "${{ matrix.target }}"
+      uses: maierj/fastlane-action@5a3b971aaa26776459bb26894d6c1a1a84a311a7 # v3.1.0
+      with:
+        lane: 'run_unit_tests'
+        options: >
+            {
+              "target": "${{ matrix.target }}",
+              "destination": "${{ matrix.destination }}",
+              "result_bundle_path": "sonar-coverage.xcresult"
+            }
+
+    - name: Convert coverage to SonarQube generic format
+      run: |
+        bash scripts/xccov-to-sonarqube-generic.sh sonar-coverage.xcresult \
+          | sed 's|path="[^"]*/GiniComponents/Utilities/|path="|g' \
+          > GiniComponents/Utilities/coverage.xml
+
+    - name: Upload coverage report
+      uses: actions/upload-artifact@v4
+      with:
+        name: sonar-coverage-utilities
+        path: GiniComponents/Utilities/coverage.xml
+        retention-days: 1
 
   sonarqube:
     name: SonarQube
@@ -45,5 +69,6 @@ jobs:
     uses: ./.github/workflows/sonarqube.yml
     with:
       project_base_dir: GiniComponents/Utilities
+      coverage_artifact_name: sonar-coverage-utilities
     secrets:
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/BankAPILibrary/sonar-project.properties
+++ b/BankAPILibrary/sonar-project.properties
@@ -12,5 +12,20 @@ sonar.test.exclusions=**/Pods/**,**/*.xcassets/**
 
 sonar.sourceEncoding=UTF-8
 
+# The following file types contain only UIKit/SwiftUI rendering code that cannot
+# be exercised by unit tests and must be excluded from coverage metrics:
+#
+#   *View.swift              — SwiftUI view bodies (rendered at runtime)
+#   *ViewController.swift    — UIKit VCs (UI lifecycle, layout only)
+#   *TableViewCell.swift     — UITableViewCell subclasses (layout only)
+#   *CollectionViewCell.swift — UICollectionViewCell subclasses (layout only)
+#   *ViewCell.swift           — Other UIKit cell subclasses (header/footer cells)
+sonar.coverage.exclusions=**/Pods/**,\
+  **/*View.swift,\
+  **/*ViewController.swift,\
+  **/*TableViewCell.swift,\
+  **/*CollectionViewCell.swift,\
+  **/*ViewCell.swift
+
 # Coverage
 sonar.coverageReportPaths=coverage.xml

--- a/BankSDK/sonar-project.properties
+++ b/BankSDK/sonar-project.properties
@@ -12,5 +12,20 @@ sonar.test.exclusions=**/Pods/**,**/*.xcassets/**
 
 sonar.sourceEncoding=UTF-8
 
+# The following file types contain only UIKit/SwiftUI rendering code that cannot
+# be exercised by unit tests and must be excluded from coverage metrics:
+#
+#   *View.swift              — SwiftUI view bodies (rendered at runtime)
+#   *ViewController.swift    — UIKit VCs (UI lifecycle, layout only)
+#   *TableViewCell.swift     — UITableViewCell subclasses (layout only)
+#   *CollectionViewCell.swift — UICollectionViewCell subclasses (layout only)
+#   *ViewCell.swift           — Other UIKit cell subclasses (header/footer cells)
+sonar.coverage.exclusions=**/Pods/**,\
+  **/*View.swift,\
+  **/*ViewController.swift,\
+  **/*TableViewCell.swift,\
+  **/*CollectionViewCell.swift,\
+  **/*ViewCell.swift
+
 # Coverage
 sonar.coverageReportPaths=coverage.xml

--- a/CaptureSDK/sonar-project.properties
+++ b/CaptureSDK/sonar-project.properties
@@ -12,5 +12,20 @@ sonar.test.exclusions=**/Pods/**,**/*.xcassets/**
 
 sonar.sourceEncoding=UTF-8
 
+# The following file types contain only UIKit/SwiftUI rendering code that cannot
+# be exercised by unit tests and must be excluded from coverage metrics:
+#
+#   *View.swift              — SwiftUI view bodies (rendered at runtime)
+#   *ViewController.swift    — UIKit VCs (UI lifecycle, layout only)
+#   *TableViewCell.swift     — UITableViewCell subclasses (layout only)
+#   *CollectionViewCell.swift — UICollectionViewCell subclasses (layout only)
+#   *ViewCell.swift           — Other UIKit cell subclasses (header/footer cells)
+sonar.coverage.exclusions=**/Pods/**,\
+  **/*View.swift,\
+  **/*ViewController.swift,\
+  **/*TableViewCell.swift,\
+  **/*CollectionViewCell.swift,\
+  **/*ViewCell.swift
+
 # Coverage
 sonar.coverageReportPaths=coverage.xml

--- a/GiniComponents/Utilities/sonar-project.properties
+++ b/GiniComponents/Utilities/sonar-project.properties
@@ -12,5 +12,20 @@ sonar.test.exclusions=**/Pods/**,**/*.xcassets/**
 
 sonar.sourceEncoding=UTF-8
 
+# The following file types contain only UIKit/SwiftUI rendering code that cannot
+# be exercised by unit tests and must be excluded from coverage metrics:
+#
+#   *View.swift              — SwiftUI view bodies (rendered at runtime)
+#   *ViewController.swift    — UIKit VCs (UI lifecycle, layout only)
+#   *TableViewCell.swift     — UITableViewCell subclasses (layout only)
+#   *CollectionViewCell.swift — UICollectionViewCell subclasses (layout only)
+#   *ViewCell.swift           — Other UIKit cell subclasses (header/footer cells)
+sonar.coverage.exclusions=**/Pods/**,\
+  **/*View.swift,\
+  **/*ViewController.swift,\
+  **/*TableViewCell.swift,\
+  **/*CollectionViewCell.swift,\
+  **/*ViewCell.swift
+
 # Coverage
-# sonar.coverageReportPaths=coverage.xml // No tests for now
+sonar.coverageReportPaths=coverage.xml

--- a/HealthAPILibrary/sonar-project.properties
+++ b/HealthAPILibrary/sonar-project.properties
@@ -12,5 +12,20 @@ sonar.test.exclusions=**/Pods/**,**/*.xcassets/**
 
 sonar.sourceEncoding=UTF-8
 
+# The following file types contain only UIKit/SwiftUI rendering code that cannot
+# be exercised by unit tests and must be excluded from coverage metrics:
+#
+#   *View.swift              — SwiftUI view bodies (rendered at runtime)
+#   *ViewController.swift    — UIKit VCs (UI lifecycle, layout only)
+#   *TableViewCell.swift     — UITableViewCell subclasses (layout only)
+#   *CollectionViewCell.swift — UICollectionViewCell subclasses (layout only)
+#   *ViewCell.swift           — Other UIKit cell subclasses (header/footer cells)
+sonar.coverage.exclusions=**/Pods/**,\
+  **/*View.swift,\
+  **/*ViewController.swift,\
+  **/*TableViewCell.swift,\
+  **/*CollectionViewCell.swift,\
+  **/*ViewCell.swift
+
 # Coverage
 sonar.coverageReportPaths=coverage.xml

--- a/HealthSDK/sonar-project.properties
+++ b/HealthSDK/sonar-project.properties
@@ -12,5 +12,20 @@ sonar.test.exclusions=**/Pods/**,**/*.xcassets/**
 
 sonar.sourceEncoding=UTF-8
 
+# The following file types contain only UIKit/SwiftUI rendering code that cannot
+# be exercised by unit tests and must be excluded from coverage metrics:
+#
+#   *View.swift              — SwiftUI view bodies (rendered at runtime)
+#   *ViewController.swift    — UIKit VCs (UI lifecycle, layout only)
+#   *TableViewCell.swift     — UITableViewCell subclasses (layout only)
+#   *CollectionViewCell.swift — UICollectionViewCell subclasses (layout only)
+#   *ViewCell.swift           — Other UIKit cell subclasses (header/footer cells)
+sonar.coverage.exclusions=**/Pods/**,\
+  **/*View.swift,\
+  **/*ViewController.swift,\
+  **/*TableViewCell.swift,\
+  **/*CollectionViewCell.swift,\
+  **/*ViewCell.swift
+
 # Coverage
 sonar.coverageReportPaths=coverage.xml


### PR DESCRIPTION
## Pull Request Description

[HEAL-369](https://ginis.atlassian.net/browse/HEAL-369)

Fixes two CI issues affecting SonarQube code coverage reporting across all SDKs.

**What changed:**

1. **Coverage `sed` path stripping** — Fixed a greedy `sed` pattern used to normalise absolute file paths in the Xcode coverage XML before uploading to SonarQube. The pattern `[^"]*SDK/` matched the *last* occurrence of e.g. `HealthSDK/` in paths like `.../HealthSDK/GiniHealthSDK/Sources/GiniHealthSDK/File.swift`, stripping too much and producing paths SonarQube could not match to sources (resulting in 0% coverage). Fixed by anchoring the pattern with a leading `/` so it only matches at the repo-level directory boundary.

2. **Coverage exclusions** — Added `sonar.coverage.exclusions` to all SDK `sonar-project.properties` files to exclude untestable UIKit/SwiftUI-only code (`*View.swift`, `*ViewController.swift`, `*TableViewCell.swift`, `*CollectionViewCell.swift`, `*ViewCell.swift`) from coverage metrics. Also enabled `sonar.coverageReportPaths` and added test execution to `utilites.check.yml` (previously only built, never ran tests).

**Affected files:**
- `.github/workflows/bank-api-library.check.yml`
- `.github/workflows/bank-sdk.check.yml`
- `.github/workflows/capture-sdk.check.yml`
- `.github/workflows/health-api-library.check.yml`
- `.github/workflows/health-sdk.check.yml`
- `.github/workflows/utilites.check.yml`
- `*/sonar-project.properties` (BankAPILibrary, BankSDK, CaptureSDK, GiniUtilites, HealthAPILibrary, HealthSDK)

## Notes for Reviewers

- Changes are CI/CD only — no source code or tests were modified.
- Cherry-picked from `fix/ci_coverage_quality_gates` (2 commits: `853728b`, `07325db`).
- **Verification:** Trigger a check workflow on any SDK after merge and confirm SonarQube receives and matches coverage data correctly.
- No manual device testing required.

HEAL-369

[HEAL-369]: https://ginis.atlassian.net/browse/HEAL-369?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ