### PR TITLE
Heal 389 when switching between portrait and landscape payment review payment information view is first displayed full screen

### DIFF
--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/PaymentReviewObservableModel.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/PaymentReviewObservableModel.swift
@@ -28,6 +28,13 @@ final class PaymentReviewObservableModel: ObservableObject {
         model.displayMode == .bottomSheet
     }
 
+    /**
+     Set to `true` by `PaymentReviewViewController.viewWillTransition` before imperatively
+     dismissing the sheet, so the sheet's `onDismiss` handler knows not to call `didTapClose`.
+     Reset to `false` inside that same `onDismiss` handler via `defer`.
+     */
+    @Published var isDismissingForRotation: Bool = false
+
     var invoiceImageAccessibilityLabel: String {
         model.strings.invoiceImageAccessibilityLabel
     }

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/PaymentReviewViewController.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/PaymentReviewViewController.swift
@@ -68,6 +68,24 @@ public class PaymentReviewViewController: UIHostingController<PaymentReviewConte
         model.closePaymentReview()
     }
     
+    public override func viewWillTransition(to size: CGSize,
+                                            with coordinator: UIViewControllerTransitionCoordinator) {
+        super.viewWillTransition(to: size, with: coordinator)
+
+        guard model.displayMode == .documentCollection else { return }
+
+        // `size` is the *incoming* size, not the current one — it must be used here rather than
+        // UIDevice.isPortrait() reflects the old orientation at this point in the transition.
+        let isLandscape = size.width > size.height
+        guard isLandscape, let presentedVC = presentedViewController else { return }
+
+        // iOS captures a snapshot of the current screen before the rotation animation
+        // begins — SwiftUI's onChange fires too late to affect it. Hiding the sheet view
+        // here, before the snapshot is taken, prevents it from appearing during rotation.
+        // SwiftUI's onChange(of: giniLayout.isLandscape) still owns the actual dismissal.
+        presentedVC.view.isHidden = true
+    }
+
     public override func viewDidDisappear(_ animated: Bool) {
         super.viewDidDisappear(animated)
         overlayPresenter.dismiss(animated: false)

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/PaymentReviewViewController.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/PaymentReviewViewController.swift
@@ -80,10 +80,12 @@ public class PaymentReviewViewController: UIHostingController<PaymentReviewConte
         guard isLandscape, let presentedVC = presentedViewController else { return }
 
         // iOS captures a snapshot of the current screen before the rotation animation
-        // begins — SwiftUI's onChange fires too late to affect it. Hiding the sheet view
-        // here, before the snapshot is taken, prevents it from appearing during rotation.
-        // SwiftUI's onChange(of: giniLayout.isLandscape) still owns the actual dismissal.
-        presentedVC.view.isHidden = true
+        // begins — SwiftUI's onChange fires too late to affect it. Hiding the entire
+        // presentation container (not just the sheet's content view) ensures both the
+        // sheet content and UIKit's dimming/backdrop overlay are invisible in the
+        // snapshot. SwiftUI's onChange(of: giniLayout.isLandscape) still owns the
+        // actual dismissal.
+        presentedVC.presentationController?.containerView?.isHidden = true
     }
 
     public override func viewDidDisappear(_ animated: Bool) {

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/PaymentReviewViewController.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/PaymentReviewViewController.swift
@@ -75,7 +75,7 @@ public class PaymentReviewViewController: UIHostingController<PaymentReviewConte
         guard model.displayMode == .documentCollection else { return }
 
         // `size` is the *incoming* size, not the current one — it must be used here rather than
-        // UIDevice.isPortrait() reflects the old orientation at this point in the transition.
+        // relying on `UIDevice.isPortrait()`, which reflects the old orientation at this point in the transition.
         let isLandscape = size.width > size.height
         guard isLandscape, let presentedVC = presentedViewController else { return }
 

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/PaymentReviewViewController.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/PaymentReviewViewController.swift
@@ -20,19 +20,22 @@ public enum DisplayMode: Int {
 }
 
 public class PaymentReviewViewController: UIHostingController<PaymentReviewContentView> {
-    
+
     private let selectedPaymentProvider: PaymentProvider
     private var isInfoBarHidden = true
     private let overlayPresenter = GiniOverlayWindowPresenter()
-    
+    // Stored so viewWillTransition can set isDismissingForRotation before dismissing the sheet.
+    private let observableModel: PaymentReviewObservableModel
+
     public let model: PaymentReviewModel
-    
+
     public init(viewModel: PaymentReviewModel, selectedPaymentProvider: PaymentProvider) {
         self.model = viewModel
         self.selectedPaymentProvider = selectedPaymentProvider
         self.isInfoBarHidden = viewModel.configuration.isInfoBarHidden
-        
+
         let observableModel = PaymentReviewObservableModel(model: model)
+        self.observableModel = observableModel
         super.init(rootView: PaymentReviewContentView(viewModel: observableModel))
     }
     
@@ -79,13 +82,20 @@ public class PaymentReviewViewController: UIHostingController<PaymentReviewConte
         let isLandscape = size.width > size.height
         guard isLandscape, let presentedVC = presentedViewController else { return }
 
-        // iOS captures a snapshot of the current screen before the rotation animation
-        // begins — SwiftUI's onChange fires too late to affect it. Hiding the entire
-        // presentation container (not just the sheet's content view) ensures both the
-        // sheet content and UIKit's dimming/backdrop overlay are invisible in the
-        // snapshot. SwiftUI's onChange(of: giniLayout.isLandscape) still owns the
-        // actual dismissal.
-        presentedVC.presentationController?.containerView?.isHidden = true
+        // On iOS 16 the `.presentationCompactAdaptation(.fullScreenCover)` animation fires
+        // the moment the size class changes — before SwiftUI's onChange and before a
+        // snapshot-hiding approach can take effect. The only reliable fix is to dismiss
+        // the sheet imperatively at the UIKit level here, before that animation starts.
+        //
+        // Setting isDismissingForRotation first ensures the sheet's onDismiss handler
+        // does not call didTapClose (which would close the entire payment review).
+        // SwiftUI reconciles showBottomSheet = false via the sheet's isPresented binding
+        // when the UIKit dismiss fires the onDismiss callback.
+        //
+        // On iOS 17+ SwiftUI's onChange(of: giniLayout.isLandscape) also runs, but
+        // showBottomSheet is already false by then so it becomes a no-op.
+        observableModel.isDismissingForRotation = true
+        presentedVC.dismiss(animated: false)
     }
 
     public override func viewDidDisappear(_ animated: Bool) {

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/Views/PaymentReviewContentView.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/Views/PaymentReviewContentView.swift
@@ -98,12 +98,19 @@ public struct PaymentReviewContentView: View {
             // On iOS 16/17, rotating to landscape destroys portraitLayout which
             // dismisses the sheet and sets showBottomSheet to false. Restore it
             // when portraitLayout reappears in documentCollection mode.
-            // Delay so the layout crossfade finishes before the sheet slides in.
+            // Delay so the layout crossfade finishes before the sheet appears.
+            // disablesAnimations suppresses the sheet's default slide-up animation
+            // so it appears instantly at its resting position, matching the
+            // no-animation dismiss applied when rotating to landscape.
             if !viewModel.isBottomSheetMode && !showBottomSheet {
                 DispatchQueue.main.asyncAfter(deadline: .now() + Constants.layoutTransitionDuration) {
                     // Re-check conditions in case the mode changed during the delay.
                     if !viewModel.isBottomSheetMode && !showBottomSheet {
-                        showBottomSheet = true
+                        var transaction = Transaction()
+                        transaction.disablesAnimations = true
+                        withTransaction(transaction) {
+                            showBottomSheet = true
+                        }
                     }
                 }
             }

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/Views/PaymentReviewContentView.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/Views/PaymentReviewContentView.swift
@@ -12,7 +12,6 @@ public struct PaymentReviewContentView: View {
     @State private var hasAppeared = false
     @State private var showBottomSheet = true
     @State private var bottomSheetHeight = Constants.bottomSheetDefaultHeight
-    @State private var isDismissingForRotation = false
     
     @Environment(\.accessibilityVoiceOverEnabled) private var isVoiceOverEnabled
     @Environment(\.giniLayout) private var giniLayout
@@ -38,11 +37,10 @@ public struct PaymentReviewContentView: View {
         .ignoresSafeArea(.keyboard)
         .animation(.easeInOut(duration: Constants.layoutTransitionDuration), value: giniLayout.isLandscape)
         .onChange(of: giniLayout.isLandscape) { landscape in
-            // When rotating to landscape in documentCollection mode, dismiss the
-            // sheet immediately (without animation) so the crossfade transition
-            // isn't disrupted by the sheet's own dismissal animation.
+            // Belt-and-suspenders for iOS 17+: the sheet is already dismissed imperatively
+            // from viewWillTransition on iOS 16, but on iOS 17 we keep this path as well.
             if landscape && !viewModel.isBottomSheetMode && showBottomSheet {
-                isDismissingForRotation = true
+                viewModel.isDismissingForRotation = true
                 showBottomSheet = false
             }
         }
@@ -116,8 +114,8 @@ public struct PaymentReviewContentView: View {
             }
         }
         .sheet(isPresented: $showBottomSheet) {
-            defer { isDismissingForRotation = false }
-            if !isDismissingForRotation && (viewModel.isBottomSheetMode || isVoiceOverEnabled) {
+            defer { viewModel.isDismissingForRotation = false }
+            if !viewModel.isDismissingForRotation && (viewModel.isBottomSheetMode || isVoiceOverEnabled) {
                 viewModel.didTapClose()
             }
         } content: {


### PR DESCRIPTION
## Pull Request Description

<!-- Briefly explain **what** this PR does and **why**. Mention the motivation, feature, or issue it's addressing. -->

[HEAL-389](https://ginis.atlassian.net/browse/HEAL-389) <!-- Closes ticket number PP-####; Replace with JIRA ticket if relevant -->

Smoothing the Payment Review “payment information” sheet behavior during orientation changes in **documentCollection** display mode, preventing the sheet from briefly appearing full-screen during rotation.

**Changes:**
- Present the bottom sheet without animation when restoring it after rotating back to portrait (SwiftUI `Transaction.disablesAnimations`).
- Hide the currently presented sheet’s view *before* the rotation snapshot is taken (UIKit `viewWillTransition`) to avoid it showing during the rotation animation.


[HEAL-389]: https://ginis.atlassian.net/browse/HEAL-389?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ