### PR TITLE
fix(GiniInternalPaymentSDK): Animate and reposition info banner on Payment Review sheet

### DIFF
--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/PaymentReviewObservableModel.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/PaymentReviewObservableModel.swift
@@ -151,7 +151,7 @@ final class PaymentReviewObservableModel: ObservableObject {
     func paymentReviewPaymentInformationView(contentHeight: Binding<CGFloat>) -> PaymentReviewPaymentInformationView {
         PaymentReviewPaymentInformationView(viewModel: paymentInformationObservableModel,
                                             contentHeight: contentHeight,
-                                            showBanner: Binding( get: { self.showBanner }, set: { self.showBanner = $0 }),
+                                            showBanner: Binding(get: { self.showBanner }, set: { self.showBanner = $0 }),
                                             onBankSelectionTapped: { [weak self] in
             self?.model.openBankSelectionBottomSheet()
         },

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/Views/PaymentInformation/PaymentReviewPaymentInformationView.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/Views/PaymentInformation/PaymentReviewPaymentInformationView.swift
@@ -17,10 +17,17 @@ struct PaymentReviewPaymentInformationView: View {
     @ObservedObject private var viewModel: PaymentReviewPaymentInformationObservableModel
     
     @FocusState private var focusedField: ActivePaymentField?
-    
+
     @Binding private var contentHeight: CGFloat
     @Binding private var showBanner: Bool
-    
+
+    /**
+     Separate animation driver for the banner. `showBanner` is already `true` at init so a
+     SwiftUI transition would never fire; this state starts `false` and animates to `true`
+     in `.onAppear`, making the banner slide down from above the sheet grabber.
+     */
+    @State private var bannerVisible: Bool = false
+
     @Environment(\.giniLayout) private var giniLayout
     @Environment(\.dynamicTypeSize) private var dynamicTypeSize
 
@@ -59,12 +66,16 @@ struct PaymentReviewPaymentInformationView: View {
     var body: some View {
         ZStack(alignment: .top) {
             scrollView
-            if showBanner {
+            // Keep banner in tree while either flag is true so the exit animation plays.
+            if showBanner || bannerVisible {
                 infoBannerView
-                    .onAppear {
-                        UIAccessibility.post(notification: .announcement,
-                                             argument: viewModel.model.strings.infoBarMessage)
-                    }
+                    .offset(y: bannerVisible ? 0 : -Constants.bannerHiddenOffset)
+                    .opacity(bannerVisible ? 1 : 0)
+                    .animation(!UIAccessibility.isReduceMotionEnabled
+                                    ? .spring(response: Constants.bannerEntranceDuration,
+                                              dampingFraction: 0.8)
+                                    : nil,
+                               value: bannerVisible)
             }
         }
         .clipped()
@@ -76,6 +87,24 @@ struct PaymentReviewPaymentInformationView: View {
             UIAccessibility.post(notification: .screenChanged, argument: nil)
             // After a rotation the view is recreated; restore keyboard if it was open.
             restoreFocusIfNeeded()
+            guard showBanner else { return }
+            let animation: Animation? = !UIAccessibility.isReduceMotionEnabled
+                ? .spring(response: Constants.bannerEntranceDuration, dampingFraction: 0.8)
+                : nil
+            withAnimation(animation) { bannerVisible = true }
+        }
+        .onChange(of: bannerVisible) { visible in
+            if visible {
+                UIAccessibility.post(notification: .announcement,
+                                     argument: viewModel.model.strings.infoBarMessage)
+            }
+        }
+        .onChange(of: showBanner) { newValue in
+            guard newValue != bannerVisible else { return }
+            let animation: Animation? = !UIAccessibility.isReduceMotionEnabled
+                ? .easeInOut(duration: Constants.bannerDismissDuration)
+                : nil
+            withAnimation(animation) { bannerVisible = newValue }
         }
         .onDisappear {
             viewModel.isViewVisible = false
@@ -183,7 +212,6 @@ struct PaymentReviewPaymentInformationView: View {
                 topTrailingRadius: Constants.bannerCornerRadius
             )
         )
-        .transition(.move(edge: .top).combined(with: .opacity))
         .accessibilityElement(children: .combine)
         .accessibilityAddTraits(.isStaticText)
         .accessibilityLabel(viewModel.model.strings.infoBarMessage)
@@ -417,6 +445,9 @@ struct PaymentReviewPaymentInformationView: View {
     private struct Constants {
         static let bannerVerticalPadding = 16.0
         static let bannerCornerRadius = 12.0
+        static let bannerHiddenOffset = 80.0
+        static let bannerEntranceDuration = 0.45
+        static let bannerDismissDuration = 0.3
         static let textFieldsContainerSpacing = 8.0
         static let buttonsContainerSpacing = 8.0
         static let paymentProviderPickerSpacing = 12.0

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/Views/PaymentInformation/PaymentReviewPaymentInformationView.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/Views/PaymentInformation/PaymentReviewPaymentInformationView.swift
@@ -57,41 +57,41 @@ struct PaymentReviewPaymentInformationView: View {
     }
     
     var body: some View {
-        scrollView
-            .overlay(alignment: .top) {
-                if showBanner {
-                    infoBannerView
-                        .onAppear {
-                            UIAccessibility.post(notification: .announcement,
-                                                 argument: viewModel.model.strings.infoBarMessage)
-                        }
-                }
+        ZStack(alignment: .top) {
+            scrollView
+            if showBanner {
+                infoBannerView
+                    .onAppear {
+                        UIAccessibility.post(notification: .announcement,
+                                             argument: viewModel.model.strings.infoBarMessage)
+                    }
             }
-            .onAppear {
-                viewModel.isViewVisible = true
-
-                viewModel.populateFieldsIfNeeded()
-                // Notify VoiceOver that a new screen (the sheet) appeared,
-                // so it moves focus into the sheet content.
-                UIAccessibility.post(notification: .screenChanged, argument: nil)
-                // After a rotation the view is recreated; restore keyboard if it was open.
-                restoreFocusIfNeeded()
-            }
-            .onDisappear {
-                viewModel.isViewVisible = false
-            }
+        }
+        .clipped()
+        .onAppear {
+            viewModel.isViewVisible = true
+            viewModel.populateFieldsIfNeeded()
+            // Notify VoiceOver that a new screen (the sheet) appeared,
+            // so it moves focus into the sheet content.
+            UIAccessibility.post(notification: .screenChanged, argument: nil)
+            // After a rotation the view is recreated; restore keyboard if it was open.
+            restoreFocusIfNeeded()
+        }
+        .onDisappear {
+            viewModel.isViewVisible = false
+        }
         // Track which field is active so it can be restored after orientation changes.
-            .onChange(of: focusedField) { newField in
-                handleFocusedFieldChange(newField)
-            }
-            .background(Color(.systemBackground))
-            .onReceive(NotificationCenter.default.publisher(for: UIResponder.keyboardWillShowNotification)) { notification in
-                guard let frame = notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? CGRect else { return }
-                keyboardHeight = frame.height
-            }
-            .onReceive(NotificationCenter.default.publisher(for: UIResponder.keyboardWillHideNotification)) { _ in
-                keyboardHeight = 0
-            }
+        .onChange(of: focusedField) { newField in
+            handleFocusedFieldChange(newField)
+        }
+        .background(Color(.systemBackground))
+        .onReceive(NotificationCenter.default.publisher(for: UIResponder.keyboardWillShowNotification)) { notification in
+            guard let frame = notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? CGRect else { return }
+            keyboardHeight = frame.height
+        }
+        .onReceive(NotificationCenter.default.publisher(for: UIResponder.keyboardWillHideNotification)) { _ in
+            keyboardHeight = 0
+        }
     }
 
     // MARK: Private views
@@ -183,7 +183,6 @@ struct PaymentReviewPaymentInformationView: View {
                 topTrailingRadius: Constants.bannerCornerRadius
             )
         )
-        .offset(y: giniLayout.isLandscape ? 0.0 : Constants.bannerYOffset)
         .transition(.move(edge: .top).combined(with: .opacity))
         .accessibilityElement(children: .combine)
         .accessibilityAddTraits(.isStaticText)
@@ -418,7 +417,6 @@ struct PaymentReviewPaymentInformationView: View {
     private struct Constants {
         static let bannerVerticalPadding = 16.0
         static let bannerCornerRadius = 12.0
-        static let bannerYOffset = -8.0
         static let textFieldsContainerSpacing = 8.0
         static let buttonsContainerSpacing = 8.0
         static let paymentProviderPickerSpacing = 12.0

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/Views/PaymentInformation/PaymentReviewPaymentInformationView.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/Views/PaymentInformation/PaymentReviewPaymentInformationView.swift
@@ -64,21 +64,7 @@ struct PaymentReviewPaymentInformationView: View {
     }
     
     var body: some View {
-        ZStack(alignment: .top) {
-            scrollView
-            // Keep banner in tree while either flag is true so the exit animation plays.
-            if showBanner || bannerVisible {
-                infoBannerView
-                    .offset(y: bannerVisible ? 0 : -Constants.bannerHiddenOffset)
-                    .opacity(bannerVisible ? 1 : 0)
-                    .animation(!UIAccessibility.isReduceMotionEnabled
-                                    ? .spring(response: Constants.bannerEntranceDuration,
-                                              dampingFraction: 0.8)
-                                    : nil,
-                               value: bannerVisible)
-            }
-        }
-        .clipped()
+        scrollView
         .onAppear {
             viewModel.isViewVisible = true
             viewModel.populateFieldsIfNeeded()
@@ -165,6 +151,13 @@ struct PaymentReviewPaymentInformationView: View {
     private var baseScrollView: some View {
         ScrollView {
             VStack(spacing: Constants.textFieldsContainerSpacing) {
+                if bannerVisible {
+                    infoBannerView
+                        .transition(!UIAccessibility.isReduceMotionEnabled
+                                        ? .move(edge: .top).combined(with: .opacity)
+                                        : .opacity)
+                }
+
                 recipientTextField
 
                 adaptiveStack(spacing: Constants.textFieldsContainerSpacing) {
@@ -204,19 +197,12 @@ struct PaymentReviewPaymentInformationView: View {
         .frame(maxWidth: .infinity)
         .padding(.vertical, Constants.bannerVerticalPadding)
         .background(Color(infoBar.backgroundColor))
-        .clipShape(
-            .rect(
-                topLeadingRadius: Constants.bannerCornerRadius,
-                bottomLeadingRadius: 0.0,
-                bottomTrailingRadius: 0.0,
-                topTrailingRadius: Constants.bannerCornerRadius
-            )
-        )
+        .clipShape(.rect(cornerRadius: Constants.bannerCornerRadius))
         .accessibilityElement(children: .combine)
         .accessibilityAddTraits(.isStaticText)
         .accessibilityLabel(viewModel.model.strings.infoBarMessage)
     }
-    
+
     @ViewBuilder
     private var recipientTextField: some View {
         TextField("", text: $viewModel.recipientInputState.text)
@@ -443,9 +429,8 @@ struct PaymentReviewPaymentInformationView: View {
     }
 
     private struct Constants {
-        static let bannerVerticalPadding = 16.0
+        static let bannerVerticalPadding = 12.0
         static let bannerCornerRadius = 12.0
-        static let bannerHiddenOffset = 80.0
         static let bannerEntranceDuration = 0.45
         static let bannerDismissDuration = 0.3
         static let textFieldsContainerSpacing = 8.0

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/Views/PaymentReviewContentView.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/Views/PaymentReviewContentView.swift
@@ -154,7 +154,7 @@ public struct PaymentReviewContentView: View {
     }
     
     // MARK: - Private Views
-    
+
     @ViewBuilder
     private var loadingOverlay: some View {
         if viewModel.isLoading {


### PR DESCRIPTION
## Pull Request Description

Fixes the green info banner on the Payment Review screen.

The banner was rendered in a `ZStack` overlay at the top of the sheet, which caused two problems:
- It covered the Recipient field, hiding pre-filled data
- The sheet height (`contentHeight`) only measured the form fields, so when the banner appeared the buttons at the bottom were pushed out of view

### How it was implemented

The banner is now the first item inside the fields `VStack` within `baseScrollView`. Because `getHeight` is applied to that `VStack`, it naturally includes the banner height and the sheet's `presentationDetents` detent grows to fit all content when the banner slides in.

The entry animation was changed from a manual `offset(y:) + opacity` driven by a separate `bannerVisible` state to SwiftUI's `.transition(.move(edge: .top).combined(with: .opacity))`. The `ScrollView` clips the view as it slides in from the top, producing the same slide-down effect without needing `.clipped()` on a wrapping `ZStack`.

The corner radius was updated from top-only to all corners, since the banner is no longer pinned to the top edge of the sheet. `bannerVerticalPadding` was reduced from 16 to 12 pt for a more compact appearance.

**Affected module:** `GiniInternalPaymentSDK` — `PaymentReviewPaymentInformationView`, `PaymentReviewObservableModel` (whitespace only)

## Notes for Reviewers

**Test scenario:**

1. Open the Payment Review screen with a pre-filled invoice
2. Observe the green "Please check the pre-filled data." banner slides down from the top of the sheet (not from behind the grabber) with a spring animation
3. All four form fields (Recipient, IBAN, Amount, Reference number) and the bank picker + "To the banking app" button are fully visible below the banner
4. After the configured popup duration (~3 s) the banner slides back up; the form snaps back to its full height
5. Verify on both small (iPhone Air) and large (iPhone 17 Pro Max) simulators — buttons must not be cut off on either

**Devices tested:** iPhone Air (iOS 18.5), iPhone 17 Pro Max (iOS 18.5)

**Known limitation:** The sheet resize animation (sheet growing when banner appears) is driven by the `presentationDetents` change and may not be perfectly in sync with the banner's spring animation on iOS 16. Functionally correct on iOS 17+.

No new unit tests were added — the change is purely visual/layout.