### PR TITLE
fix(GiniInternalPaymentSDK): improve landscape UX in bottom-sheet Payment Review

### DIFF
--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/BottomSheet/GiniBottomSheetModifier.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/BottomSheet/GiniBottomSheetModifier.swift
@@ -35,10 +35,10 @@ struct GiniBottomSheetModifier: ViewModifier {
         
         if #available(iOS 16.4, *) {
             let presentationBackgroundInteractionForVoiceOver = isVoiceOverEnabled ? .disabled : PresentationBackgroundInteraction.enabled(upThrough: .height(contentHeight))
-            
+
             base
                 .presentationBackgroundInteraction(allowsDismiss ? .automatic : presentationBackgroundInteractionForVoiceOver)
-                .presentationCompactAdaptation(horizontal: .sheet, vertical: .fullScreenCover)
+                .presentationCompactAdaptation(horizontal: .sheet, vertical: .sheet)
                 .presentationContentInteraction(.scrolls)
         } else {
             base

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/BottomSheet/GiniBottomSheetModifier.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/BottomSheet/GiniBottomSheetModifier.swift
@@ -38,7 +38,7 @@ struct GiniBottomSheetModifier: ViewModifier {
 
             base
                 .presentationBackgroundInteraction(allowsDismiss ? .automatic : presentationBackgroundInteractionForVoiceOver)
-                .presentationCompactAdaptation(horizontal: .sheet, vertical: .sheet)
+                .presentationCompactAdaptation(horizontal: .sheet, vertical: .fullScreenCover)
                 .presentationContentInteraction(.scrolls)
         } else {
             base

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/Views/PaymentReviewContentView.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/Views/PaymentReviewContentView.swift
@@ -66,15 +66,7 @@ public struct PaymentReviewContentView: View {
         .toolbar {
             ToolbarItemGroup(placement: .keyboard) {
                 if giniLayout.isLandscape && !viewModel.isBottomSheetMode && viewModel.isAmountFieldFocused {
-                    Spacer()
-                    Button(viewModel.keyboardDoneButtonTitle) {
-                        viewModel.trackKeyboardDismissed()
-                        UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder),
-                                                        to: nil,
-                                                        from: nil,
-                                                        for: nil)
-                    }
-                    .padding(.trailing, Constants.doneButtonHorizontalPadding)
+                    keyboardDoneButton
                 }
             }
         }
@@ -129,15 +121,7 @@ public struct PaymentReviewContentView: View {
             .toolbar {
                 ToolbarItemGroup(placement: .keyboard) {
                     if giniLayout.isLandscape && viewModel.isAmountFieldFocused {
-                        Spacer()
-                        Button(viewModel.keyboardDoneButtonTitle) {
-                            viewModel.trackKeyboardDismissed()
-                            UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder),
-                                                            to: nil,
-                                                            from: nil,
-                                                            for: nil)
-                        }
-                        .padding(.trailing, Constants.doneButtonHorizontalPadding)
+                        keyboardDoneButton
                     }
                 }
             }
@@ -192,6 +176,19 @@ public struct PaymentReviewContentView: View {
         }
         .accessibilityLabel(viewModel.model.strings.closeButtonAccessibilityLabel)
         .padding(Constants.closeButtonEdgePadding)
+    }
+
+    @ViewBuilder
+    private var keyboardDoneButton: some View {
+        Spacer()
+        Button(viewModel.keyboardDoneButtonTitle) {
+            viewModel.trackKeyboardDismissed()
+            UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder),
+                                            to: nil,
+                                            from: nil,
+                                            for: nil)
+        }
+        .padding(.trailing, Constants.doneButtonHorizontalPadding)
     }
 
     @ViewBuilder

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/Views/PaymentReviewContentView.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/Views/PaymentReviewContentView.swift
@@ -126,6 +126,21 @@ public struct PaymentReviewContentView: View {
                     contentHeight: $bottomSheetHeight
                 )
             }
+            .toolbar {
+                ToolbarItemGroup(placement: .keyboard) {
+                    if giniLayout.isLandscape && viewModel.isAmountFieldFocused {
+                        Spacer()
+                        Button(viewModel.keyboardDoneButtonTitle) {
+                            viewModel.trackKeyboardDismissed()
+                            UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder),
+                                                            to: nil,
+                                                            from: nil,
+                                                            for: nil)
+                        }
+                        .padding(.trailing, Constants.doneButtonHorizontalPadding)
+                    }
+                }
+            }
             .modifier(GiniBottomSheetModifier(
                 contentHeight: bottomSheetHeight,
                 allowsDismiss: viewModel.isBottomSheetMode,

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/Views/PaymentReviewContentView.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/Views/PaymentReviewContentView.swift
@@ -79,7 +79,7 @@ public struct PaymentReviewContentView: View {
             }
         }
     }
-    
+
     // MARK: - Portrait Layout
     
     @ViewBuilder
@@ -114,9 +114,18 @@ public struct PaymentReviewContentView: View {
                 viewModel.didTapClose()
             }
         } content: {
-            viewModel.paymentReviewPaymentInformationView(
-                contentHeight: $bottomSheetHeight
-            )
+            VStack(spacing: Constants.zero) {
+                if giniLayout.isLandscape && viewModel.isBottomSheetMode
+                    && viewModel.cellViewModels.isEmpty && !viewModel.isImagesLoading {
+                    HStack {
+                        Spacer()
+                        closeButton
+                    }
+                }
+                viewModel.paymentReviewPaymentInformationView(
+                    contentHeight: $bottomSheetHeight
+                )
+            }
             .modifier(GiniBottomSheetModifier(
                 contentHeight: bottomSheetHeight,
                 allowsDismiss: viewModel.isBottomSheetMode,
@@ -154,7 +163,22 @@ public struct PaymentReviewContentView: View {
     }
     
     // MARK: - Private Views
-    
+
+    @ViewBuilder
+    private var closeButton: some View {
+        Button {
+            viewModel.didTapClose()
+        } label: {
+            Image(uiImage: viewModel.model.configuration.paymentReviewClose)
+                .renderingMode(.original)
+                .padding(Constants.closeButtonPadding)
+                .background(Color(UIColor.systemBackground).opacity(Constants.closeButtonBackgroundOpacity))
+                .clipShape(.circle)
+        }
+        .accessibilityLabel(viewModel.model.strings.closeButtonAccessibilityLabel)
+        .padding(Constants.closeButtonEdgePadding)
+    }
+
     @ViewBuilder
     private var loadingOverlay: some View {
         if viewModel.isLoading {
@@ -224,5 +248,8 @@ public struct PaymentReviewContentView: View {
         static let paymentInformationContainerTopCornerRadius: CGFloat = 12.0
         static let paymentInformationContainerBottomCornerRadius: CGFloat = 6.0
         static let doneButtonHorizontalPadding: CGFloat = 16.0
+        static let closeButtonPadding: CGFloat = 8.0
+        static let closeButtonEdgePadding: CGFloat = 12.0
+        static let closeButtonBackgroundOpacity: CGFloat = 0.9
     }
 }


### PR DESCRIPTION
### Pull Request Description

[HEAL-401](https://ginis.atlassian.net/browse/HEAL-401)

In bottom-sheet mode, the Payment Review sheet is presented inside a SwiftUI `.sheet()` over the host screen (e.g. Order List). When the device is in landscape, iOS converts the SwiftUI sheet to a full-screen cover via `presentationCompactAdaptation(vertical: .fullScreenCover)`, which has two consequences:

1. The drag indicator (grabber) disappears — full-screen covers do not support `presentationDragIndicator`.
2. If the amount field receives focus, the keyboard appears with no way to dismiss it.

**What changed:**

- **`GiniBottomSheetModifier`** – reverts `presentationCompactAdaptation` to `vertical: .fullScreenCover` (original behaviour for document-collection mode); the grabber issue for bottom-sheet mode is instead addressed by a close button.
- **`PaymentReviewContentView`** – when in landscape + bottom-sheet mode and no document images are present, a circular close button (using the existing `paymentReviewClose` icon) is shown in the top-trailing corner of the sheet, giving the user a clear dismiss affordance.
- **`PaymentReviewContentView`** – extends the keyboard Done button (already present for document-collection landscape) to also appear above the keyboard when the amount field is focused in landscape bottom-sheet mode. The toolbar is placed on the sheet content `VStack` so it is in the correct presentation context.

### Notes for Reviewers

**How to verify:**

1. Open the app and navigate to the Order List (bottom-sheet mode).
2. Tap a payment item to open the Payment Review sheet.
3. Rotate the device to landscape.
4. **Close button:** if no document is attached, a circular X button should appear in the top-trailing corner. Tap it to confirm it dismisses the sheet.
5. **Keyboard Done button:** tap the Amount field. The number keyboard should appear with a Done button in the toolbar above it. Tap Done to confirm the keyboard dismisses.
6. Rotate back to portrait and confirm normal behaviour is unchanged.

**Modules affected:** `GiniInternalPaymentSDK`

**Manual validation:** iPhone simulator (iPhone 17, iOS 18.5), portrait and landscape orientations, bottom-sheet mode.

**Known limitations:** the grabber is still not visible in landscape because `presentationCompactAdaptation(vertical: .fullScreenCover)` is preserved for consistency. The close button serves as the dismiss affordance in that case.

[HEAL-401]: https://ginis.atlassian.net/browse/HEAL-401?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ