### PR TITLE
fix: Restructure green info bar layout above payment form fields

### DIFF
--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/Views/PaymentInformation/PaymentReviewPaymentInformationView.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/Views/PaymentInformation/PaymentReviewPaymentInformationView.swift
@@ -58,15 +58,6 @@ struct PaymentReviewPaymentInformationView: View {
     
     var body: some View {
         scrollView
-            .overlay(alignment: .top) {
-                if showBanner {
-                    infoBannerView
-                        .onAppear {
-                            UIAccessibility.post(notification: .announcement,
-                                                 argument: viewModel.model.strings.infoBarMessage)
-                        }
-                }
-            }
             .onAppear {
                 viewModel.isViewVisible = true
 
@@ -135,28 +126,39 @@ struct PaymentReviewPaymentInformationView: View {
 
     private var baseScrollView: some View {
         ScrollView {
-            VStack(spacing: Constants.textFieldsContainerSpacing) {
-                recipientTextField
-
-                adaptiveStack(spacing: Constants.textFieldsContainerSpacing) {
-                    ibanTextField
-                    amountTextField
+            VStack(spacing: 0) {
+                if showBanner {
+                    infoBannerView
+                        .transition(.move(edge: .top).combined(with: .opacity))
+                        .onAppear {
+                            UIAccessibility.post(notification: .announcement,
+                                                 argument: viewModel.model.strings.infoBarMessage)
+                        }
                 }
 
-                paymentPurposeTextField
+                VStack(spacing: Constants.textFieldsContainerSpacing) {
+                    recipientTextField
 
-                adaptiveStack(spacing: Constants.buttonsContainerSpacing) {
-                    paymentProviderSelectionPicker
-                    payButton
-                }
-                .padding(.bottom, Constants.buttonsContainerBottomPadding)
+                    adaptiveStack(spacing: Constants.textFieldsContainerSpacing) {
+                        ibanTextField
+                        amountTextField
+                    }
 
-                if viewModel.shouldShowBrandedView {
-                    poweredByGiniView
+                    paymentPurposeTextField
+
+                    adaptiveStack(spacing: Constants.buttonsContainerSpacing) {
+                        paymentProviderSelectionPicker
+                        payButton
+                    }
+                    .padding(.bottom, Constants.buttonsContainerBottomPadding)
+
+                    if viewModel.shouldShowBrandedView {
+                        poweredByGiniView
+                    }
                 }
+                .padding(.horizontal, Constants.textFieldsContainerHorizontalPadding)
+                .padding(.top, Constants.textFieldsContainerTopPadding)
             }
-            .padding(.horizontal, Constants.textFieldsContainerHorizontalPadding)
-            .padding(.top, Constants.textFieldsContainerTopPadding)
             .getHeight(for: $contentHeight)
         }
     }
@@ -183,8 +185,6 @@ struct PaymentReviewPaymentInformationView: View {
                 topTrailingRadius: Constants.bannerCornerRadius
             )
         )
-        .offset(y: giniLayout.isLandscape ? 0.0 : Constants.bannerYOffset)
-        .transition(.move(edge: .top).combined(with: .opacity))
         .accessibilityElement(children: .combine)
         .accessibilityAddTraits(.isStaticText)
         .accessibilityLabel(viewModel.model.strings.infoBarMessage)
@@ -431,7 +431,6 @@ struct PaymentReviewPaymentInformationView: View {
     private struct Constants {
         static let bannerVerticalPadding = 16.0
         static let bannerCornerRadius = 12.0
-        static let bannerYOffset = -8.0
         static let textFieldsContainerSpacing = 8.0
         static let buttonsContainerSpacing = 8.0
         static let paymentProviderPickerSpacing = 12.0


### PR DESCRIPTION
## Summary
[HEAL-387](https://ginis.atlassian.net/browse/HEAL-387)

Moves the green info bar from an overlay (which covered the top of the form fields) into the scroll content VStack so it sits **above** the form fields as designed.

## Changes
- Removed `.overlay(alignment: .top)` from `body` — banner no longer covers form content
- Banner is now the first element in the scroll content `VStack`, full-width with no horizontal padding
- Form fields are in an inner `VStack` with original horizontal/top padding
- `getHeight` now wraps the outer VStack so sheet height auto-adjusts when the banner appears/disappears
- Moved `.transition` and VoiceOver accessibility announcement to the banner's new location
- Removed unused `bannerYOffset = -8.0` constant

[HEAL-387]: https://ginis.atlassian.net/browse/HEAL-387?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ