### PR TITLE
fix(GiniInternalPaymentSDK): Update image aspect ration and removed f…

### DIFF
--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PoweredByGini/PoweredByGiniView.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PoweredByGini/PoweredByGiniView.swift
@@ -28,8 +28,8 @@ public final class PoweredByGiniView: UIView {
     
     private lazy var giniImageView: UIImageView = {
         let imageView = UIImageView(image: viewModel.configuration.giniIcon)
-        imageView.frame = CGRect(x: 0, y: 0, width: Constants.widthGiniLogo, height: Constants.heightGiniLogo)
         imageView.translatesAutoresizingMaskIntoConstraints = false
+        imageView.contentMode = .scaleAspectFit
         imageView.isAccessibilityElement = false
         return imageView
     }()


### PR DESCRIPTION



## Pull Request Description

<!-- Briefly explain **what** this PR does and **why**. Mention the motivation, feature, or issue it's addressing. -->

HEAL-413<!-- Closes ticket number PP-####; Replace with JIRA ticket if relevant -->

Updates the PoweredByGiniView logo rendering to rely on Auto Layout sizing and preserve the icon’s aspect ratio, aligning the implementation with the view’s constraint-based layout.
<!--

Some description of HOW you achieved it. Perhaps give a high level description of the chnages you did. Did you need to refactor something? What tradeoffs did you take?

-->

## Notes for Reviewers

- Removed manual frame assignment for the Gini logo UIImageView.
- Set the logo UIImageView to use .scaleAspectFit to prevent distortion under varying heights.
<!--

Explain how you verified the changes.
A clear testing scenario helps colleagues who may not be familiar with this part of the code quickly understand and verify the changes. Include steps they can follow to see the impact in action.

You can include: 
- Simulators/Devices you used (e.g. iPhone 13, iPad Pro) 
- iOS versions tested (e.g. 16.0, 17.5) 
- Manual checks (e.g. flow tested: onboarding, permissions, error states) 
- Unit tests added or updated 
 
 Include screenshots, screen recordings, or simulator gifs for UI changes. 
 
 - Optional: Anything that needs extra attention in review? Are there TODOs, known limitations, or follow-up work? 
 
 -->