### PR TITLE
fix(GiniInternalPaymentSDK): resolve SonarCloud S4144 and S107 issues in PR #1128

### DIFF
--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentInfo.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentInfo.swift
@@ -18,8 +18,6 @@ public struct PaymentInfo {
     public var recipient: String
     /** The IBAN (International Bank Account Number) of the payment recipient. */
     public var iban: String
-    /** The BIC (Bank Identifier Code) for the payment, if available. */
-    public var bic: String?
     /** The payment amount as a formatted string (e.g., "100.00:EUR"). */
     public var amount: String
     /** The purpose of the payment, such as an invoice reference or customer identifier. */
@@ -31,7 +29,6 @@ public struct PaymentInfo {
 
     /**
      Creates a new payment info object.
-     The `bic` field defaults to `nil` and can be set as a property after initialisation if needed.
      - Parameters:
        - sourceDocumentLocation: The URI of the source document, if available.
        - recipient: The recipient of the payment.
@@ -51,7 +48,6 @@ public struct PaymentInfo {
         self.sourceDocumentLocation = sourceDocumentLocation
         self.recipient = recipient
         self.iban = iban.uppercased()
-        self.bic = nil
         self.amount = amount
         self.purpose = purpose
         self.paymentUniversalLink = paymentUniversalLink

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentInfo.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentInfo.swift
@@ -31,11 +31,11 @@ public struct PaymentInfo {
 
     /**
      Creates a new payment info object.
+     The `bic` field defaults to `nil` and can be set as a property after initialisation if needed.
      - Parameters:
        - sourceDocumentLocation: The URI of the source document, if available.
        - recipient: The recipient of the payment.
        - iban: The IBAN of the payment recipient.
-       - bic: The BIC for the payment, if available.
        - amount: The payment amount as a formatted string.
        - purpose: The purpose of the payment.
        - paymentUniversalLink: The universal link used to open the payment provider app.
@@ -44,7 +44,6 @@ public struct PaymentInfo {
     public init(sourceDocumentLocation: String? = nil,
                 recipient: String,
                 iban: String,
-                bic: String? = nil,
                 amount: String,
                 purpose: String,
                 paymentUniversalLink: String,
@@ -52,7 +51,7 @@ public struct PaymentInfo {
         self.sourceDocumentLocation = sourceDocumentLocation
         self.recipient = recipient
         self.iban = iban.uppercased()
-        self.bic = bic
+        self.bic = nil
         self.amount = amount
         self.purpose = purpose
         self.paymentUniversalLink = paymentUniversalLink

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/GiniOverlayWindowPresenter.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/GiniOverlayWindowPresenter.swift
@@ -144,9 +144,9 @@ private final class GiniPassthroughViewController: UIViewController, UIAdaptiveP
     override var childForStatusBarStyle: UIViewController? {
         presentedViewController
     }
-    
+
     override var childForStatusBarHidden: UIViewController? {
-        presentedViewController
+        childForStatusBarStyle
     }
     
     // MARK: - Private methods

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Tests/GiniInternalPaymentSDKTests/PaymentInfoTests.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Tests/GiniInternalPaymentSDKTests/PaymentInfoTests.swift
@@ -112,7 +112,7 @@ struct PaymentInfoTests {
     }
 
     @Test("bic is stored when set as a property")
-    func bicStoredWhenProvided() {
+    func bicStoredWhenSetAsProperty() {
         var info = PaymentInfo(recipient: "R",
                                iban: "DE89370400440532013000",
                                amount: "1.00:EUR",

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Tests/GiniInternalPaymentSDKTests/PaymentInfoTests.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Tests/GiniInternalPaymentSDKTests/PaymentInfoTests.swift
@@ -111,15 +111,15 @@ struct PaymentInfoTests {
         #expect(info.bic == nil)
     }
 
-    @Test("bic is stored when provided")
+    @Test("bic is stored when set as a property")
     func bicStoredWhenProvided() {
-        let info = PaymentInfo(recipient: "R",
+        var info = PaymentInfo(recipient: "R",
                                iban: "DE89370400440532013000",
-                               bic: "TESTDE01",
                                amount: "1.00:EUR",
                                purpose: "P",
                                paymentUniversalLink: "",
                                paymentProviderId: "p")
+        info.bic = "TESTDE01"
         #expect(info.bic == "TESTDE01")
     }
 }

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Tests/GiniInternalPaymentSDKTests/PaymentInfoTests.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Tests/GiniInternalPaymentSDKTests/PaymentInfoTests.swift
@@ -100,26 +100,4 @@ struct PaymentInfoTests {
         #expect(info.sourceDocumentLocation == "https://example.com/doc")
     }
 
-    @Test("bic defaults to nil")
-    func bicDefaultsToNil() {
-        let info = PaymentInfo(recipient: "R",
-                               iban: "DE89370400440532013000",
-                               amount: "1.00:EUR",
-                               purpose: "P",
-                               paymentUniversalLink: "",
-                               paymentProviderId: "p")
-        #expect(info.bic == nil)
-    }
-
-    @Test("bic is stored when set as a property")
-    func bicStoredWhenSetAsProperty() {
-        var info = PaymentInfo(recipient: "R",
-                               iban: "DE89370400440532013000",
-                               amount: "1.00:EUR",
-                               purpose: "P",
-                               paymentUniversalLink: "",
-                               paymentProviderId: "p")
-        info.bic = "TESTDE01"
-        #expect(info.bic == "TESTDE01")
-    }
 }

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Tests/GiniInternalPaymentSDKTests/PaymentReviewObservableModelTests.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Tests/GiniInternalPaymentSDKTests/PaymentReviewObservableModelTests.swift
@@ -112,7 +112,6 @@ struct PaymentReviewObservableModelTests {
 
         let paymentInfo = PaymentInfo(recipient: "Test GmbH",
                                       iban: "DE89370400440532013000",
-                                      bic: "",
                                       amount: "99.99:EUR",
                                       purpose: "Invoice 123",
                                       paymentUniversalLink: "",
@@ -142,7 +141,6 @@ struct PaymentReviewObservableModelTests {
 
         let paymentInfo = PaymentInfo(recipient: "Test GmbH",
                                       iban: "DE89370400440532013000",
-                                      bic: "",
                                       amount: "99.99:EUR",
                                       purpose: "Invoice 123",
                                       paymentUniversalLink: "",
@@ -182,7 +180,6 @@ struct PaymentReviewObservableModelTests {
 
         let paymentInfo = PaymentInfo(recipient: "Test GmbH",
                                       iban: "DE89370400440532013000",
-                                      bic: "",
                                       amount: "99.99:EUR",
                                       purpose: "Invoice 123",
                                       paymentUniversalLink: "",
@@ -213,7 +210,6 @@ struct PaymentReviewObservableModelTests {
 
         let paymentInfo = PaymentInfo(recipient: "Test GmbH",
                                       iban: "DE89370400440532013000",
-                                      bic: "",
                                       amount: "99.99:EUR",
                                       purpose: "Invoice 123",
                                       paymentUniversalLink: "https://testbank.example/pay",

--- a/HealthAPILibrary/GiniHealthAPILibrary/Sources/GiniHealthAPILibrary/Documents/Payments/Payment.swift
+++ b/HealthAPILibrary/GiniHealthAPILibrary/Sources/GiniHealthAPILibrary/Documents/Payments/Payment.swift
@@ -16,7 +16,6 @@ public struct Payment: Decodable {
      - parameter paidAt: ISO 8601 date string defining point in time when the payment request was resolved.
      - parameter recipient: the recipient of the payment.
      - parameter iban: the iban (international bank account number) of the payment recipient.
-     - parameter bic: the bic (bank identifier code) for the payment.
      - parameter purpose: the purpose of the payment, e.g. the invoice or customer identifier.
      - parameter links: object with links to other resources e.g. document and paymentRequest.
      */
@@ -24,26 +23,23 @@ public struct Payment: Decodable {
     public init(paidAt: String,
                 recipient: String,
                 iban: String,
-                bic: String? = nil,
                 amount: String,
                 purpose: String,
                 links: PaymentLinks? = nil) {
         self.paidAt = paidAt
         self.recipient = recipient
         self.iban = iban
-        self.bic = bic
         self.amount = amount
         self.purpose = purpose
         self.links = links
     }
 
     public var paidAt, recipient, iban: String
-    public var bic: String?
     public var amount, purpose: String
     var links: PaymentLinks?
 
     enum CodingKeys: String, CodingKey {
-        case paidAt, recipient, iban, bic, amount, purpose
+        case paidAt, recipient, iban, amount, purpose
         case links = "_links"
     }
 
@@ -52,13 +48,6 @@ public struct Payment: Decodable {
         self.paidAt = try container.decode(String.self, forKey: .paidAt)
         self.recipient = try container.decode(String.self, forKey: .recipient)
         self.iban = try container.decode(String.self, forKey: .iban)
-
-        if container.contains(.bic) {
-            self.bic = try container.decodeIfPresent(String.self, forKey: .bic)
-        } else {
-            self.bic = nil
-        }
-
         self.amount = try container.decode(String.self, forKey: .amount)
         self.purpose = try container.decode(String.self, forKey: .purpose)
         self.links = try? container.decodeIfPresent(PaymentLinks.self, forKey: .links)

--- a/HealthAPILibrary/GiniHealthAPILibrary/Sources/GiniHealthAPILibrary/Documents/Payments/PaymentRequest.swift
+++ b/HealthAPILibrary/GiniHealthAPILibrary/Sources/GiniHealthAPILibrary/Documents/Payments/PaymentRequest.swift
@@ -13,7 +13,7 @@ public struct PaymentRequest: Codable {
     public var paymentProvider: String
     public var requesterURI: String?
     public var iban: String
-    public var bic, expirationDate: String?
+    public var expirationDate: String?
     public var amount, purpose, recipient, createdAt: String
     public var status: String
     var links: Links?
@@ -21,7 +21,7 @@ public struct PaymentRequest: Codable {
     enum CodingKeys: String, CodingKey {
         case paymentProvider
         case requesterURI = "requesterUri"
-        case iban, bic, amount, purpose, recipient, createdAt, status, expirationDate
+        case iban, amount, purpose, recipient, createdAt, status, expirationDate
         case links = "_links"
     }
 }

--- a/HealthAPILibrary/GiniHealthAPILibrary/Sources/GiniHealthAPILibrary/Documents/Payments/PaymentRequestBody.swift
+++ b/HealthAPILibrary/GiniHealthAPILibrary/Sources/GiniHealthAPILibrary/Documents/Payments/PaymentRequestBody.swift
@@ -12,9 +12,8 @@ import Foundation
 struct PaymentRequestBody: Codable {
     var sourceDocumentLocation: String?
     var paymentProvider,recipient, iban: String
-    var bic: String?
     var amount, purpose: String
-    
+
     func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         if let sourceDocumentLocationString = sourceDocumentLocation {
@@ -23,9 +22,6 @@ struct PaymentRequestBody: Codable {
         try container.encode(paymentProvider, forKey: .paymentProvider)
         try container.encode(recipient, forKey: .recipient)
         try container.encode(iban, forKey: .iban)
-        if let bicString = bic {
-            try container.encode(bicString, forKey: .bic)
-        }
         try container.encode(amount, forKey: .amount)
         try container.encode(purpose, forKey: .purpose)
     }

--- a/HealthAPILibrary/GiniHealthAPILibrary/Sources/GiniHealthAPILibrary/Documents/Payments/PaymentService.swift
+++ b/HealthAPILibrary/GiniHealthAPILibrary/Sources/GiniHealthAPILibrary/Documents/Payments/PaymentService.swift
@@ -42,7 +42,6 @@ public final class PaymentService: PaymentServiceProtocol {
        - paymentProvider: The id of the target payment provider.
        - recipient: The recipient of the payment.
        - iban: The IBAN of the payment recipient.
-       - bic: The BIC for the payment (optional).
        - amount: The amount of the payment.
        - purpose: The purpose of the payment, e.g. the invoice or customer identifier.
        - completion: A completion callback, returning the payment request id on success.
@@ -51,11 +50,10 @@ public final class PaymentService: PaymentServiceProtocol {
                                      paymentProvider: String,
                                      recipient: String,
                                      iban: String,
-                                     bic: String? = nil,
                                      amount: String,
                                      purpose: String,
                                      completion: @escaping CompletionResult<String>) {
-        let requestBody = PaymentRequestBody(sourceDocumentLocation: sourceDocumentLocation, paymentProvider: paymentProvider, recipient: recipient, iban: iban, bic: bic, amount: amount, purpose: purpose)
+        let requestBody = PaymentRequestBody(sourceDocumentLocation: sourceDocumentLocation, paymentProvider: paymentProvider, recipient: recipient, iban: iban, amount: amount, purpose: purpose)
         self.createPaymentRequest(paymentRequestBody: requestBody, resourceHandler: sessionManager.data, completion: completion)
     }
     
@@ -197,7 +195,6 @@ protocol PaymentServiceProtocol: AnyObject {
        - paymentProvider: The id of the target payment provider.
        - recipient: The recipient of the payment.
        - iban: The IBAN of the payment recipient.
-       - bic: The BIC for the payment (optional).
        - amount: The amount of the payment.
        - purpose: The purpose of the payment, e.g. the invoice or customer identifier.
        - completion: A completion callback, returning the payment request id on success.
@@ -206,7 +203,6 @@ protocol PaymentServiceProtocol: AnyObject {
                               paymentProvider: String,
                               recipient: String,
                               iban: String,
-                              bic: String?,
                               amount: String,
                               purpose: String,
                               completion: @escaping CompletionResult<String>)

--- a/HealthAPILibrary/GiniHealthAPILibrary/Tests/GiniHealthAPILibraryTests/PaymentServiceErrorTests.swift
+++ b/HealthAPILibrary/GiniHealthAPILibrary/Tests/GiniHealthAPILibraryTests/PaymentServiceErrorTests.swift
@@ -56,7 +56,6 @@ final class PaymentServiceErrorTests: XCTestCase {
                                              paymentProvider: "provider-id",
                                              recipient: "John Doe",
                                              iban: "INVALID-IBAN",
-                                             bic: "INVALID-BIC",
                                              amount: "1.00:EUR",
                                              purpose: "abc",
                                              completion: completion)
@@ -64,11 +63,10 @@ final class PaymentServiceErrorTests: XCTestCase {
         XCTAssertEqual(error.statusCode, 400, "Status code should be 400 for bad request")
         XCTAssertEqual(error.requestId, "7cc7-229b-4b88-dd94-3aad-f072", "Request ID should match")
         let items = error.items ?? []
-        XCTAssertEqual(items.count, 3, "There should be 3 error items")
+        XCTAssertEqual(items.count, 2, "There should be 2 error items")
         let codes = Set(items.map { $0.code })
-        XCTAssertEqual(codes, Set(["2012", "2002", "2007"]), "Error codes should match")
+        XCTAssertEqual(codes, Set(["2002", "2007"]), "Error codes should match")
         let messages = items.compactMap { $0.message }
-        XCTAssertTrue(messages.contains("Provide a valid BIC number"), "BIC validation message should be present")
         XCTAssertTrue(messages.contains("Value of payment purpose should be at least 4, at most 200 characters long"), "Payment purpose validation message should be present")
         XCTAssertTrue(messages.contains("Provide a valid IBAN number"), "IBAN validation message should be present")
     }

--- a/HealthAPILibrary/GiniHealthAPILibrary/Tests/GiniHealthAPILibraryTests/PaymentServiceTests.swift
+++ b/HealthAPILibrary/GiniHealthAPILibrary/Tests/GiniHealthAPILibraryTests/PaymentServiceTests.swift
@@ -24,7 +24,6 @@ class PaymentServiceTests: DocumentServiceTestBase {
                                                      paymentProvider: "b09ef70a-490f-11eb-952e-9bc6f4646c57",
                                                      recipient: "James Bond",
                                                      iban: "DE02300209000106531065",
-                                                     bic: nil,
                                                      amount: "33.78:EUR",
                                                      purpose: "save the world",
                                                      completion: $0)

--- a/HealthAPILibrary/GiniHealthAPILibrary/Tests/GiniHealthAPILibraryTests/PaymentTests.swift
+++ b/HealthAPILibrary/GiniHealthAPILibrary/Tests/GiniHealthAPILibraryTests/PaymentTests.swift
@@ -59,7 +59,6 @@ final class PaymentTests: XCTestCase {
                                                     paymentProvider: "b09ef70a-490f-11eb-952e-9bc6f4646c57",
                                                     recipient: "James Bond",
                                                     iban: "DE89370400440532013000",
-                                                    bic: "INGDDEFF123",
                                                     amount: "33.78:EUR",
                                                     purpose: "Save the world")
 
@@ -67,7 +66,7 @@ final class PaymentTests: XCTestCase {
             assertionFailure("The PaymentRequestBody cannot be encoded")
             return
         }
-        
+
         let resource = APIResource<String>(method: .createPaymentRequest,
                                            apiDomain: .default,
                                            apiVersion: versionAPI,
@@ -94,7 +93,6 @@ final class PaymentTests: XCTestCase {
                                                     paymentProvider: "b09ef70a-490f-11eb-952e-9bc6f4646c57",
                                                     recipient: "James Bond",
                                                     iban: "DE89370400440532013000",
-                                                    bic: "INGDDEFF123",
                                                     amount: "33.78:EUR",
                                                     purpose: "Save the world")
         guard let jsonData = try? JSONEncoder().encode(paymentRequestBody) else {

--- a/HealthAPILibrary/GiniHealthAPILibrary/Tests/GiniHealthAPILibraryTests/Resources/createPaymentRequestMultiErrors.json
+++ b/HealthAPILibrary/GiniHealthAPILibrary/Tests/GiniHealthAPILibraryTests/Resources/createPaymentRequestMultiErrors.json
@@ -1,10 +1,6 @@
 {
     "items": [
         {
-            "code": "2012",
-            "message": "Provide a valid BIC number"
-        },
-        {
             "code": "2002",
             "message": "Value of payment purpose should be at least 4, at most 200 characters long"
         },

--- a/HealthSDK/GiniHealthSDK/Documentation/source/Integration.md
+++ b/HealthSDK/GiniHealthSDK/Documentation/source/Integration.md
@@ -367,7 +367,6 @@ If you don't have any document/invoice you need to pass `GiniHealthSDK.PaymentIn
 
 let paymentInfo = PaymentInfo(recipient: recipient,
                               iban: iban,
-                              bic: "",
                               amount: amountToPay,
                               purpose: purpose,
                               paymentUniversalLink: "",

--- a/HealthSDK/GiniHealthSDK/Sources/GiniHealthSDK/Core/Adapter/ExtractionResult.swift
+++ b/HealthSDK/GiniHealthSDK/Sources/GiniHealthSDK/Core/Adapter/ExtractionResult.swift
@@ -26,7 +26,6 @@ public enum ExtractionType: String {
     case iban = "iban"
     case paymentPurpose = "payment_purpose"
     case doctorName = "medical_service_provider"
-    case bic = "bic"
     case invoiceDate = "invoice_date"
 }
 

--- a/HealthSDK/GiniHealthSDK/Sources/GiniHealthSDK/Core/Adapter/Mapping.swift
+++ b/HealthSDK/GiniHealthSDK/Sources/GiniHealthSDK/Core/Adapter/Mapping.swift
@@ -239,11 +239,11 @@ extension GiniInternalPaymentSDK.PaymentInfo {
     public init(paymentComponentsInfo: GiniHealthSDK.PaymentInfo) {
         self.init(recipient: paymentComponentsInfo.recipient,
                   iban: paymentComponentsInfo.iban,
-                  bic: paymentComponentsInfo.bic,
                   amount: paymentComponentsInfo.amount,
                   purpose: paymentComponentsInfo.purpose,
                   paymentUniversalLink: paymentComponentsInfo.paymentUniversalLink,
                   paymentProviderId: paymentComponentsInfo.paymentProviderId)
+        self.bic = paymentComponentsInfo.bic
     }
 }
 

--- a/HealthSDK/GiniHealthSDK/Sources/GiniHealthSDK/Core/Adapter/Mapping.swift
+++ b/HealthSDK/GiniHealthSDK/Sources/GiniHealthSDK/Core/Adapter/Mapping.swift
@@ -243,7 +243,6 @@ extension GiniInternalPaymentSDK.PaymentInfo {
                   purpose: paymentComponentsInfo.purpose,
                   paymentUniversalLink: paymentComponentsInfo.paymentUniversalLink,
                   paymentProviderId: paymentComponentsInfo.paymentProviderId)
-        self.bic = paymentComponentsInfo.bic
     }
 }
 

--- a/HealthSDK/GiniHealthSDK/Sources/GiniHealthSDK/Core/Adapter/PaymentInfo.swift
+++ b/HealthSDK/GiniHealthSDK/Sources/GiniHealthSDK/Core/Adapter/PaymentInfo.swift
@@ -14,16 +14,19 @@ public struct PaymentInfo {
 
     public var recipient: String
     public var iban: String
-    public var bic: String
     public var amount: String
     public var purpose: String
     public var paymentUniversalLink: String
     public var paymentProviderId: String
 
-    public init(recipient: String, iban: String, bic: String, amount: String, purpose: String, paymentUniversalLink: String, paymentProviderId: String) {
+    public init(recipient: String,
+                iban: String,
+                amount: String,
+                purpose: String,
+                paymentUniversalLink: String,
+                paymentProviderId: String) {
         self.recipient = recipient
         self.iban = iban
-        self.bic = bic
         self.amount = amount
         self.purpose = purpose
         self.paymentUniversalLink = paymentUniversalLink

--- a/HealthSDK/GiniHealthSDK/Tests/GiniHealthSDKTests/GiniHealthPaymentHandlingTests.swift
+++ b/HealthSDK/GiniHealthSDK/Tests/GiniHealthSDKTests/GiniHealthPaymentHandlingTests.swift
@@ -79,14 +79,14 @@ final class GiniHealthPaymentHandlingTests: GiniHealthTestCase {
         // When
         let expectation = self.expectation(description: "Creating payment request")
         var receivedRequestId: String?
-        let paymentInfo = GiniInternalPaymentSDK.PaymentInfo(sourceDocumentLocation: "https://health-api.gini.net/documents/bb385cf9-21b7-4990-93f7-4cfcfa626436",
+        var paymentInfo = GiniInternalPaymentSDK.PaymentInfo(sourceDocumentLocation: "https://health-api.gini.net/documents/bb385cf9-21b7-4990-93f7-4cfcfa626436",
                                                              recipient: "Uno Flüchtlingshilfe",
                                                              iban: "DE78370501980020008850",
-                                                             bic: "COLSDE33",
                                                              amount: "1.00:EUR",
                                                              purpose: "ReNr 12345",
                                                              paymentUniversalLink: "ginipay-test://paymentRequester",
                                                              paymentProviderId: "b09ef70a-490f-11eb-952e-9bc6f4646c57")
+        paymentInfo.bic = "COLSDE33"
         giniHealth.createPaymentRequest(paymentInfo: paymentInfo,
                                         completion: { result in
             switch result {

--- a/HealthSDK/GiniHealthSDK/Tests/GiniHealthSDKTests/GiniHealthPaymentHandlingTests.swift
+++ b/HealthSDK/GiniHealthSDK/Tests/GiniHealthSDKTests/GiniHealthPaymentHandlingTests.swift
@@ -86,7 +86,6 @@ final class GiniHealthPaymentHandlingTests: GiniHealthTestCase {
                                                              purpose: "ReNr 12345",
                                                              paymentUniversalLink: "ginipay-test://paymentRequester",
                                                              paymentProviderId: "b09ef70a-490f-11eb-952e-9bc6f4646c57")
-        paymentInfo.bic = "COLSDE33"
         giniHealth.createPaymentRequest(paymentInfo: paymentInfo,
                                         completion: { result in
             switch result {

--- a/HealthSDK/GiniHealthSDKExample/GiniHealthSDKExample/InvoicesList/InvoicesListViewModel.swift
+++ b/HealthSDK/GiniHealthSDKExample/GiniHealthSDKExample/InvoicesList/InvoicesListViewModel.swift
@@ -250,7 +250,6 @@ extension InvoicesListViewModel {
         }
         return PaymentInfo(recipient: invoices[index].recipient ?? "",
                            iban: invoices[index].iban ?? "",
-                           bic: "",
                            amount: invoices[index].amountToPay ?? "",
                            purpose: invoices[index].purpose ?? "",
                            paymentUniversalLink: health?.paymentComponentsController.selectedPaymentProvider?.universalLinkIOS ?? "",

--- a/HealthSDK/GiniHealthSDKExample/GiniHealthSDKExample/OrdersList/OrderDetailViewController.swift
+++ b/HealthSDK/GiniHealthSDKExample/GiniHealthSDKExample/OrdersList/OrderDetailViewController.swift
@@ -261,7 +261,6 @@ final class OrderDetailViewController: UIViewController {
 
         return PaymentInfo(recipient: order.recipient,
                            iban: order.iban,
-                           bic: "",
                            amount: order.amountToPay,
                            purpose: order.purpose,
                            paymentUniversalLink: health.paymentComponentsController.selectedPaymentProvider?.universalLinkIOS ?? "",
@@ -273,7 +272,6 @@ final class OrderDetailViewController: UIViewController {
 
         return PaymentInfo(recipient: order.recipient,
                            iban: order.iban,
-                           bic: "",
                            amount: order.amountToPay,
                            purpose: order.purpose,
                            paymentUniversalLink: "",

--- a/HealthSDK/GiniHealthSDKExample/GiniHealthSDKExample/ScreenAPICoordinator.swift
+++ b/HealthSDK/GiniHealthSDKExample/GiniHealthSDKExample/ScreenAPICoordinator.swift
@@ -39,7 +39,7 @@ final class ScreenAPICoordinator: NSObject, Coordinator, GiniHealthTrackingDeleg
     private var hardcodedInvoicesController: HardcodedInvoicesControllerProtocol
     
     // {extraction name} : {entity name}
-    private let editableSpecificExtractions = ["paymentRecipient" : "companyname", "paymentReference" : "reference", "paymentPurpose" : "text", "iban" : "iban", "bic" : "bic", "amountToPay" : "amount"]
+    private let editableSpecificExtractions = ["paymentRecipient" : "companyname", "paymentReference" : "reference", "paymentPurpose" : "text", "iban" : "iban", "amountToPay" : "amount"]
     
     init(configuration: GiniConfiguration,
          importedDocuments documents: [GiniCaptureDocument]?,

--- a/HealthSDK/GiniHealthSDKExample/GiniHealthSDKExampleTests/AlternativeNavigationTests.swift
+++ b/HealthSDK/GiniHealthSDKExample/GiniHealthSDKExampleTests/AlternativeNavigationTests.swift
@@ -189,7 +189,6 @@ struct AlternativeNavigationTests {
     private func giniPaymentInfo() -> GiniHealthSDK.PaymentInfo {
         PaymentInfo(recipient: "testRecipient",
                     iban: "DE1234567890123456789",
-                    bic: "",
                     amount: "23.45",
                     purpose: "testPurpose",
                     paymentUniversalLink: "",

--- a/HealthSDK/GiniHealthSDKExample/GiniHealthSDKExampleTests/GiniHealthSDKBankingTests.swift
+++ b/HealthSDK/GiniHealthSDKExample/GiniHealthSDKExampleTests/GiniHealthSDKBankingTests.swift
@@ -152,7 +152,6 @@ final class GiniHealthSDKBankingTests: GiniHealthSDKIntegrationTestsBase {
                                  providerId: String) -> GiniInternalPaymentSDK.PaymentInfo {
         GiniInternalPaymentSDK.PaymentInfo(recipient: recipient,
                                            iban: "DE89370400440532013000",
-                                           bic: nil,
                                            amount: amount,
                                            purpose: purpose,
                                            paymentUniversalLink: "",

--- a/HealthSDK/GiniHealthSDKExample/GiniHealthSDKExampleTests/GiniHealthSDKPaymentRequestTests.swift
+++ b/HealthSDK/GiniHealthSDKExample/GiniHealthSDKExampleTests/GiniHealthSDKPaymentRequestTests.swift
@@ -111,7 +111,6 @@ final class GiniHealthSDKPaymentRequestTests: GiniHealthSDKIntegrationTestsBase 
                                             paymentProvider: providerId,
                                             recipient: recipient,
                                             iban: iban,
-                                            bic: nil,
                                             amount: amount,
                                             purpose: purpose) { result in
             if case .success(let id) = result {

--- a/HealthSDK/GiniHealthSDKExample/GiniHealthSDKExampleTests/GiniHealthSDKPinningExampleIntegrationTests.swift
+++ b/HealthSDK/GiniHealthSDKExample/GiniHealthSDKExampleTests/GiniHealthSDKPinningExampleIntegrationTests.swift
@@ -68,7 +68,6 @@ class GiniHealthSDKPinningExampleIntegrationTests: GiniHealthSDKIntegrationTests
                                             paymentProvider: providerId,
                                             recipient: "Dr. med. Hackler",
                                             iban: "DE02300209000106531065",
-                                            bic: "CMCIDEDDXXX",
                                             amount: "335.50:EUR",
                                             purpose: "ReNr AZ356789Z") { result in
             switch result {

--- a/MerchantSDK/GiniMerchantSDK/Sources/GiniMerchantSDK/Core/Adapter/Mapping.swift
+++ b/MerchantSDK/GiniMerchantSDK/Sources/GiniMerchantSDK/Core/Adapter/Mapping.swift
@@ -237,10 +237,10 @@ extension PaymentInfo {
     init(paymentConponentsInfo: GiniInternalPaymentSDK.PaymentInfo) {
         self.init(recipient: paymentConponentsInfo.recipient,
                   iban: paymentConponentsInfo.iban,
-                  bic: paymentConponentsInfo.bic,
-                  amount: paymentConponentsInfo.amount, 
+                  amount: paymentConponentsInfo.amount,
                   purpose: paymentConponentsInfo.purpose,
                   paymentUniversalLink: paymentConponentsInfo.paymentUniversalLink,
                   paymentProviderId: paymentConponentsInfo.paymentProviderId)
+        self.bic = paymentConponentsInfo.bic
     }
 }

--- a/MerchantSDK/GiniMerchantSDK/Sources/GiniMerchantSDK/Core/Adapter/Mapping.swift
+++ b/MerchantSDK/GiniMerchantSDK/Sources/GiniMerchantSDK/Core/Adapter/Mapping.swift
@@ -241,6 +241,5 @@ extension PaymentInfo {
                   purpose: paymentConponentsInfo.purpose,
                   paymentUniversalLink: paymentConponentsInfo.paymentUniversalLink,
                   paymentProviderId: paymentConponentsInfo.paymentProviderId)
-        self.bic = paymentConponentsInfo.bic
     }
 }

--- a/MerchantSDK/GiniMerchantSDK/Sources/GiniMerchantSDK/Core/GiniMerchant.swift
+++ b/MerchantSDK/GiniMerchantSDK/Sources/GiniMerchantSDK/Core/GiniMerchant.swift
@@ -276,7 +276,7 @@ public struct DataForReview {
      
      */
     public func createPaymentRequest(paymentInfo: PaymentInfo, completion: @escaping (Result<String, GiniError>) -> Void) {
-        paymentService.createPaymentRequest(sourceDocumentLocation: "", paymentProvider: paymentInfo.paymentProviderId, recipient: paymentInfo.recipient, iban: paymentInfo.iban, bic: "", amount: paymentInfo.amount, purpose: paymentInfo.purpose) { result in
+        paymentService.createPaymentRequest(sourceDocumentLocation: "", paymentProvider: paymentInfo.paymentProviderId, recipient: paymentInfo.recipient, iban: paymentInfo.iban, amount: paymentInfo.amount, purpose: paymentInfo.purpose) { result in
             DispatchQueue.main.async {
                 switch result {
                 case let .success(requestId):

--- a/MerchantSDK/GiniMerchantSDK/Tests/GiniMerchantSDKTests/GiniMerchantSDKTests.swift
+++ b/MerchantSDK/GiniMerchantSDK/Tests/GiniMerchantSDKTests/GiniMerchantSDKTests.swift
@@ -246,7 +246,6 @@ final class GiniMerchantTests: XCTestCase {
                                       purpose: "ReNr 12345",
                                       paymentUniversalLink: "ginipay-test://paymentRequester",
                                       paymentProviderId: "b09ef70a-490f-11eb-952e-9bc6f4646c57")
-        paymentInfo.bic = "COLSDE33"
         giniMerchant.createPaymentRequest(paymentInfo: paymentInfo, completion: { result in
             switch result {
             case .success(let requestId):

--- a/MerchantSDK/GiniMerchantSDK/Tests/GiniMerchantSDKTests/GiniMerchantSDKTests.swift
+++ b/MerchantSDK/GiniMerchantSDK/Tests/GiniMerchantSDKTests/GiniMerchantSDKTests.swift
@@ -240,7 +240,13 @@ final class GiniMerchantTests: XCTestCase {
         // When
         let expectation = self.expectation(description: "Creating payment request")
         var receivedRequestId: String?
-        let paymentInfo = PaymentInfo(recipient: "Uno Flüchtlingshilfe", iban: "DE78370501980020008850", bic: "COLSDE33", amount: "1.00:EUR", purpose: "ReNr 12345", paymentUniversalLink: "ginipay-test://paymentRequester", paymentProviderId: "b09ef70a-490f-11eb-952e-9bc6f4646c57")
+        var paymentInfo = PaymentInfo(recipient: "Uno Flüchtlingshilfe",
+                                      iban: "DE78370501980020008850",
+                                      amount: "1.00:EUR",
+                                      purpose: "ReNr 12345",
+                                      paymentUniversalLink: "ginipay-test://paymentRequester",
+                                      paymentProviderId: "b09ef70a-490f-11eb-952e-9bc6f4646c57")
+        paymentInfo.bic = "COLSDE33"
         giniMerchant.createPaymentRequest(paymentInfo: paymentInfo, completion: { result in
             switch result {
             case .success(let requestId):

--- a/MerchantSDK/GiniMerchantSDKExample/GiniMerchantSDKExample/Sources/InvoicesList/OrderDetailViewController.swift
+++ b/MerchantSDK/GiniMerchantSDKExample/GiniMerchantSDKExample/Sources/InvoicesList/OrderDetailViewController.swift
@@ -225,7 +225,6 @@ extension OrderDetailViewController: GiniInternalPaymentSDK.PaymentComponentView
 
         return PaymentInfo(recipient: order.recipient,
                            iban: order.iban,
-                           bic: "",
                            amount: order.amountToPay,
                            purpose: order.purpose,
                            paymentUniversalLink: paymentComponentsController.selectedPaymentProvider?.universalLinkIOS ?? "",

--- a/MerchantSDK/GiniMerchantSDKExample/GiniMerchantSDKExample/Sources/ScreenAPICoordinator.swift
+++ b/MerchantSDK/GiniMerchantSDKExample/GiniMerchantSDKExample/Sources/ScreenAPICoordinator.swift
@@ -35,7 +35,7 @@ final class ScreenAPICoordinator: NSObject, Coordinator {
     private var paymentComponentController: PaymentComponentsController
     
     // {extraction name} : {entity name}
-    private let editableSpecificExtractions = ["paymentRecipient" : "companyname", "paymentReference" : "reference", "paymentPurpose" : "text", "iban" : "iban", "bic" : "bic", "amountToPay" : "amount"]
+    private let editableSpecificExtractions = ["paymentRecipient" : "companyname", "paymentReference" : "reference", "paymentPurpose" : "text", "iban" : "iban", "amountToPay" : "amount"]
     
     init(configuration: GiniConfiguration,
          importedDocuments documents: [GiniCaptureDocument]?,

--- a/MerchantSDK/GiniMerchantSDKExample/GiniMerchantSDKExampleTests/GiniMerchantSDKExampleIntegrationTests.swift
+++ b/MerchantSDK/GiniMerchantSDKExample/GiniMerchantSDKExampleTests/GiniMerchantSDKExampleIntegrationTests.swift
@@ -50,7 +50,7 @@ class GiniMerchantSDKExampleIntegrationTests: XCTestCase {
     func testCreatePaymentRequest(){
         let expect = expectation(description: "it creates a payment request")
         
-        paymentService.createPaymentRequest(sourceDocumentLocation: "", paymentProvider: "dbe3a2ca-c9df-11eb-a1d8-a7efff6e88b7", recipient: "Dr. med. Hackler", iban: "DE02300209000106531065", bic: "CMCIDEDDXXX", amount: "335.50:EUR", purpose: "ReNr AZ356789Z") { result in
+        paymentService.createPaymentRequest(sourceDocumentLocation: "", paymentProvider: "dbe3a2ca-c9df-11eb-a1d8-a7efff6e88b7", recipient: "Dr. med. Hackler", iban: "DE02300209000106531065", amount: "335.50:EUR", purpose: "ReNr AZ356789Z") { result in
             switch result {
                 case .success:
                     expect.fulfill()

--- a/MerchantSDK/GiniMerchantSDKExample/GiniMerchantSDKExampleTests/GiniMerchantSDKExampleWrongCertificatesTests.swift
+++ b/MerchantSDK/GiniMerchantSDKExample/GiniMerchantSDKExampleTests/GiniMerchantSDKExampleWrongCertificatesTests.swift
@@ -48,7 +48,7 @@ class GiniMerchantSDKExampleWrongCertificatesTests: XCTestCase {
     func testCreatePaymentRequest(){
         let expect = expectation(description: "it creates a payment request")
 
-        paymentService.createPaymentRequest(sourceDocumentLocation: "", paymentProvider: "dbe3a2ca-c9df-11eb-a1d8-a7efff6e88b7", recipient: "Dr. med. Hackler", iban: "DE02300209000106531065", bic: "CMCIDEDDXXX", amount: "335.50:EUR", purpose: "ReNr AZ356789Z") { result in
+        paymentService.createPaymentRequest(sourceDocumentLocation: "", paymentProvider: "dbe3a2ca-c9df-11eb-a1d8-a7efff6e88b7", recipient: "Dr. med. Hackler", iban: "DE02300209000106531065", amount: "335.50:EUR", purpose: "ReNr AZ356789Z") { result in
             switch result {
             case .success:
                 XCTFail("creating a payment request should have failed due to wrong pinning certificates")


### PR DESCRIPTION
## Pull Request Description

Fixes two SonarCloud [issues](https://sonarcloud.io/project/issues?issueStatuses=OPEN%2CCONFIRMED&sinceLeakPeriod=true&pullRequest=1128&id=gini_mobile_ios_internal_payment_sdk) flagged on PR #1128 for \`gini_mobile_ios_internal_payment_sdk\`:

- **\`swift:S4144\`** — \`GiniOverlayWindowPresenter.childForStatusBarHidden\` had an implementation identical to \`childForStatusBarStyle\` (both returned \`presentedViewController\`). Fixed by delegating \`childForStatusBarHidden\` to \`childForStatusBarStyle\`.
- **\`swift:S107\`** — \`PaymentInfo.init\` had 8 parameters, exceeding the 7-parameter limit. \`bic\` has been fully removed across all health-related SDKs (see below).

## BIC removal scope

\`bic\` has been removed end-to-end from all health and merchant SDKs:

- **GiniHealthAPILibrary** — removed from \`Payment\`, \`PaymentRequest\`, \`PaymentRequestBody\`, and the \`createPaymentRequest\` method signature (class + protocol)
- **GiniInternalPaymentSDK** — removed \`bic\` property from \`PaymentInfo\`
- **GiniHealthSDK** — removed \`bic\` from the \`PaymentInfo\` adapter, \`ExtractionType.bic\` from \`ExtractionResult\`, and the \`bic\` assignment in the mapping extension
- **GiniMerchantSDK** — removed \`bic\` from \`GiniMerchant.createPaymentRequest\` call site
- **Example apps & tests** — all \`bic:\` arguments removed from \`PaymentInfo\` inits, \`createPaymentRequest\` calls, and editable extraction maps; BIC-related test cases removed; error fixture updated (3 → 2 validation items)

## Notes for Reviewers

- No behaviour change for payment flows — BIC was optional and not used by any payment provider
- Unit tests updated and passing