### PR TITLE
fix(GiniInternalPaymentSDK): Enable Dynamic Type scaling in InstallAp…

### DIFF
--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/InstallApp/InstallAppBottomView.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/InstallApp/InstallAppBottomView.swift
@@ -37,6 +37,7 @@ public final class InstallAppBottomView: GiniBottomSheetViewController {
         label.text = viewModel.titleText
         label.textColor = viewModel.configuration.titleAccentColor
         label.font = viewModel.configuration.titleFont
+        label.adjustsFontForContentSizeCategory = true
         label.numberOfLines = 0
         label.lineBreakMode = .byTruncatingTail
         return label
@@ -68,6 +69,7 @@ public final class InstallAppBottomView: GiniBottomSheetViewController {
         label.translatesAutoresizingMaskIntoConstraints = false
         label.textColor = viewModel.configuration.moreInformationTextColor
         label.font = viewModel.configuration.moreInformationFont
+        label.adjustsFontForContentSizeCategory = true
         label.numberOfLines = 0
         label.text = viewModel.moreInformationLabelText
         return label


### PR DESCRIPTION
## Pull Request Description

[HEAL-407]

Enable Dynamic Type font scaling in `InstallAppBottomView`.

`titleLabel` and `moreInformationLabel` were missing `adjustsFontForContentSizeCategory = true`, so their fonts stayed at the size captured at view creation and never responded to Dynamic Type changes.

The fix adds that flag to both labels. It works because `FontProvider.createFont` builds fonts with `UIFontMetrics.scaledFont(for:)`, which embeds the scaling metadata UIKit needs to rescale automatically. The existing `EmptyScrollView` Combine publisher already propagates content size changes to the sheet height, so no additional layout work is needed.

## Notes for Reviewers

**What to verify:**
1. Open the Install App bottom sheet (bank not installed)
2. Change Dynamic Type size in Settings → Accessibility → Display & Text Size → Larger Text
3. Return to the app — `titleLabel` and `moreInformationLabel` should reflect the new size
4. Decrease the size — labels should scale back down
5. Sheet height should adjust to fit the updated content

**Files changed:** `InstallAppBottomView.swift` (+2 lines)

[HEAL-407]: https://ginis.atlassian.net/browse/HEAL-407?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ