### PR TITLE
Heal 375 dots in inline error messages should be removed on the payment preview page

### DIFF
--- a/GiniComponents/Utilities/GiniUtilites/.swiftpm/xcode/xcshareddata/xcschemes/GiniUtilites.xcscheme
+++ b/GiniComponents/Utilities/GiniUtilites/.swiftpm/xcode/xcshareddata/xcschemes/GiniUtilites.xcscheme
@@ -29,6 +29,18 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES"
       shouldAutocreateTestPlan = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "GiniUtilitesTests"
+               BuildableName = "GiniUtilitesTests"
+               BlueprintName = "GiniUtilitesTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"

--- a/HealthSDK/GiniHealthSDK/Sources/GiniHealthSDK/Resources/de.lproj/Localizable.strings
+++ b/HealthSDK/GiniHealthSDK/Sources/GiniHealthSDK/Resources/de.lproj/Localizable.strings
@@ -10,13 +10,14 @@
 "gini.health.bottomSheet.grabber.accessibility.label" = "Anfassbereich";
 "gini.health.bottomSheet.grabber.accessibility.hint" = "Doppeltippen zum Schließen";
 "gini.health.errors.default" = "Oh da ist was schief gelaufen. Probieren Sie es bitte noch einmal.";
-"gini.health.errors.failed.amount.non.empty.check" = "Betrag ist notwendig.";
-"gini.health.errors.failed.default.textfield.validation.check" = "Das Feld ist ungültig.";
-"gini.health.errors.failed.iban.non.empty.check" = "IBAN ist notwendig.";
-"gini.health.errors.failed.iban.validation.check" = "IBAN ist ungültig.";
 "gini.health.errors.failed.payment.request.creation" = "Oh da ist was schief gelaufen. Probieren Sie es bitte noch einmal.";
-"gini.health.errors.failed.purpose.non.empty.check" = "Verwendungszweck ist notwendig.";
-"gini.health.errors.failed.recipient.non.empty.check" = "Empfänger ist notwendig.";
+
+"gini.health.errors.failed.amount.non.empty.check" = "Betrag ist notwendig";
+"gini.health.errors.failed.iban.non.empty.check" = "IBAN ist notwendig";
+"gini.health.errors.failed.iban.validation.check" = "IBAN ist ungültig";
+"gini.health.errors.failed.purpose.non.empty.check" = "Verwendungszweck ist notwendig";
+"gini.health.errors.failed.recipient.non.empty.check" = "Empfänger ist notwendig";
+
 "gini.health.paymentcomponent.continue.to.overview.label" = "Weiter zur Übersicht";
 "gini.health.paymentcomponent.install.app.bottom.sheet.continue.button.text" = "Weiter";
 "gini.health.paymentcomponent.install.app.bottom.sheet.notes.description" = "Hinweis: Bitte aktualisieren oder installieren Sie zunächst die [BANK]-App aus dem App-Store.";

--- a/HealthSDK/GiniHealthSDK/Sources/GiniHealthSDK/Resources/en.lproj/Localizable.strings
+++ b/HealthSDK/GiniHealthSDK/Sources/GiniHealthSDK/Resources/en.lproj/Localizable.strings
@@ -16,12 +16,11 @@
 "gini.health.reviewscreen.invoice.image.content.description" = "Invoice document";
 "gini.health.errors.default" = "Oops something went wrong. Please try again.";
 "gini.health.errors.failed.payment.request.creation" = "Oops something went wrong. Please try again.";
-"gini.health.errors.failed.recipient.non.empty.check" = "Recipient is required.";
-"gini.health.errors.failed.iban.non.empty.check" = "IBAN is required.";
-"gini.health.errors.failed.iban.validation.check" = "IBAN is not valid.";
-"gini.health.errors.failed.amount.non.empty.check" = "Amount is required.";
-"gini.health.errors.failed.purpose.non.empty.check" = "Reference is required.";
-"gini.health.errors.failed.default.textfield.validation.check" = "The field is not valid.";
+"gini.health.errors.failed.recipient.non.empty.check" = "Recipient is required";
+"gini.health.errors.failed.iban.non.empty.check" = "IBAN is required";
+"gini.health.errors.failed.iban.validation.check" = "IBAN is not valid";
+"gini.health.errors.failed.amount.non.empty.check" = "Amount is required";
+"gini.health.errors.failed.purpose.non.empty.check" = "Reference is required";
 
 "gini.health.alert.ok.title" = "OK";
 "gini.health.close.button.accessibility.label" = "Close";


### PR DESCRIPTION
## Pull Request Description

<!-- Briefly explain **what** this PR does and **why**. Mention the motivation, feature, or issue it's addressing. -->

[HEAL-375](https://ginis.atlassian.net/browse/HEAL-375)<!-- Closes ticket number PP-####; Replace with JIRA ticket if relevant -->

Their PR is removing trailing dots in inline error messages.

[HEAL-375]: https://ginis.atlassian.net/browse/HEAL-375?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ