### PR TITLE
fix(GiniHealthSDK): Update XCFrameworks workflow and build script for Xcode 26

### DIFF
--- a/.github/workflows/health-sdk.build.xcframeworks.yml
+++ b/.github/workflows/health-sdk.build.xcframeworks.yml
@@ -20,11 +20,11 @@ on:
 jobs:
   prepare-frameworks:
     name: Create Release
-    runs-on: macos-15
+    runs-on: macos-26
     steps:
       - uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd # v1.6.0
         with:
-          xcode-version: '16.4'
+          xcode-version: '26'
 
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/build-healthsdk.sh
+++ b/build-healthsdk.sh
@@ -53,96 +53,6 @@ cp-modules() {
     cp -a "$srcPath/$frName.swiftmodule" "$dstPath/$frName.framework/Modules/$frName.swiftmodule" 2>/dev/null || true
 }
 
-# Function to copy resource bundles
-copy-resources() {
-    local schemeName=$1
-    local dstPath=$2
-    local derivedDataPath=$4
-
-    echo "Copying resources for $schemeName from DerivedDataPath to $dstPath"
-
-    local frameworkDir="$dstPath/$schemeName.framework"
-    mkdir -p "$frameworkDir"
-
-    # Look for Assets.car in various locations
-    local assetCarPath=""
-    local possibleCarPaths=(
-        "$derivedDataPath/Build/Intermediates.noindex/ArchiveIntermediates/GiniHealthSDK/IntermediateBuildFilesPath/${schemeName}.build/Release-iphoneos/${schemeName}.build/assetcatalog_output/thinned/Assets.car"
-        "$derivedDataPath/Build/Intermediates.noindex/ArchiveIntermediates/GiniHealthSDK/IntermediateBuildFilesPath/${schemeName}.build/Release-iphoneos/${schemeName}_${schemeName}.build/assetcatalog_output/thinned/Assets.car"
-        "$derivedDataPath/Build/Intermediates.noindex/ArchiveIntermediates/GiniHealthSDK/BuildProductsPath/Release-iphoneos/${schemeName}.framework/Assets.car"
-    )
-
-    for path in "${possibleCarPaths[@]}"; do
-        if [[ -f "$path" ]]; then
-            assetCarPath="$path"
-            echo "Found Assets.car at: $path"
-            break
-        fi
-    done
-
-    # If not found, search recursively
-    if [[ -z "$assetCarPath" ]]; then
-        assetCarPath=$(find "$derivedDataPath" -name "Assets.car" -type f | grep -v ".xcarchive" | head -1)
-        if [[ -n "$assetCarPath" ]]; then
-            echo "Found Assets.car at: $assetCarPath"
-        fi
-    fi
-
-    # Copy Assets.car if found
-    if [[ -n "$assetCarPath" ]]; then
-        cp "$assetCarPath" "$frameworkDir/"
-        echo "Copied Assets.car to $frameworkDir/"
-    fi
-
-    # Look for bundle
-    local bundlePath=""
-    local possibleBundlePaths=(
-        "$derivedDataPath/Build/Intermediates.noindex/ArchiveIntermediates/GiniHealthSDK/IntermediateBuildFilesPath/UninstalledProducts/iphoneos/${schemeName}_${schemeName}.bundle"
-        "$derivedDataPath/Build/Intermediates.noindex/ArchiveIntermediates/GiniHealthSDK/BuildProductsPath/Release-iphoneos/${schemeName}_${schemeName}.bundle"
-    )
-
-    for path in "${possibleBundlePaths[@]}"; do
-        if [[ -d "$path" ]]; then
-            bundlePath="$path"
-            echo "Found bundle at: $path"
-            break
-        fi
-    done
-
-    # If not found, search recursively
-    if [[ -z "$bundlePath" ]]; then
-        bundlePath=$(find "$derivedDataPath" -name "*${schemeName}*.bundle" -type d | grep -v ".xcarchive" | head -1)
-        if [[ -n "$bundlePath" ]]; then
-            echo "Found bundle at: $bundlePath"
-        fi
-    fi
-
-    # Copy bundle if found
-    if [[ -n "$bundlePath" ]]; then
-        cp -r "$bundlePath" "$frameworkDir/"
-        echo "Copied bundle to $frameworkDir/"
-    fi
-}
-
-# Function to completely strip code signatures from framework
-strip-code-signatures() {
-    local frameworkPath=$1
-
-    echo "Stripping code signatures from $(basename "$frameworkPath")..."
-
-    # Remove signature from framework binary
-    codesign --remove-signature "$frameworkPath" 2>/dev/null || true
-
-    # Remove signatures from all files inside framework
-    find "$frameworkPath" -type f -exec codesign --remove-signature {} \; 2>/dev/null || true
-
-    # Remove all extended attributes (which can contain signatures)
-    find "$frameworkPath" -type f -exec xattr -c {} \; 2>/dev/null || true
-
-    echo "Code signatures stripped from $(basename "$frameworkPath")"
-
-    return 0
-}
 
 # Function to archive a target
 archive() {
@@ -154,7 +64,7 @@ archive() {
 
     local resultFrameworksPath="$outputPath/Products/usr/local/lib"
     local modulesPath="$derivedDataPath/Build/Intermediates.noindex/ArchiveIntermediates/GiniHealthSDK/BuildProductsPath/Release-$sdk"
-
+    
     echo "Archiving for $platform ($sdk)"
     xcodebuild archive -workspace "$srcPath" \
         -scheme GiniHealthSDK \
@@ -164,25 +74,21 @@ archive() {
         -derivedDataPath "$derivedDataPath" \
         SKIP_INSTALL=NO \
         BUILD_LIBRARY_FOR_DISTRIBUTION=YES \
-        CODE_SIGNING_ALLOWED=NO \
-        CODE_SIGN_IDENTITY="" \
+        CODE_SIGNING_ALLOWED=YES \
         CODE_SIGNING_REQUIRED=NO
 
     for framework in "${frameworks[@]}"; do
         cp-modules "$framework" "$modulesPath" "$resultFrameworksPath"
     done
 
-    for framework in "${frameworks[@]}"; do
-        copy-resources "$framework" "$resultFrameworksPath" "" "$derivedDataPath"
-    done
+    # Copy bundle resources
+    local bundlePath="$modulesPath/../../IntermediateBuildFilesPath/UninstalledProducts/$sdk/GiniHealthSDK_GiniHealthSDK.bundle"
+    if [ -d "$bundlePath" ]; then
+        cp -a "$bundlePath" "$resultFrameworksPath/GiniHealthSDK.framework/GiniHealthSDK_GiniHealthSDK.bundle"
+    else
+        echo "Resource bundle not found at expected path, skipping: $bundlePath"
+    fi
 
-    # Strip code signatures after copying resources
-    for framework in "${frameworks[@]}"; do
-        local frameworkPath="$resultFrameworksPath/$framework.framework"
-        if [[ -d "$frameworkPath" ]]; then
-            strip-code-signatures "$frameworkPath"
-        fi
-    done
 }
 
 # Function to create an XCFramework

--- a/build-healthsdk.sh
+++ b/build-healthsdk.sh
@@ -16,6 +16,8 @@ iphonesimulatorBuildDir="build-health-iphonesimulator"
 iphoneosArchivePath="iphoneosHealth.xcarchive"
 iphoneosBuildDir="build-health-iphoneos"
 
+frameworks=("GiniHealthAPILibrary" "GiniUtilites" "GiniInternalPaymentSDK" "GiniHealthSDK")
+
 # Function to cleanup simulator and iOS archives
 cleanup-artefacts() {
     # check if cleanup is disabled in arguments
@@ -37,10 +39,7 @@ cleanup-artefacts() {
 
 cleanup-frameworks() {
     # cleaning up xcframeworks
-    rm -rf "GiniHealthSDK.xcframework"
-    rm -rf "GiniHealthAPILibrary.xcframework"
-    rm -rf "GiniUtilites.xcframework"
-    rm -rf "GiniInternalPaymentSDK.xcframework"
+    rm -rf *.xcframework
 }
 
 # Function to copy .swiftmodule files manually
@@ -51,7 +50,98 @@ cp-modules() {
 
     echo "Copying modules for $frName from $srcPath to $dstPath"
     mkdir -p "$dstPath/$frName.framework/Modules"
-    cp -a "$srcPath/$frName.swiftmodule" "$dstPath/$frName.framework/Modules/$frName.swiftmodule"
+    cp -a "$srcPath/$frName.swiftmodule" "$dstPath/$frName.framework/Modules/$frName.swiftmodule" 2>/dev/null || true
+}
+
+# Function to copy resource bundles
+copy-resources() {
+    local schemeName=$1
+    local dstPath=$2
+    local derivedDataPath=$4
+
+    echo "Copying resources for $schemeName from DerivedDataPath to $dstPath"
+
+    local frameworkDir="$dstPath/$schemeName.framework"
+    mkdir -p "$frameworkDir"
+
+    # Look for Assets.car in various locations
+    local assetCarPath=""
+    local possibleCarPaths=(
+        "$derivedDataPath/Build/Intermediates.noindex/ArchiveIntermediates/GiniHealthSDK/IntermediateBuildFilesPath/${schemeName}.build/Release-iphoneos/${schemeName}.build/assetcatalog_output/thinned/Assets.car"
+        "$derivedDataPath/Build/Intermediates.noindex/ArchiveIntermediates/GiniHealthSDK/IntermediateBuildFilesPath/${schemeName}.build/Release-iphoneos/${schemeName}_${schemeName}.build/assetcatalog_output/thinned/Assets.car"
+        "$derivedDataPath/Build/Intermediates.noindex/ArchiveIntermediates/GiniHealthSDK/BuildProductsPath/Release-iphoneos/${schemeName}.framework/Assets.car"
+    )
+
+    for path in "${possibleCarPaths[@]}"; do
+        if [[ -f "$path" ]]; then
+            assetCarPath="$path"
+            echo "Found Assets.car at: $path"
+            break
+        fi
+    done
+
+    # If not found, search recursively
+    if [[ -z "$assetCarPath" ]]; then
+        assetCarPath=$(find "$derivedDataPath" -name "Assets.car" -type f | grep -v ".xcarchive" | head -1)
+        if [[ -n "$assetCarPath" ]]; then
+            echo "Found Assets.car at: $assetCarPath"
+        fi
+    fi
+
+    # Copy Assets.car if found
+    if [[ -n "$assetCarPath" ]]; then
+        cp "$assetCarPath" "$frameworkDir/"
+        echo "Copied Assets.car to $frameworkDir/"
+    fi
+
+    # Look for bundle
+    local bundlePath=""
+    local possibleBundlePaths=(
+        "$derivedDataPath/Build/Intermediates.noindex/ArchiveIntermediates/GiniHealthSDK/IntermediateBuildFilesPath/UninstalledProducts/iphoneos/${schemeName}_${schemeName}.bundle"
+        "$derivedDataPath/Build/Intermediates.noindex/ArchiveIntermediates/GiniHealthSDK/BuildProductsPath/Release-iphoneos/${schemeName}_${schemeName}.bundle"
+    )
+
+    for path in "${possibleBundlePaths[@]}"; do
+        if [[ -d "$path" ]]; then
+            bundlePath="$path"
+            echo "Found bundle at: $path"
+            break
+        fi
+    done
+
+    # If not found, search recursively
+    if [[ -z "$bundlePath" ]]; then
+        bundlePath=$(find "$derivedDataPath" -name "*${schemeName}*.bundle" -type d | grep -v ".xcarchive" | head -1)
+        if [[ -n "$bundlePath" ]]; then
+            echo "Found bundle at: $bundlePath"
+        fi
+    fi
+
+    # Copy bundle if found
+    if [[ -n "$bundlePath" ]]; then
+        cp -r "$bundlePath" "$frameworkDir/"
+        echo "Copied bundle to $frameworkDir/"
+    fi
+}
+
+# Function to completely strip code signatures from framework
+strip-code-signatures() {
+    local frameworkPath=$1
+
+    echo "Stripping code signatures from $(basename "$frameworkPath")..."
+
+    # Remove signature from framework binary
+    codesign --remove-signature "$frameworkPath" 2>/dev/null || true
+
+    # Remove signatures from all files inside framework
+    find "$frameworkPath" -type f -exec codesign --remove-signature {} \; 2>/dev/null || true
+
+    # Remove all extended attributes (which can contain signatures)
+    find "$frameworkPath" -type f -exec xattr -c {} \; 2>/dev/null || true
+
+    echo "Code signatures stripped from $(basename "$frameworkPath")"
+
+    return 0
 }
 
 # Function to archive a target
@@ -74,21 +164,25 @@ archive() {
         -derivedDataPath "$derivedDataPath" \
         SKIP_INSTALL=NO \
         BUILD_LIBRARY_FOR_DISTRIBUTION=YES \
-        CODE_SIGNING_ALLOWED=YES \
+        CODE_SIGNING_ALLOWED=NO \
+        CODE_SIGN_IDENTITY="" \
         CODE_SIGNING_REQUIRED=NO
 
-    cp-modules "GiniHealthSDK" "$modulesPath" "$resultFrameworksPath"
-    cp-modules "GiniHealthAPILibrary" "$modulesPath" "$resultFrameworksPath"
-    cp-modules "GiniInternalPaymentSDK" "$modulesPath" "$resultFrameworksPath"
-    cp-modules "GiniUtilites" "$modulesPath" "$resultFrameworksPath"
+    for framework in "${frameworks[@]}"; do
+        cp-modules "$framework" "$modulesPath" "$resultFrameworksPath"
+    done
 
-    # Copy bundle resources
-    local bundlePath="$modulesPath/../../IntermediateBuildFilesPath/UninstalledProducts/$sdk/GiniHealthSDK_GiniHealthSDK.bundle"
-    if [ -d "$bundlePath" ]; then
-        cp -a "$bundlePath" "$resultFrameworksPath/GiniHealthSDK.framework/GiniHealthSDK_GiniHealthSDK.bundle"
-    else
-        echo "Resource bundle not found: $bundlePath"
-    fi
+    for framework in "${frameworks[@]}"; do
+        copy-resources "$framework" "$resultFrameworksPath" "" "$derivedDataPath"
+    done
+
+    # Strip code signatures after copying resources
+    for framework in "${frameworks[@]}"; do
+        local frameworkPath="$resultFrameworksPath/$framework.framework"
+        if [[ -d "$frameworkPath" ]]; then
+            strip-code-signatures "$frameworkPath"
+        fi
+    done
 }
 
 # Function to create an XCFramework
@@ -99,6 +193,9 @@ make-xcframework() {
 
     local frameworkPath="$srcPath/Products/usr/local/lib/$frName.framework"
     local frameworkPathSim="$srcPathSim/Products/usr/local/lib/$frName.framework"
+
+    echo "Framework Path (iPhone): $frameworkPath"
+    echo "Framework Path (Simulator): $frameworkPathSim"
 
     echo "Creating XCFramework for $frName"
     xcodebuild -create-xcframework \
@@ -127,21 +224,9 @@ archive "HealthSDK/GiniHealthSDK" \
     $iphonesimulatorBuildDir \
     $iphonesimulatorArchivePath
 
-make-xcframework "GiniHealthSDK" \
-    $iphoneosArchivePath \
-    $iphonesimulatorArchivePath
-
-make-xcframework "GiniHealthAPILibrary" \
-    $iphoneosArchivePath \
-    $iphonesimulatorArchivePath
-
-make-xcframework "GiniInternalPaymentSDK" \
-    $iphoneosArchivePath \
-    $iphonesimulatorArchivePath
-
-make-xcframework "GiniUtilites" \
-    $iphoneosArchivePath \
-    $iphonesimulatorArchivePath
+for framework in "${frameworks[@]}"; do
+    make-xcframework "$framework" "$iphoneosArchivePath" "$iphonesimulatorArchivePath"
+done
 
 # swift package checks for "1" so making it empty is enough to clean it
 export GINI_FORCE_DYNAMIC_LIBRARY=""


### PR DESCRIPTION
## Pull Request Description

[HEAL-363](https://ginis.atlassian.net/browse/HEAL-363)

Updates the Health SDK XCFrameworks generation workflow and build script to support Xcode 26.

The existing script had non-fatal `cp-modules` errors that could abort the script, and four separate hardcoded `make-xcframework` calls. The bundle path (`GiniHealthSDK_GiniHealthSDK.bundle`) was confirmed unchanged between Xcode 16.4 and Xcode 26 via CI logs — the original inline copy works correctly.

## Notes for Reviewers

- No simulators/devices required — CI-only change
- Bundle path verified from Xcode 26 CI run logs (identical to Xcode 16.4)
- Changes:
  - Runner: `macos-15` → `macos-26`, Xcode: `16.4` → `26`
  - Added `frameworks` array to drive `cp-modules` and `make-xcframework` loops — eliminates four separate hardcoded calls
  - Restored original inline bundle copy (path confirmed correct on Xcode 26)
  - Suppressed non-fatal `cp-modules` errors with `2>/dev/null || true`
  - Added debug output for framework paths in `make-xcframework`

[HEAL-363]: https://ginis.atlassian.net/browse/HEAL-363?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ