### PR TITLE
Heal 377 payment review keyboard dismissal on error edit

### DIFF
--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/PaymentReviewObservableModel.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/PaymentReviewObservableModel.swift
@@ -62,6 +62,19 @@ final class PaymentReviewObservableModel: ObservableObject {
         paymentInformationObservableModel.activeField = nil
         model.delegate?.trackOnPaymentReviewCloseKeyboardClicked()
     }
+
+    /**
+     Validates the amount field as if it had just lost focus.
+     Called explicitly by the landscape Done button, which resigns first responder via
+     UIKit rather than setting `focusedField = nil`. SwiftUI's `@FocusState` update from
+     a UIKit `resignFirstResponder` call is not guaranteed to be synchronous, so relying
+     solely on `onChange(of: focusedField)` to trigger validation can cause the error
+     message to appear only on the second Done press. Calling this directly — mirroring
+     what the portrait Done button does — ensures validation runs immediately.
+     */
+    func validateAmountFieldOnKeyboardDismiss() {
+        paymentInformationObservableModel.handleAmountFocusChange(isFocused: false)
+    }
     
     @Published private var showBanner: Bool
     

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/Views/PaymentInformation/PaymentReviewPaymentInformationObservableModel.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/Views/PaymentInformation/PaymentReviewPaymentInformationObservableModel.swift
@@ -196,10 +196,12 @@ final class PaymentReviewPaymentInformationObservableModel: ObservableObject {
     }
 
     /**
-     Clears the error state for a text field when the user edits its content.
-     Called from `onChange(of: text)` in the view so the error disappears on the first
-     keystroke rather than on focus-gain. This keeps the layout height stable while the
-     keyboard animates in, preventing the bottom-sheet from dismissing the keyboard.
+     Clears the error state for a text field when its text changes while the field is not focused.
+     Called from `onChange(of: text)` in the view, guarded by a focus check, so it only runs
+     for programmatic text changes (e.g. population on load) — never while the user is actively
+     typing. Clearing error during typing would trigger a `.error → .focused` style transition
+     inside `GiniTextFieldStyle`, causing SwiftUI to replace the underlying `UITextField` and
+     dismiss the keyboard (HEAL-377).
      */
     func clearErrorOnTextChange(for inputState: ReferenceWritableKeyPath<PaymentReviewPaymentInformationObservableModel, GiniInputFieldState>) {
         guard self[keyPath: inputState].hasError else { return }

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/Views/PaymentInformation/PaymentReviewPaymentInformationObservableModel.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/Views/PaymentInformation/PaymentReviewPaymentInformationObservableModel.swift
@@ -42,6 +42,7 @@ final class PaymentReviewPaymentInformationObservableModel: ObservableObject {
     @Published var isAmountFieldFocused: Bool = false
 
     private var cancellables = Set<AnyCancellable>()
+    private var amountErrorClearTask: Task<Void, Never>?
     
     @Published var extractions: [Extraction]
     @Published var selectedPaymentProvider: PaymentProvider
@@ -309,9 +310,10 @@ final class PaymentReviewPaymentInformationObservableModel: ObservableObject {
     }
     
     private func clearAmountErrorAfterKeyboardAppears() {
-        Task { @MainActor [weak self] in
+        amountErrorClearTask?.cancel()
+        amountErrorClearTask = Task { @MainActor [weak self] in
             try? await Task.sleep(for: .seconds(Constants.keyboardAnimationDelay))
-            guard let self, self.isAmountFieldFocused else { return }
+            guard !Task.isCancelled, let self, self.isAmountFieldFocused else { return }
             self.amountInputState.hasError = false
             self.amountInputState.errorMessage = nil
         }

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/Views/PaymentInformation/PaymentReviewPaymentInformationObservableModel.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/Views/PaymentInformation/PaymentReviewPaymentInformationObservableModel.swift
@@ -226,11 +226,10 @@ final class PaymentReviewPaymentInformationObservableModel: ObservableObject {
             if amountToPay.value > 0, let rawText = amountToPay.stringWithoutSymbol {
                 if rawText != amountInputState.text {
                     amountInputState.text = rawText
-                    // onChange(of: amountInputState.text) fires → handleAmountTextChange → clears error
                 } else {
-                    // Text is already in raw format — no onChange fires, so handleAmountTextChange
-                    // won't run. Clear the error after the keyboard animation completes to avoid
-                    // a height change that would conflict with keyboard appearance.
+                    /// Text is already in raw format — no onChange fires.
+                    /// Clear the error after the keyboard animation completes to avoid
+                    /// a height change that would conflict with keyboard appearance.
                     clearAmountErrorAfterKeyboardAppears()
                 }
             }
@@ -258,21 +257,15 @@ final class PaymentReviewPaymentInformationObservableModel: ObservableObject {
     }
 
     /**
-     Handles a text change in the amount field: clears the error flag (only while the
-     user is actively editing) and updates both the displayed text and the `amountToPay`
-     value if the input is parsable.
+     Handles a text change in the amount field: updates both the displayed text and the
+     `amountToPay` value if the input is parsable.
 
-     The guard on `isAmountFieldFocused` prevents programmatic text changes — e.g.
-     the reformatting step inside `handleAmountFocusChange(isFocused: false)` — from
-     discarding a validation error that was just set by `updateFieldErrorStates` or the
-     pay-button action.
+     Error clearing is intentionally removed from this method. The view's
+     `onChange(of: amountInputState.text)` only calls `clearErrorOnTextChange` when the
+     amount field is **not** focused, which prevents the `.error → .focused` style
+     transition while the user is actively typing and avoids keyboard dismissal (HEAL-377).
      */
     func handleAmountTextChange(updatedText: String) {
-        /// Only clear the error while the user is actively typing. Programmatic
-        /// changes (formatting on focus-out) must not discard a validation error.
-        if isAmountFieldFocused {
-            amountInputState.hasError = false
-        }
         if let result = adjustAmountValue(text: updatedText) {
             amountInputState.text = result.adjustedText
             amountToPay.value = result.newValue

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/Views/PaymentInformation/PaymentReviewPaymentInformationObservableModel.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/Views/PaymentInformation/PaymentReviewPaymentInformationObservableModel.swift
@@ -201,7 +201,7 @@ final class PaymentReviewPaymentInformationObservableModel: ObservableObject {
      for programmatic text changes (e.g. population on load) — never while the user is actively
      typing. Clearing error during typing would trigger a `.error → .focused` style transition
      inside `GiniTextFieldStyle`, causing SwiftUI to replace the underlying `UITextField` and
-     dismiss the keyboard (HEAL-377).
+     dismiss the keyboard.
      */
     func clearErrorOnTextChange(for inputState: ReferenceWritableKeyPath<PaymentReviewPaymentInformationObservableModel, GiniInputFieldState>) {
         guard self[keyPath: inputState].hasError else { return }
@@ -265,7 +265,7 @@ final class PaymentReviewPaymentInformationObservableModel: ObservableObject {
      Error clearing is intentionally removed from this method. The view's
      `onChange(of: amountInputState.text)` only calls `clearErrorOnTextChange` when the
      amount field is **not** focused, which prevents the `.error → .focused` style
-     transition while the user is actively typing and avoids keyboard dismissal (HEAL-377).
+     transition while the user is actively typing and avoids keyboard dismissal.
      */
     func handleAmountTextChange(updatedText: String) {
         if let result = adjustAmountValue(text: updatedText) {

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/Views/PaymentInformation/PaymentReviewPaymentInformationObservableModel.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/Views/PaymentInformation/PaymentReviewPaymentInformationObservableModel.swift
@@ -314,9 +314,13 @@ final class PaymentReviewPaymentInformationObservableModel: ObservableObject {
         amountErrorClearTask = Task { @MainActor [weak self] in
             try? await Task.sleep(for: .seconds(Constants.keyboardAnimationDelay))
             guard !Task.isCancelled, let self, self.isAmountFieldFocused else { return }
-            self.amountInputState.hasError = false
-            self.amountInputState.errorMessage = nil
+            self.applyAmountErrorClear()
         }
+    }
+
+    func applyAmountErrorClear() {
+        amountInputState.hasError = false
+        amountInputState.errorMessage = nil
     }
 
     private func setupBindings() {

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/Views/PaymentInformation/PaymentReviewPaymentInformationObservableModel.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/Views/PaymentInformation/PaymentReviewPaymentInformationObservableModel.swift
@@ -176,16 +176,16 @@ final class PaymentReviewPaymentInformationObservableModel: ObservableObject {
 
     /**
      Handles a focus-change event for a generic text field.
-     When the field gains focus its error state is cleared; when it loses focus the field is
-     re-validated and, if invalid, the error message is announced to VoiceOver.
+     On focus-lost the field is re-validated and, if invalid, the error message is announced
+     to VoiceOver. Error clearing on focus-gain is intentionally deferred to text-change
+     (see `clearErrorOnTextChange(for:)`) to avoid a layout-height change while the keyboard
+     is animating in, which would cause the bottom-sheet detent to update and dismiss the keyboard.
      */
     func handleFocusChange(isFocused: Bool,
                            inputState: ReferenceWritableKeyPath<PaymentReviewPaymentInformationObservableModel, GiniInputFieldState>,
                            validate: (String) -> Bool,
                            error: KeyPath<PaymentReviewPaymentInformationObservableModel, String?>) {
-        if isFocused {
-            self[keyPath: inputState].hasError = false
-        } else {
+        if !isFocused {
             let text = self[keyPath: inputState].text
             self[keyPath: inputState].hasError = !validate(text)
             self[keyPath: inputState].errorMessage = self[keyPath: error]
@@ -196,25 +196,45 @@ final class PaymentReviewPaymentInformationObservableModel: ObservableObject {
     }
 
     /**
+     Clears the error state for a text field when the user edits its content.
+     Called from `onChange(of: text)` in the view so the error disappears on the first
+     keystroke rather than on focus-gain. This keeps the layout height stable while the
+     keyboard animates in, preventing the bottom-sheet from dismissing the keyboard.
+     */
+    func clearErrorOnTextChange(for inputState: ReferenceWritableKeyPath<PaymentReviewPaymentInformationObservableModel, GiniInputFieldState>) {
+        guard self[keyPath: inputState].hasError else { return }
+        self[keyPath: inputState].hasError = false
+        self[keyPath: inputState].errorMessage = nil
+    }
+
+    /**
      Handles a focus-change event specific to the amount field.
      On focus-gained the raw numeric value is shown; on focus-lost the value is re-formatted,
      validated, and any error is announced to VoiceOver.
+     Error clearing on focus-gain is deferred to `handleAmountTextChange` (via `onChange`)
+     to keep the layout height stable while the keyboard animates in. For the rare edge case
+     where the text is already in raw format and no `onChange` fires, error clearing is
+     scheduled after the keyboard animation completes.
      */
     func handleAmountFocusChange(isFocused: Bool) {
         if isFocused {
-            /// Always clear the error on focus-gain so the field immediately shows
-            /// as editable, even when the raw text equals the prior stored value and
-            /// no onChange fires to trigger handleAmountTextChange.
-            amountInputState.hasError = false
-            amountInputState.errorMessage = nil
             /// Only strip the currency symbol from the displayed text when there is a
             /// positive amount. For zero / unset values the text is already empty and
             /// a programmatic change from "" to "0,00" inside a Task can race with
             /// UIKit establishing first-responder, causing the field to briefly lose
             /// focus, re-trigger the validation path, and show the error again.
             if amountToPay.value > 0, let rawText = amountToPay.stringWithoutSymbol {
-                amountInputState.text = rawText
+                if rawText != amountInputState.text {
+                    amountInputState.text = rawText
+                    // onChange(of: amountInputState.text) fires → handleAmountTextChange → clears error
+                } else {
+                    // Text is already in raw format — no onChange fires, so handleAmountTextChange
+                    // won't run. Clear the error after the keyboard animation completes to avoid
+                    // a height change that would conflict with keyboard appearance.
+                    clearAmountErrorAfterKeyboardAppears()
+                }
             }
+            // Zero/empty amount: error is cleared when the user starts typing.
         } else {
             if !amountInputState.text.isEmpty,
                let decimalAmount = amountInputState.text.decimal() {
@@ -293,6 +313,15 @@ final class PaymentReviewPaymentInformationObservableModel: ObservableObject {
         return ("", "", "", "")
     }
     
+    private func clearAmountErrorAfterKeyboardAppears() {
+        Task { @MainActor [weak self] in
+            try? await Task.sleep(for: .seconds(Constants.keyboardAnimationDelay))
+            guard let self, self.isAmountFieldFocused else { return }
+            self.amountInputState.hasError = false
+            self.amountInputState.errorMessage = nil
+        }
+    }
+
     private func setupBindings() {
         model.onExtractionFetched = { [weak self] () in
             Task { @MainActor in
@@ -326,5 +355,13 @@ final class PaymentReviewPaymentInformationObservableModel: ObservableObject {
         let amountString = paymentInfo.amount
         
         return (recipient, iban, amountString, purpose)
+    }
+
+    private struct Constants {
+        /// Approximate duration of the iOS keyboard appearance animation.
+        /// Used to defer error-clearing for the amount field in the edge case where
+        /// no text-change fires on focus-gain, ensuring the height change does not
+        /// conflict with keyboard presentation in bottom-sheet mode.
+        static let keyboardAnimationDelay = 0.35
     }
 }

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/Views/PaymentInformation/PaymentReviewPaymentInformationObservableModel.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/Views/PaymentInformation/PaymentReviewPaymentInformationObservableModel.swift
@@ -236,7 +236,6 @@ final class PaymentReviewPaymentInformationObservableModel: ObservableObject {
                     clearAmountErrorAfterKeyboardAppears()
                 }
             }
-            // Zero/empty amount: error is cleared when the user starts typing.
         } else {
             if !amountInputState.text.isEmpty,
                let decimalAmount = amountInputState.text.decimal() {

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/Views/PaymentInformation/PaymentReviewPaymentInformationView.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/Views/PaymentInformation/PaymentReviewPaymentInformationView.swift
@@ -258,12 +258,8 @@ struct PaymentReviewPaymentInformationView: View {
             .focused($focusedField, equals: .amount)
             .onChange(of: viewModel.amountInputState.text) { newValue in
                 viewModel.handleAmountTextChange(updatedText: newValue)
-                /// Clearing the error while the field is focused triggers a `.error → .focused`
-                /// style-state transition that causes SwiftUI to replace the underlying UITextField,
-                /// dismissing the keyboard. Only clear when the field is not focused.
-                if focusedField != .amount {
-                    viewModel.clearErrorOnTextChange(for: \.amountInputState)
-                }
+                /// Amount error clearing is handled by `handleAmountFocusChange` and
+                /// `clearAmountErrorAfterKeyboardAppears` — not by text change.
             }
             .onChange(of: focusedField) { newFocus in
                 Task { @MainActor in

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/Views/PaymentInformation/PaymentReviewPaymentInformationView.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/Views/PaymentInformation/PaymentReviewPaymentInformationView.swift
@@ -215,7 +215,7 @@ struct PaymentReviewPaymentInformationView: View {
         .onChange(of: viewModel.recipientInputState.text) { _ in
             /// Clearing the error while the field is focused triggers a `.error → .focused`
             /// style-state transition that causes SwiftUI to replace the underlying UITextField,
-            /// dismissing the keyboard (HEAL-377). Only clear when the field is not focused.
+            /// dismissing the keyboard. Only clear when the field is not focused.
             guard focusedField != .recipient else { return }
             viewModel.clearErrorOnTextChange(for: \.recipientInputState)
         }
@@ -246,7 +246,7 @@ struct PaymentReviewPaymentInformationView: View {
         .onChange(of: viewModel.ibanInputState.text) { _ in
             /// Clearing the error while the field is focused triggers a `.error → .focused`
             /// style-state transition that causes SwiftUI to replace the underlying UITextField,
-            /// dismissing the keyboard (HEAL-377). Only clear when the field is not focused.
+            /// dismissing the keyboard. Only clear when the field is not focused.
             guard focusedField != .iban else { return }
             viewModel.clearErrorOnTextChange(for: \.ibanInputState)
         }
@@ -260,7 +260,7 @@ struct PaymentReviewPaymentInformationView: View {
                 viewModel.handleAmountTextChange(updatedText: newValue)
                 /// Clearing the error while the field is focused triggers a `.error → .focused`
                 /// style-state transition that causes SwiftUI to replace the underlying UITextField,
-                /// dismissing the keyboard (HEAL-377). Only clear when the field is not focused.
+                /// dismissing the keyboard. Only clear when the field is not focused.
                 if focusedField != .amount {
                     viewModel.clearErrorOnTextChange(for: \.amountInputState)
                 }
@@ -302,7 +302,7 @@ struct PaymentReviewPaymentInformationView: View {
         .onChange(of: viewModel.paymentPurposeInputState.text) { _ in
             /// Clearing the error while the field is focused triggers a `.error → .focused`
             /// style-state transition that causes SwiftUI to replace the underlying UITextField,
-            /// dismissing the keyboard (HEAL-377). Only clear when the field is not focused.
+            /// dismissing the keyboard. Only clear when the field is not focused.
             guard focusedField != .paymentPurpose else { return }
             viewModel.clearErrorOnTextChange(for: \.paymentPurposeInputState)
         }

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/Views/PaymentInformation/PaymentReviewPaymentInformationView.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/Views/PaymentInformation/PaymentReviewPaymentInformationView.swift
@@ -212,6 +212,9 @@ struct PaymentReviewPaymentInformationView: View {
                                             error: \.recipientError)
             }
         }
+        .onChange(of: viewModel.recipientInputState.text) { _ in
+            viewModel.clearErrorOnTextChange(for: \.recipientInputState)
+        }
     }
     
     @ViewBuilder
@@ -235,6 +238,9 @@ struct PaymentReviewPaymentInformationView: View {
                                             validate: viewModel.validateIBAN,
                                             error: \.ibanError)
             }
+        }
+        .onChange(of: viewModel.ibanInputState.text) { _ in
+            viewModel.clearErrorOnTextChange(for: \.ibanInputState)
         }
     }
     
@@ -276,6 +282,9 @@ struct PaymentReviewPaymentInformationView: View {
                                             validate: viewModel.validatePaymentPurpose,
                                             error: \.paymentPurposeError)
             }
+        }
+        .onChange(of: viewModel.paymentPurposeInputState.text) { _ in
+            viewModel.clearErrorOnTextChange(for: \.paymentPurposeInputState)
         }
     }
     

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/Views/PaymentInformation/PaymentReviewPaymentInformationView.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/Views/PaymentInformation/PaymentReviewPaymentInformationView.swift
@@ -213,9 +213,9 @@ struct PaymentReviewPaymentInformationView: View {
             }
         }
         .onChange(of: viewModel.recipientInputState.text) { _ in
-            /// Clearing the error while the field is focused triggers a `.error → .focused`
-            /// style-state transition that causes SwiftUI to replace the underlying UITextField,
-            /// dismissing the keyboard. Only clear when the field is not focused.
+            // Clearing the error while the field is focused triggers a `.error → .focused`
+            // style-state transition that causes SwiftUI to replace the underlying UITextField,
+            // dismissing the keyboard. Only clear when the field is not focused.
             guard focusedField != .recipient else { return }
             viewModel.clearErrorOnTextChange(for: \.recipientInputState)
         }
@@ -244,9 +244,9 @@ struct PaymentReviewPaymentInformationView: View {
             }
         }
         .onChange(of: viewModel.ibanInputState.text) { _ in
-            /// Clearing the error while the field is focused triggers a `.error → .focused`
-            /// style-state transition that causes SwiftUI to replace the underlying UITextField,
-            /// dismissing the keyboard. Only clear when the field is not focused.
+            // Clearing the error while the field is focused triggers a `.error → .focused`
+            // style-state transition that causes SwiftUI to replace the underlying UITextField,
+            // dismissing the keyboard. Only clear when the field is not focused.
             guard focusedField != .iban else { return }
             viewModel.clearErrorOnTextChange(for: \.ibanInputState)
         }
@@ -258,8 +258,8 @@ struct PaymentReviewPaymentInformationView: View {
             .focused($focusedField, equals: .amount)
             .onChange(of: viewModel.amountInputState.text) { newValue in
                 viewModel.handleAmountTextChange(updatedText: newValue)
-                /// Amount error clearing is handled by `handleAmountFocusChange` and
-                /// `clearAmountErrorAfterKeyboardAppears` — not by text change.
+                // Amount error clearing is handled by `handleAmountFocusChange` and
+                // `clearAmountErrorAfterKeyboardAppears` — not by text change.
             }
             .onChange(of: focusedField) { newFocus in
                 Task { @MainActor in
@@ -296,9 +296,9 @@ struct PaymentReviewPaymentInformationView: View {
             }
         }
         .onChange(of: viewModel.paymentPurposeInputState.text) { _ in
-            /// Clearing the error while the field is focused triggers a `.error → .focused`
-            /// style-state transition that causes SwiftUI to replace the underlying UITextField,
-            /// dismissing the keyboard. Only clear when the field is not focused.
+            // Clearing the error while the field is focused triggers a `.error → .focused`
+            // style-state transition that causes SwiftUI to replace the underlying UITextField,
+            // dismissing the keyboard. Only clear when the field is not focused.
             guard focusedField != .paymentPurpose else { return }
             viewModel.clearErrorOnTextChange(for: \.paymentPurposeInputState)
         }

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/Views/PaymentInformation/PaymentReviewPaymentInformationView.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/Views/PaymentInformation/PaymentReviewPaymentInformationView.swift
@@ -213,6 +213,10 @@ struct PaymentReviewPaymentInformationView: View {
             }
         }
         .onChange(of: viewModel.recipientInputState.text) { _ in
+            /// Clearing the error while the field is focused triggers a `.error → .focused`
+            /// style-state transition that causes SwiftUI to replace the underlying UITextField,
+            /// dismissing the keyboard (HEAL-377). Only clear when the field is not focused.
+            guard focusedField != .recipient else { return }
             viewModel.clearErrorOnTextChange(for: \.recipientInputState)
         }
     }
@@ -240,6 +244,10 @@ struct PaymentReviewPaymentInformationView: View {
             }
         }
         .onChange(of: viewModel.ibanInputState.text) { _ in
+            /// Clearing the error while the field is focused triggers a `.error → .focused`
+            /// style-state transition that causes SwiftUI to replace the underlying UITextField,
+            /// dismissing the keyboard (HEAL-377). Only clear when the field is not focused.
+            guard focusedField != .iban else { return }
             viewModel.clearErrorOnTextChange(for: \.ibanInputState)
         }
     }
@@ -247,19 +255,27 @@ struct PaymentReviewPaymentInformationView: View {
     @ViewBuilder
     private var amountTextField: some View {
         TextField("", text: $viewModel.amountInputState.text)
-        .focused($focusedField, equals: .amount)
-        .onChange(of: viewModel.amountInputState.text) { newValue in
-            viewModel.handleAmountTextChange(updatedText: newValue)
-        }
-        .onChange(of: focusedField) { newFocus in
-            Task { @MainActor in
-                viewModel.handleAmountFocusChange(isFocused: newFocus == .amount)
+            .focused($focusedField, equals: .amount)
+            .onChange(of: viewModel.amountInputState.text) { newValue in
+                viewModel.handleAmountTextChange(updatedText: newValue)
+                /// Clearing the error while the field is focused triggers a `.error → .focused`
+                /// style-state transition that causes SwiftUI to replace the underlying UITextField,
+                /// dismissing the keyboard (HEAL-377). Only clear when the field is not focused.
+                if focusedField != .amount {
+                    viewModel.clearErrorOnTextChange(for: \.amountInputState)
+                }
             }
-        }
-        .keyboardType(.decimalPad)
-        .textFieldStyle(makeTextFieldStyle(title: viewModelStrings.fieldPlaceholders.amount,
-                                           field: .amount,
-                                           inputState: viewModel.amountInputState))
+            .onChange(of: focusedField) { newFocus in
+                Task { @MainActor in
+                    viewModel.handleAmountFocusChange(isFocused: newFocus == .amount)
+                }
+            }
+            .keyboardType(.decimalPad)
+            .textFieldStyle(makeTextFieldStyle(
+                title: viewModelStrings.fieldPlaceholders.amount,
+                field: .amount,
+                inputState: viewModel.amountInputState
+            ))
     }
     
     @ViewBuilder
@@ -284,6 +300,10 @@ struct PaymentReviewPaymentInformationView: View {
             }
         }
         .onChange(of: viewModel.paymentPurposeInputState.text) { _ in
+            /// Clearing the error while the field is focused triggers a `.error → .focused`
+            /// style-state transition that causes SwiftUI to replace the underlying UITextField,
+            /// dismissing the keyboard (HEAL-377). Only clear when the field is not focused.
+            guard focusedField != .paymentPurpose else { return }
             viewModel.clearErrorOnTextChange(for: \.paymentPurposeInputState)
         }
     }

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/Views/PaymentReviewContentView.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/Views/PaymentReviewContentView.swift
@@ -69,6 +69,7 @@ public struct PaymentReviewContentView: View {
                     Spacer()
                     Button(viewModel.keyboardDoneButtonTitle) {
                         viewModel.trackKeyboardDismissed()
+                        viewModel.validateAmountFieldOnKeyboardDismiss()
                         UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder),
                                                         to: nil,
                                                         from: nil,

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Tests/GiniInternalPaymentSDKTests/PaymentReviewHandleAmountFocusChangeTests.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Tests/GiniInternalPaymentSDKTests/PaymentReviewHandleAmountFocusChangeTests.swift
@@ -35,19 +35,6 @@ struct PaymentReviewHandleAmountFocusChangeTests {
         #expect(sut.amountInputState.text == "", "focus gained with zero amount must not pre-fill text — a programmatic '\"\" → \"0,00\"' change inside the async Task can race with UIKit first-responder setup and trigger a focus loss that re-shows the error")
     }
 
-    @Test("focus gained clears any existing error")
-    func focusGainedClearsError() {
-        let sut = PaymentReviewPaymentInformationObservableModel(model: .test())
-        sut.amountToPay = Price(value: 12.50, currencyCode: "EUR")
-        sut.amountInputState.hasError = true
-        sut.amountInputState.errorMessage = "some error"
-
-        sut.handleAmountFocusChange(isFocused: true)
-
-        #expect(sut.amountInputState.hasError == false, "focus gained must clear hasError so the field is immediately editable even when text did not change")
-        #expect(sut.amountInputState.errorMessage == nil, "focus gained must clear errorMessage")
-    }
-
     @Test("focus lost with empty text sets hasError")
     func focusLostEmptyTextSetsError() {
         let sut = PaymentReviewPaymentInformationObservableModel(model: .test())

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Tests/GiniInternalPaymentSDKTests/PaymentReviewHandleAmountFocusChangeTests.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Tests/GiniInternalPaymentSDKTests/PaymentReviewHandleAmountFocusChangeTests.swift
@@ -142,3 +142,33 @@ struct PaymentReviewHandleAmountFocusChangeTests {
         #expect(sut.amountInputState.hasError == true, "double call with empty amount must keep hasError set — the Done button triggers this path")
     }
 }
+
+// MARK: - applyAmountErrorClear
+
+@Suite("PaymentReviewPaymentInformationObservableModel — applyAmountErrorClear")
+@MainActor
+struct PaymentReviewApplyAmountErrorClearTests {
+
+    @Test("clears hasError and errorMessage")
+    func clearsError() {
+        let sut = PaymentReviewPaymentInformationObservableModel(model: .test())
+        sut.amountInputState.hasError = true
+        sut.amountInputState.errorMessage = "Amount is required"
+
+        sut.applyAmountErrorClear()
+
+        #expect(sut.amountInputState.hasError == false, "applyAmountErrorClear must set hasError to false")
+        #expect(sut.amountInputState.errorMessage == nil, "applyAmountErrorClear must clear errorMessage")
+    }
+
+    @Test("is a no-op when no error is set")
+    func isNoOpWhenNoError() {
+        let sut = PaymentReviewPaymentInformationObservableModel(model: .test())
+        sut.amountInputState.hasError = false
+        sut.amountInputState.errorMessage = nil
+
+        sut.applyAmountErrorClear()
+
+        #expect(sut.amountInputState.hasError == false, "applyAmountErrorClear must not flip hasError when already false")
+    }
+}

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Tests/GiniInternalPaymentSDKTests/PaymentReviewHandleAmountFocusChangeTests.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Tests/GiniInternalPaymentSDKTests/PaymentReviewHandleAmountFocusChangeTests.swift
@@ -91,6 +91,33 @@ struct PaymentReviewHandleAmountFocusChangeTests {
     // second call. UIAccessibility.post cannot be unit-tested directly, but the guard's
     // effect is verified indirectly: if hasError was already true on entry to the second
     // call, the announcement branch is skipped.
+    @Test("focus gained when text is already raw does not change text")
+    func focusGainedWithTextAlreadyRawDoesNotChangeText() {
+        let sut = PaymentReviewPaymentInformationObservableModel(model: .test())
+        sut.amountToPay = Price(value: 12.50, currencyCode: "EUR")
+        /// Pre-set the text to the raw value so the `rawText == amountInputState.text` branch is taken.
+        sut.amountInputState.text = sut.amountToPay.stringWithoutSymbol ?? "12.50"
+        let textBefore = sut.amountInputState.text
+
+        sut.handleAmountFocusChange(isFocused: true)
+
+        #expect(sut.amountInputState.text == textBefore, "focus gained with text already in raw format must not change the text")
+    }
+
+    @Test("focus gained when text is already raw does not immediately clear error (clears are deferred)")
+    func focusGainedWithTextAlreadyRawDoesNotImmediatelyClearError() {
+        let sut = PaymentReviewPaymentInformationObservableModel(model: .test())
+        sut.amountToPay = Price(value: 12.50, currencyCode: "EUR")
+        sut.amountInputState.text = sut.amountToPay.stringWithoutSymbol ?? "12.50"
+        sut.amountInputState.hasError = true
+        /// isAmountFieldFocused is false in this test — the deferred Task inside
+        /// clearAmountErrorAfterKeyboardAppears will guard on it and be a no-op.
+
+        sut.handleAmountFocusChange(isFocused: true)
+
+        #expect(sut.amountInputState.hasError == true, "error must not be cleared immediately when the deferred-clear path is taken")
+    }
+
     @Test("calling handleAmountFocusChange(isFocused: false) twice with valid amount stays error-free")
     func doubleCallWithValidAmountIsIdempotent() {
         let sut = PaymentReviewPaymentInformationObservableModel(model: .test())

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Tests/GiniInternalPaymentSDKTests/PaymentReviewHandleAmountTextChangeTests.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Tests/GiniInternalPaymentSDKTests/PaymentReviewHandleAmountTextChangeTests.swift
@@ -12,31 +12,8 @@ import Testing
 @MainActor
 struct PaymentReviewHandleAmountTextChangeTests {
 
-    @Test("valid amount text clears error and updates amountToPay while field is focused")
-    func validTextClearsErrorWhenFocused() {
-        let sut = PaymentReviewPaymentInformationObservableModel(model: .test())
-        sut.amountInputState.hasError = true
-        sut.isAmountFieldFocused = true
-
-        sut.handleAmountTextChange(updatedText: "12,50")
-
-        #expect(sut.amountInputState.hasError == false, "handleAmountTextChange with valid text must clear hasError while the user is actively typing")
-        #expect(sut.amountToPay.value > 0, "handleAmountTextChange with valid text must update amountToPay to a positive value")
-    }
-
-    @Test("non-parsable text still clears hasError without crashing while field is focused")
-    func nonParsableTextClearsErrorWhenFocused() {
-        let sut = PaymentReviewPaymentInformationObservableModel(model: .test())
-        sut.amountInputState.hasError = true
-        sut.isAmountFieldFocused = true
-
-        sut.handleAmountTextChange(updatedText: "abc")
-
-        #expect(sut.amountInputState.hasError == false, "handleAmountTextChange with non-parsable text must still clear hasError without crashing while the user is actively typing")
-    }
-
-    @Test("text change does not clear error when field is not focused (programmatic change)")
-    func textChangeDoesNotClearErrorWhenNotFocused() {
+    @Test("text change does not clear error — handleAmountTextChange never clears error regardless of focus state")
+    func textChangeDoesNotClearError() {
         let sut = PaymentReviewPaymentInformationObservableModel(model: .test())
         sut.amountInputState.hasError = true
         sut.isAmountFieldFocused = false
@@ -44,6 +21,6 @@ struct PaymentReviewHandleAmountTextChangeTests {
         sut.handleAmountTextChange(updatedText: "12,50")
 
         #expect(sut.amountInputState.hasError == true,
-                "programmatic text change (isAmountFieldFocused == false) must not clear a validation error set by the pay button")
+                "handleAmountTextChange must never clear a validation error — error clearing is handled by the view's onChange(of: text) guard, not the model")
     }
 }

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Tests/GiniInternalPaymentSDKTests/PaymentReviewHandleFocusChangeTests.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Tests/GiniInternalPaymentSDKTests/PaymentReviewHandleFocusChangeTests.swift
@@ -12,19 +12,6 @@ import Testing
 @MainActor
 struct PaymentReviewHandleFocusChangeTests {
 
-    @Test("focus gained clears hasError")
-    func focusGainedClearsError() {
-        let sut = PaymentReviewPaymentInformationObservableModel(model: .test())
-        sut.recipientInputState.hasError = true
-
-        sut.handleFocusChange(isFocused: true,
-                              inputState: \.recipientInputState,
-                              validate: sut.validateRecipient,
-                              error: \.recipientError)
-
-        #expect(sut.recipientInputState.hasError == false, "focus gained must clear hasError on the input state")
-    }
-
     @Test("focus lost with valid text sets no error")
     func focusLostValidTextNoError() {
         let sut = PaymentReviewPaymentInformationObservableModel(model: .test())

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Tests/GiniInternalPaymentSDKTests/PaymentReviewHandleFocusChangeTests.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Tests/GiniInternalPaymentSDKTests/PaymentReviewHandleFocusChangeTests.swift
@@ -52,3 +52,44 @@ struct PaymentReviewHandleFocusChangeTests {
         #expect(sut.ibanInputState.hasError == true, "focus lost with invalid IBAN must set hasError on the IBAN input state")
     }
 }
+
+// MARK: - clearErrorOnTextChange
+
+@Suite("PaymentReviewPaymentInformationObservableModel — clearErrorOnTextChange")
+@MainActor
+struct PaymentReviewClearErrorOnTextChangeTests {
+
+    @Test("clears hasError and errorMessage when hasError is true")
+    func clearsErrorWhenErrorIsSet() {
+        let sut = PaymentReviewPaymentInformationObservableModel(model: .test())
+        sut.recipientInputState.hasError = true
+        sut.recipientInputState.errorMessage = "Recipient is required"
+
+        sut.clearErrorOnTextChange(for: \.recipientInputState)
+
+        #expect(sut.recipientInputState.hasError == false, "clearErrorOnTextChange must set hasError to false")
+        #expect(sut.recipientInputState.errorMessage == nil, "clearErrorOnTextChange must clear errorMessage")
+    }
+
+    @Test("is a no-op when hasError is already false")
+    func isNoOpWhenNoError() {
+        let sut = PaymentReviewPaymentInformationObservableModel(model: .test())
+        sut.recipientInputState.hasError = false
+        sut.recipientInputState.errorMessage = nil
+
+        sut.clearErrorOnTextChange(for: \.recipientInputState)
+
+        #expect(sut.recipientInputState.hasError == false, "clearErrorOnTextChange must not flip hasError when it is already false")
+    }
+
+    @Test("works for any field via the key path parameter")
+    func worksForIBANField() {
+        let sut = PaymentReviewPaymentInformationObservableModel(model: .test())
+        sut.ibanInputState.hasError = true
+        sut.ibanInputState.errorMessage = "Invalid IBAN"
+
+        sut.clearErrorOnTextChange(for: \.ibanInputState)
+
+        #expect(sut.ibanInputState.hasError == false, "clearErrorOnTextChange must clear the field identified by the key path")
+    }
+}

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Tests/GiniInternalPaymentSDKTests/PaymentReviewHandleFocusChangeTests.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Tests/GiniInternalPaymentSDKTests/PaymentReviewHandleFocusChangeTests.swift
@@ -82,14 +82,22 @@ struct PaymentReviewClearErrorOnTextChangeTests {
         #expect(sut.recipientInputState.hasError == false, "clearErrorOnTextChange must not flip hasError when it is already false")
     }
 
-    @Test("works for any field via the key path parameter")
-    func worksForIBANField() {
+    @Test("clears error for any field", arguments: [
+        \PaymentReviewPaymentInformationObservableModel.recipientInputState,
+        \.ibanInputState,
+        \.amountInputState,
+        \.paymentPurposeInputState
+    ])
+    func clearsErrorForField(
+        keyPath: ReferenceWritableKeyPath<PaymentReviewPaymentInformationObservableModel, GiniInputFieldState>
+    ) {
         let sut = PaymentReviewPaymentInformationObservableModel(model: .test())
-        sut.ibanInputState.hasError = true
-        sut.ibanInputState.errorMessage = "Invalid IBAN"
+        sut[keyPath: keyPath].hasError = true
+        sut[keyPath: keyPath].errorMessage = "Error"
 
-        sut.clearErrorOnTextChange(for: \.ibanInputState)
+        sut.clearErrorOnTextChange(for: keyPath)
 
-        #expect(sut.ibanInputState.hasError == false, "clearErrorOnTextChange must clear the field identified by the key path")
+        #expect(sut[keyPath: keyPath].hasError == false, "clearErrorOnTextChange must clear hasError")
+        #expect(sut[keyPath: keyPath].errorMessage == nil, "clearErrorOnTextChange must clear errorMessage")
     }
 }

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Tests/GiniInternalPaymentSDKTests/PaymentReviewObservableModelTests.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Tests/GiniInternalPaymentSDKTests/PaymentReviewObservableModelTests.swift
@@ -370,22 +370,6 @@ struct PaymentReviewObservableModelTests {
 
     // MARK: - validateAmountFieldOnKeyboardDismiss
 
-    @Test("validateAmountFieldOnKeyboardDismiss does not affect focus state")
-    func validateAmountFieldOnKeyboardDismissDoesNotChangeFocusState() {
-        let delegate = MockPaymentReviewDelegate()
-        let provider = MockBottomSheetsProvider()
-        let model = makePaymentReviewModel(delegate: delegate, bottomSheetsProvider: provider)
-        let sut = PaymentReviewObservableModel(model: model)
-        /// Simulate the landscape Done button path: validates the amount field directly
-        /// because SwiftUI's @FocusState update from UIKit resignFirstResponder is not
-        /// guaranteed to be synchronous.
-
-        sut.validateAmountFieldOnKeyboardDismiss()
-
-        #expect(sut.isAmountFieldFocused == false,
-                "validateAmountFieldOnKeyboardDismiss must not alter the focus state of the amount field")
-    }
-
     @Test("validateAmountFieldOnKeyboardDismiss is safe to call twice without crashing")
     func validateAmountFieldOnKeyboardDismissIsIdempotent() {
         let delegate = MockPaymentReviewDelegate()

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Tests/GiniInternalPaymentSDKTests/PaymentReviewObservableModelTests.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Tests/GiniInternalPaymentSDKTests/PaymentReviewObservableModelTests.swift
@@ -367,4 +367,33 @@ struct PaymentReviewObservableModelTests {
         #expect(vmDelegate.lastErrorMessage == "Payment error",
                 "The error message must match the configured createPaymentErrorMessage")
     }
+
+    // MARK: - validateAmountFieldOnKeyboardDismiss
+
+    @Test("validateAmountFieldOnKeyboardDismiss does not affect focus state")
+    func validateAmountFieldOnKeyboardDismissDoesNotChangeFocusState() {
+        let delegate = MockPaymentReviewDelegate()
+        let provider = MockBottomSheetsProvider()
+        let model = makePaymentReviewModel(delegate: delegate, bottomSheetsProvider: provider)
+        let sut = PaymentReviewObservableModel(model: model)
+        /// Simulate the landscape Done button path: validates the amount field directly
+        /// because SwiftUI's @FocusState update from UIKit resignFirstResponder is not
+        /// guaranteed to be synchronous.
+
+        sut.validateAmountFieldOnKeyboardDismiss()
+
+        #expect(sut.isAmountFieldFocused == false,
+                "validateAmountFieldOnKeyboardDismiss must not alter the focus state of the amount field")
+    }
+
+    @Test("validateAmountFieldOnKeyboardDismiss is safe to call twice without crashing")
+    func validateAmountFieldOnKeyboardDismissIsIdempotent() {
+        let delegate = MockPaymentReviewDelegate()
+        let provider = MockBottomSheetsProvider()
+        let model = makePaymentReviewModel(delegate: delegate, bottomSheetsProvider: provider)
+        let sut = PaymentReviewObservableModel(model: model)
+
+        sut.validateAmountFieldOnKeyboardDismiss()
+        sut.validateAmountFieldOnKeyboardDismiss()
+    }
 }


### PR DESCRIPTION
## Pull Request Description

<!-- Briefly explain **what** this PR does and **why**. Mention the motivation, feature, or issue it's addressing. -->

[HEAL-377](https://ginis.atlassian.net/browse/HEAL-377)
[HEAL-390](https://ginis.atlassian.net/browse/HEAL-390)
<!-- Closes ticket number PP-####; Replace with JIRA ticket if relevant -->

This PR addresses  HEAL-377, HEAL-390 by changing when payment-review input-field errors are cleared/validated to prevent SwiftUI state transitions from replacing the underlying UITextField and dismissing the keyboard, and it also adds an explicit validation call for the landscape keyboard “Done” button.
<!--

Some description of HOW you achieved it. Perhaps give a high level description of the chnages you did. Did you need to refactor something? What tradeoffs did you take?

-->

## Notes for Reviewers

- Trigger amount validation explicitly when dismissing the keyboard via the landscape Done button (UIKit resignFirstResponder path).
- Stop clearing field errors on focus-gain; introduce a new helper intended to clear errors on text changes and adjust amount-field edge-case behavior with a delayed clear.
- Add onChange(of: ...text) handlers in the view to conditionally clear errors based on focus state.
<!--

Explain how you verified the changes.
A clear testing scenario helps colleagues who may not be familiar with this part of the code quickly understand and verify the changes. Include steps they can follow to see the impact in action.

You can include: 
- Simulators/Devices you used (e.g. iPhone 13, iPad Pro) 
- iOS versions tested (e.g. 16.0, 17.5) 
- Manual checks (e.g. flow tested: onboarding, permissions, error states) 
- Unit tests added or updated 
 
 Include screenshots, screen recordings, or simulator gifs for UI changes. 
 
 - Optional: Anything that needs extra attention in review? Are there TODOs, known limitations, or follow-up work? 
 
 -->

[HEAL-377]: https://ginis.atlassian.net/browse/HEAL-377?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[HEAL-390]: https://ginis.atlassian.net/browse/HEAL-390?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ