### PR TITLE
fix(GiniInternalPaymentSDK): Remove close button from InstallAppBottom sheet

### DIFF
--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/InstallApp/InstallAppBottomView.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/InstallApp/InstallAppBottomView.swift
@@ -17,7 +17,7 @@ public final class InstallAppBottomView: GiniBottomSheetViewController {
     }
     
     public var shouldShowInFullScreenInLandscapeMode: Bool {
-        true
+        false
     }
 
     var viewModel: InstallAppBottomViewModel
@@ -29,22 +29,6 @@ public final class InstallAppBottomView: GiniBottomSheetViewController {
     private let contentView = EmptyScrollView()
     private let contentStackView = EmptyStackView().orientation(.vertical)
     
-    private lazy var closeButtonContainerView: EmptyView = {
-        let view = EmptyView()
-        return view
-    }()
-    
-    private lazy var closeButton: UIButton = {
-        let button = UIButton()
-        button.translatesAutoresizingMaskIntoConstraints = false
-        button.setImage(viewModel.configuration.closeIcon.withRenderingMode(.alwaysTemplate),
-                        for: .normal)
-        button.addTarget(self, action: #selector(tapOnCloseIcon), for: .touchUpInside)
-        button.tintColor = viewModel.configuration.closeIconAccentColor
-        button.accessibilityLabel = viewModel.strings.accessibilityCloseIconText
-        return button
-    }()
-
     private let titleView = EmptyView()
 
     private lazy var titleLabel: UILabel = {
@@ -201,7 +185,6 @@ public final class InstallAppBottomView: GiniBottomSheetViewController {
     private func setupAccessibility() {
         view.accessibilityViewIsModal = true
         view.accessibilityElements = [
-            closeButton,
             titleLabel,
             bankIconImageView,
             moreInformationLabel,
@@ -211,7 +194,6 @@ public final class InstallAppBottomView: GiniBottomSheetViewController {
     }
     
     private func setupViewHierarchy() {
-        addCloseButton()
         titleView.addSubview(titleLabel)
         contentStackView.addArrangedSubview(titleView)
         bankView.addSubview(bankIconImageView)
@@ -238,21 +220,6 @@ public final class InstallAppBottomView: GiniBottomSheetViewController {
         ])
     }
     
-    private func addCloseButton() {
-        closeButtonContainerView.addSubview(closeButton)
-        
-        NSLayoutConstraint.activate([
-            closeButton.widthAnchor.constraint(equalToConstant: Constants.closeIconSize),
-            closeButton.heightAnchor.constraint(equalToConstant: Constants.closeIconSize),
-            closeButton.topAnchor.constraint(equalTo: closeButtonContainerView.topAnchor),
-            closeButton.bottomAnchor.constraint(equalTo: closeButtonContainerView.bottomAnchor),
-            closeButton.trailingAnchor.constraint(equalTo: closeButtonContainerView.trailingAnchor,
-                                                 constant: -Constants.viewPaddingConstraint),
-        ])
-        
-        contentStackView.addArrangedSubview(closeButtonContainerView)
-    }
-
     private func setupViewVisibility() {
         poweredByGiniView.isHidden = !viewModel.shouldShowBrandedView
     }
@@ -287,7 +254,6 @@ public final class InstallAppBottomView: GiniBottomSheetViewController {
 
     // Portrait Layout Constraints
     private func setupPortraitConstraints() {
-        closeButtonContainerView.isHidden = true
         deactivateAllConstraints()
         updateMoreInformationStackView(for: .portrait)
 
@@ -302,7 +268,6 @@ public final class InstallAppBottomView: GiniBottomSheetViewController {
 
     // Landscape Layout Constraints
     private func setupLandscapeConstraints() {
-        closeButtonContainerView.isHidden = false
         deactivateAllConstraints()
         updateMoreInformationStackView(for: .landscape)
 
@@ -357,10 +322,6 @@ public final class InstallAppBottomView: GiniBottomSheetViewController {
     @objc private func willEnterForeground() {
         setButtonsState()
         postAccessibilityFocus()
-    }
-    
-    @objc private func tapOnCloseIcon() {
-        dismiss(animated: true)
     }
     
     private func setButtonsState() {
@@ -498,6 +459,5 @@ extension InstallAppBottomView {
         static let bottomViewHeight = 22.0
         static let landscapePadding = 126.0
         static let moreInformationTopPaddingLandscape = 32.0
-        static let closeIconSize = 24.0
     }
 }

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/InstallApp/InstallAppConfiguration.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/InstallApp/InstallAppConfiguration.swift
@@ -15,8 +15,6 @@ public struct InstallAppConfiguration {
     let moreInformationIcon: UIImage
     let appStoreIcon: UIImage
     let bankIconBorderColor: UIColor
-    let closeIcon: UIImage
-    let closeIconAccentColor: UIColor
 
     public init(titleAccentColor: UIColor,
                 titleFont: UIFont,
@@ -25,9 +23,7 @@ public struct InstallAppConfiguration {
                 moreInformationAccentColor: UIColor,
                 moreInformationIcon: UIImage,
                 appStoreIcon: UIImage,
-                bankIconBorderColor: UIColor,
-                closeIcon: UIImage,
-                closeIconAccentColor: UIColor) {
+                bankIconBorderColor: UIColor) {
         self.titleAccentColor = titleAccentColor
         self.titleFont = titleFont
         self.moreInformationFont = moreInformationFont
@@ -36,8 +32,6 @@ public struct InstallAppConfiguration {
         self.moreInformationIcon = moreInformationIcon
         self.appStoreIcon = appStoreIcon
         self.bankIconBorderColor = bankIconBorderColor
-        self.closeIcon = closeIcon
-        self.closeIconAccentColor = closeIconAccentColor
     }
 }
 
@@ -48,21 +42,18 @@ public struct InstallAppStrings {
     let continueLabelText: String
     let accessibilityAppStoreText: String
     let accessibilityBankLogoText: String
-    let accessibilityCloseIconText: String
 
     public init(titlePattern: String,
                 moreInformationTipPattern: String,
                 moreInformationNotePattern: String,
                 continueLabelText: String,
                 accessibilityAppStoreText: String,
-                accessibilityBankLogoText: String,
-                accessibilityCloseIconText: String) {
+                accessibilityBankLogoText: String) {
         self.titlePattern = titlePattern
         self.moreInformationTipPattern = moreInformationTipPattern
         self.moreInformationNotePattern = moreInformationNotePattern
         self.continueLabelText = continueLabelText
         self.accessibilityAppStoreText = accessibilityAppStoreText
         self.accessibilityBankLogoText = accessibilityBankLogoText
-        self.accessibilityCloseIconText = accessibilityCloseIconText
     }
 }

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Tests/GiniInternalPaymentSDKTests/PaymentReviewTestHelpers.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Tests/GiniInternalPaymentSDKTests/PaymentReviewTestHelpers.swift
@@ -381,9 +381,7 @@ extension InstallAppConfiguration {
                                 moreInformationAccentColor: .systemBlue,
                                 moreInformationIcon: UIImage(),
                                 appStoreIcon: UIImage(),
-                                bankIconBorderColor: .systemGray4,
-                                closeIcon: UIImage(),
-                                closeIconAccentColor: .label)
+                                bankIconBorderColor: .systemGray4)
     }
 }
 
@@ -394,8 +392,7 @@ extension InstallAppStrings {
                           moreInformationNotePattern: "Note: install [BANK]",
                           continueLabelText: "Continue",
                           accessibilityAppStoreText: "App Store",
-                          accessibilityBankLogoText: "Bank logo",
-                          accessibilityCloseIconText: "Close")
+                          accessibilityBankLogoText: "Bank logo")
     }
 }
 

--- a/HealthSDK/GiniHealthSDK/Sources/GiniHealthSDK/Core/GiniHealth+PaymentComponentsConfigurationProvider.swift
+++ b/HealthSDK/GiniHealthSDK/Sources/GiniHealthSDK/Core/GiniHealth+PaymentComponentsConfigurationProvider.swift
@@ -62,9 +62,7 @@ extension GiniHealth: PaymentComponentsConfigurationProvider {
             moreInformationAccentColor: GiniColor.standard8.uiColor(),
             moreInformationIcon: GiniHealthImage.info.preferredUIImage(),
             appStoreIcon: GiniHealthImage.appStore.preferredUIImage(),
-            bankIconBorderColor: GiniColor.standard5.uiColor(),
-            closeIcon: GiniHealthImage.close.preferredUIImage(),
-            closeIconAccentColor: GiniColor.standard2.uiColor()
+            bankIconBorderColor: GiniColor.standard5.uiColor()
         )
     }
 

--- a/HealthSDK/GiniHealthSDK/Sources/GiniHealthSDK/Core/GiniHealth+PaymentComponentsStringsProvider.swift
+++ b/HealthSDK/GiniHealthSDK/Sources/GiniHealthSDK/Core/GiniHealth+PaymentComponentsStringsProvider.swift
@@ -80,9 +80,7 @@ extension GiniHealth: PaymentComponentsStringsProvider {
             accessibilityAppStoreText: NSLocalizedStringPreferredFormat("gini.health.paymentcomponent.install.app.bottom.sheet.appstore",
                                                                         comment: "Accessibility label for the App Store button"),
             accessibilityBankLogoText: NSLocalizedStringPreferredFormat("gini.health.paymentcomponent.install.app.bottom.sheet.bank.logo",
-                                                                        comment: "Accessibility label for the bank logo image"),
-            accessibilityCloseIconText: NSLocalizedStringPreferredFormat("gini.health.close.button.accessibility.label",
-                                                                         comment: "close button accessibility label text")
+                                                                        comment: "Accessibility label for the bank logo image")
         )
     }
 

--- a/MerchantSDK/GiniMerchantSDK/Sources/GiniMerchantSDK/Core/GiniMerchant+PaymentComponentsConfigurationProvider.swift
+++ b/MerchantSDK/GiniMerchantSDK/Sources/GiniMerchantSDK/Core/GiniMerchant+PaymentComponentsConfigurationProvider.swift
@@ -62,9 +62,7 @@ extension GiniMerchant: PaymentComponentsConfigurationProvider {
             moreInformationAccentColor: GiniColor.standard3.uiColor(),
             moreInformationIcon: GiniMerchantImage.info.preferredUIImage(),
             appStoreIcon: GiniMerchantImage.appStore.preferredUIImage(),
-            bankIconBorderColor: GiniColor.standard5.uiColor(),
-            closeIcon: GiniMerchantImage.close.preferredUIImage(),
-            closeIconAccentColor: GiniColor.standard2.uiColor()
+            bankIconBorderColor: GiniColor.standard5.uiColor()
         )
     }
 

--- a/MerchantSDK/GiniMerchantSDK/Sources/GiniMerchantSDK/Core/GiniMerchant+PaymentComponentsStringsProvider.swift
+++ b/MerchantSDK/GiniMerchantSDK/Sources/GiniMerchantSDK/Core/GiniMerchant+PaymentComponentsStringsProvider.swift
@@ -80,12 +80,10 @@ extension GiniMerchant: PaymentComponentsStringsProvider {
             accessibilityAppStoreText: NSLocalizedStringPreferredFormat("gini.merchant.paymentcomponent.install.app.bottom.sheet.appstore",
                                                                         comment: "Accessibility label for the App Store button"),
             accessibilityBankLogoText: NSLocalizedStringPreferredFormat("gini.health.paymentcomponent.install.app.bottom.sheet.bank.logo",
-                                                                        comment: "Accessibility label for the bank logo image"),
-            accessibilityCloseIconText: NSLocalizedStringPreferredFormat("gini.health.close.button.accessibility.label",
-                                                                         comment: "close button accessibility label text")
+                                                                        comment: "Accessibility label for the bank logo image")
         )
     }
-    
+
     public var shareInvoiceStrings: ShareInvoiceStrings {
         ShareInvoiceStrings(
             continueLabelText: NSLocalizedStringPreferredFormat("gini.merchant.paymentcomponent.share.invoice.bottom.sheet.continue.button.text",


### PR DESCRIPTION
## Pull Request Description

[HEAL-370](https://ginis.atlassian.net/browse/HEAL-370)

After dismissing the Install App bottom sheet via its landscape close button, the Payment Review screen became unresponsive to taps. The root cause was that the close button called `dismiss(animated:)` programmatically, which does not trigger `UIAdaptivePresentationControllerDelegate.presentationControllerDidDismiss`. As a result, `GiniOverlayWindowPresenter` never tore down its overlay `UIWindow`, which silently intercepted all subsequent touches on the Payment Review screen beneath.

The fix removes the close button from `InstallAppBottomView` entirely, matching the pattern used by `ShareInvoiceBottomView` (swipe-to-dismiss only). This guarantees the overlay window is always torn down via the delegate callback on swipe. `shouldShowInFullScreenInLandscapeMode` is also changed to `false` so the sheet presents edge-attached in landscape, consistent with `BanksBottomView`. The now-unused `closeIcon`/`closeIconAccentColor`/`accessibilityCloseIconText` fields were removed from `InstallAppConfiguration`, `InstallAppStrings`, and their providers in HealthSDK and MerchantSDK.

## Notes for Reviewers

- Tested on iPhone 17 simulator (iOS 18.5)
- Manual checks: reproduce steps — rotate to landscape, tap Pay with uninstalled bank, dismiss Install sheet via close button, verify Payment Review close button is still responsive (swipe-to-dismiss is the only dismiss path now)
- No unit tests added (bug was in UIKit presentation layer; existing 184 tests pass)
- No known limitations or follow-up work

[HEAL-370]: https://ginis.atlassian.net/browse/HEAL-370?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ