### PR TITLE
fix(GiniInternalPaymentSDK): Update fonts for larger accessibility

### DIFF
--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/BanksView/BanksBottomView.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/BanksView/BanksBottomView.swift
@@ -266,6 +266,8 @@ public final class BanksBottomView: GiniBottomSheetViewController {
     private func updateLayoutForCurrentOrientation(screenSize: CGSize) {
         let isPortrait = UIDevice.isPortrait()
         let isAccessibilitySize = traitCollection.preferredContentSizeCategory.isAccessibilityCategory
+        /// In landscape with an accessibility font size 200%, the description label is hidden
+        /// to prevent it consuming the limited vertical space above the bank list.
         descriptionView.isHidden = !isPortrait && isAccessibilitySize
         if isPortrait {
             setupPortraitConstraints()

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/BanksView/BanksBottomView.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/BanksView/BanksBottomView.swift
@@ -266,8 +266,8 @@ public final class BanksBottomView: GiniBottomSheetViewController {
     private func updateLayoutForCurrentOrientation(screenSize: CGSize) {
         let isPortrait = UIDevice.isPortrait()
         let isAccessibilitySize = traitCollection.preferredContentSizeCategory.isAccessibilityCategory
-        /// In landscape with an accessibility font size 200%, the description label is hidden
-        /// to prevent it consuming the limited vertical space above the bank list.
+        // In landscape with an accessibility font size 200%, the description label is hidden
+        // to prevent it consuming the limited vertical space above the bank list.
         descriptionView.isHidden = !isPortrait && isAccessibilitySize
         if isPortrait {
             setupPortraitConstraints()

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/BanksView/BanksBottomView.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/BanksView/BanksBottomView.swift
@@ -25,7 +25,7 @@ public final class BanksBottomView: GiniBottomSheetViewController {
         label.translatesAutoresizingMaskIntoConstraints = false
         label.text = viewModel.strings.selectBankTitleText
         label.textColor = viewModel.configuration.selectBankAccentColor
-        label.font = viewModel.configuration.selectBankFont
+        label.font = viewModel.configuration.selectBankFont.limitingFontSize(to: Constants.titleMaxFontSize)
         label.adjustsFontForContentSizeCategory = true
         label.numberOfLines = 0
         return label
@@ -38,8 +38,9 @@ public final class BanksBottomView: GiniBottomSheetViewController {
         label.translatesAutoresizingMaskIntoConstraints = false
         label.text = viewModel.strings.descriptionText
         label.textColor = viewModel.configuration.descriptionAccentColor
-        label.font = viewModel.configuration.descriptionFont
+        label.font = viewModel.configuration.descriptionFont.limitingFontSize(to: Constants.descriptionMaxFontSize)
         label.adjustsFontForContentSizeCategory = true
+        label.setContentCompressionResistancePriority(.required, for: .vertical)
         label.numberOfLines = 0
         return label
     }()
@@ -165,6 +166,13 @@ public final class BanksBottomView: GiniBottomSheetViewController {
         contentStackView.addArrangedSubview(bottomView)
         contentView.addSubview(contentStackView)
         view.addSubview(contentView)
+
+        // Title, description, and bottom bar hug their content tightly.
+        // The bank list (paymentProvidersView) absorbs all remaining vertical space.
+        titleView.setContentHuggingPriority(.defaultHigh, for: .vertical)
+        descriptionView.setContentHuggingPriority(.defaultHigh, for: .vertical)
+        bottomView.setContentHuggingPriority(.defaultHigh, for: .vertical)
+        paymentProvidersView.setContentHuggingPriority(.defaultLow, for: .vertical)
     }
 
     private func setupViewAttributes() {
@@ -256,7 +264,10 @@ public final class BanksBottomView: GiniBottomSheetViewController {
     }
 
     private func updateLayoutForCurrentOrientation(screenSize: CGSize) {
-        if UIDevice.isPortrait() {
+        let isPortrait = UIDevice.isPortrait()
+        let isAccessibilitySize = traitCollection.preferredContentSizeCategory.isAccessibilityCategory
+        descriptionView.isHidden = !isPortrait && isAccessibilitySize
+        if isPortrait {
             setupPortraitConstraints()
         } else {
             setupLandscapeConstraints(screenWidth: screenSize.width)
@@ -288,6 +299,8 @@ extension BanksBottomView {
         static let bottomViewHeight = 44.0
         static let landscapePaddingRatio = 0.15
         static let bottomSheetHeight: (CGFloat) -> CGFloat = { screenHeight in screenHeight * 0.9 }
+        static let titleMaxFontSize = 22.0
+        static let descriptionMaxFontSize = 20.0
     }
 }
 

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/BanksView/BanksBottomView.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/BanksView/BanksBottomView.swift
@@ -25,6 +25,7 @@ public final class BanksBottomView: GiniBottomSheetViewController {
         label.translatesAutoresizingMaskIntoConstraints = false
         label.text = viewModel.strings.selectBankTitleText
         label.textColor = viewModel.configuration.selectBankAccentColor
+        // Font size is capped at accessibility sizes to prevent clipping. Remove when HEAL-414 migrates this screen to a fully scrollable layout.
         label.font = viewModel.configuration.selectBankFont.limitingFontSize(to: Constants.titleMaxFontSize)
         label.adjustsFontForContentSizeCategory = true
         label.numberOfLines = 0
@@ -38,6 +39,7 @@ public final class BanksBottomView: GiniBottomSheetViewController {
         label.translatesAutoresizingMaskIntoConstraints = false
         label.text = viewModel.strings.descriptionText
         label.textColor = viewModel.configuration.descriptionAccentColor
+        // Font size is capped at accessibility sizes to prevent clipping. Remove when HEAL-414 migrates this screen to a fully scrollable layout.
         label.font = viewModel.configuration.descriptionFont.limitingFontSize(to: Constants.descriptionMaxFontSize)
         label.adjustsFontForContentSizeCategory = true
         label.setContentCompressionResistancePriority(.required, for: .vertical)

--- a/GiniComponents/Utilities/GiniUtilites/Sources/GiniUtilites/Font/UIFont.swift
+++ b/GiniComponents/Utilities/GiniUtilites/Sources/GiniUtilites/Font/UIFont.swift
@@ -23,12 +23,19 @@ extension UIFont.TextStyle {
 }
 
 extension UIFont {
-    
+
+    /**
+     Returns a version of the font capped at `fontSizeLimit`, but only when the user has enabled
+     an accessibility text size (AX1–AX5 via Settings → Accessibility → Display & Text Size).
+     At regular text sizes the font is returned unchanged.
+     - Parameters:
+       - fontSizeLimit: The maximum point size to allow under accessibility text sizes.
+     - Returns: The capped font when an accessibility category is active; otherwise the original font.
+     */
     public func limitingFontSize(to fontSizeLimit: CGFloat) -> UIFont {
-        if self.pointSize > fontSizeLimit {
-            return self.withSize(fontSizeLimit)
-        } else {
+        guard UITraitCollection.current.preferredContentSizeCategory.isAccessibilityCategory else {
             return self
         }
+        return self.pointSize > fontSizeLimit ? self.withSize(fontSizeLimit) : self
     }
 }

--- a/GiniComponents/Utilities/GiniUtilites/Tests/GiniUtilitesTests/UIFontLimitingFontSizeTests.swift
+++ b/GiniComponents/Utilities/GiniUtilites/Tests/GiniUtilitesTests/UIFontLimitingFontSizeTests.swift
@@ -1,0 +1,55 @@
+//
+//  UIFontLimitingFontSizeTests.swift
+//  GiniUtilites
+//
+//  Copyright © 2024 Gini GmbH. All rights reserved.
+//
+
+import XCTest
+@testable import GiniUtilites
+
+final class UIFontLimitingFontSizeTests: XCTestCase {
+
+    private let baseFont = UIFont.systemFont(ofSize: 24)
+    private let limit: CGFloat = 20
+
+    // MARK: - Non-accessibility category
+
+    func testReturnsOriginalFontWhenNotAccessibilityCategory() {
+        UITraitCollection.current = UITraitCollection(preferredContentSizeCategory: .large)
+
+        let result = baseFont.limitingFontSize(to: limit)
+
+        XCTAssertEqual(result.pointSize, baseFont.pointSize)
+    }
+
+    // MARK: - Accessibility category, font within limit
+
+    func testReturnsOriginalFontWhenPointSizeWithinLimitAndAccessibility() {
+        UITraitCollection.current = UITraitCollection(preferredContentSizeCategory: .accessibilityExtraLarge)
+        let smallFont = UIFont.systemFont(ofSize: 16)
+
+        let result = smallFont.limitingFontSize(to: limit)
+
+        XCTAssertEqual(result.pointSize, smallFont.pointSize)
+    }
+
+    // MARK: - Accessibility category, font exceeds limit
+
+    func testCapsPointSizeWhenExceedsLimitAndAccessibility() {
+        UITraitCollection.current = UITraitCollection(preferredContentSizeCategory: .accessibilityExtraLarge)
+
+        let result = baseFont.limitingFontSize(to: limit)
+
+        XCTAssertEqual(result.pointSize, limit)
+    }
+
+    func testCapsPointSizeAtExactLimitWhenAccessibility() {
+        UITraitCollection.current = UITraitCollection(preferredContentSizeCategory: .accessibilityExtraLarge)
+        let exactFont = UIFont.systemFont(ofSize: limit)
+
+        let result = exactFont.limitingFontSize(to: limit)
+
+        XCTAssertEqual(result.pointSize, limit)
+    }
+}


### PR DESCRIPTION
## Pull Request Description

<!-- Briefly explain **what** this PR does and **why**. Mention the motivation, feature, or issue it's addressing. -->
This PR improves the BanksBottomView layout behavior for large Dynamic Type sizes (accessibility categories), particularly in landscape, to prevent layout crowding.
[HEAL-404](https://ginis.atlassian.net/browse/HEAL-404)<!-- Closes ticket number PP-####; Replace with JIRA ticket if relevant -->

<!--

Some description of HOW you achieved it. Perhaps give a high level description of the chnages you did. Did you need to refactor something? What tradeoffs did you take?

-->

## Notes for Reviewers

- Cap the title and description label fonts to a maximum point size.
- Adjust vertical content hugging priorities so the bank list area is the primary flexible vertical region.
- Hide the description section in landscape when the preferred content size category is an accessibility category.
<!--

Explain how you verified the changes.
A clear testing scenario helps colleagues who may not be familiar with this part of the code quickly understand and verify the changes. Include steps they can follow to see the impact in action.

You can include: 
- Simulators/Devices you used (e.g. iPhone 13, iPad Pro) 
- iOS versions tested (e.g. 16.0, 17.5) 
- Manual checks (e.g. flow tested: onboarding, permissions, error states) 
- Unit tests added or updated 
 
 Include screenshots, screen recordings, or simulator gifs for UI changes. 
 
 - Optional: Anything that needs extra attention in review? Are there TODOs, known limitations, or follow-up work? 
 
 -->

[HEAL-404]: https://ginis.atlassian.net/browse/HEAL-404?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ