### PR TITLE
fix(GiniInternalPaymentSDK): prevent Payment Review closing on orient…

### DIFF
--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/Views/PaymentReviewContentView.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/Views/PaymentReviewContentView.swift
@@ -12,6 +12,7 @@ public struct PaymentReviewContentView: View {
     @State private var hasAppeared = false
     @State private var showBottomSheet = true
     @State private var bottomSheetHeight = Constants.bottomSheetDefaultHeight
+    @State private var isDismissingForRotation = false
     
     @Environment(\.accessibilityVoiceOverEnabled) private var isVoiceOverEnabled
     @Environment(\.giniLayout) private var giniLayout
@@ -41,6 +42,7 @@ public struct PaymentReviewContentView: View {
             // sheet immediately (without animation) so the crossfade transition
             // isn't disrupted by the sheet's own dismissal animation.
             if landscape && !viewModel.isBottomSheetMode && showBottomSheet {
+                isDismissingForRotation = true
                 showBottomSheet = false
             }
         }
@@ -107,7 +109,8 @@ public struct PaymentReviewContentView: View {
             }
         }
         .sheet(isPresented: $showBottomSheet) {
-            if viewModel.isBottomSheetMode || isVoiceOverEnabled {
+            defer { isDismissingForRotation = false }
+            if !isDismissingForRotation && (viewModel.isBottomSheetMode || isVoiceOverEnabled) {
                 viewModel.didTapClose()
             }
         } content: {


### PR DESCRIPTION

HEAL-366

## Pull Request Description

<!-- Briefly explain **what** this PR does and **why**. Mention the motivation, feature, or issue it's addressing. -->

[HEAL-366](https://ginis.atlassian.net/browse/HEAL-366)<!-- Closes ticket number PP-####; Replace with JIRA ticket if relevant -->
When VoiceOver was enabled and the user rotated the device on the Payment Review screen, the app unexpectedly navigated back to the invoice list. This happened regardless of user intent — simply rotating the device was enough to trigger it.
<!--

Some description of HOW you achieved it. Perhaps give a high level description of the chnages you did. Did you need to refactor something? What tradeoffs did you take?

-->

## Notes for Reviewers
- Track when the bottom sheet is being dismissed specifically due to rotation (isDismissingForRotation).
- Prevent didTapClose() from being triggered on sheet dismissal if that dismissal was caused by a rotation-driven layout change.

<!--

Explain how you verified the changes.
A clear testing scenario helps colleagues who may not be familiar with this part of the code quickly understand and verify the changes. Include steps they can follow to see the impact in action.

You can include: 
- Simulators/Devices you used (e.g. iPhone 13, iPad Pro) 
- iOS versions tested (e.g. 16.0, 17.5) 
- Manual checks (e.g. flow tested: onboarding, permissions, error states) 
- Unit tests added or updated 
 
 Include screenshots, screen recordings, or simulator gifs for UI changes. 
 
 - Optional: Anything that needs extra attention in review? Are there TODOs, known limitations, or follow-up work? 
 
 -->

[HEAL-366]: https://ginis.atlassian.net/browse/HEAL-366?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ