### PR TITLE
Heal 410 issue payment component 200 gini logo

### DIFF
--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentComponents/PaymentComponentView.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentComponents/PaymentComponentView.swift
@@ -107,6 +107,7 @@ public final class PaymentComponentView: UIView {
         updateButtonsViews()
         setupGestures()
         setupAccessibility()
+        updateBottomStackOrientation()
     }
 
     private func setupAccessibility() {
@@ -205,6 +206,18 @@ public final class PaymentComponentView: UIView {
     @objc
     private func tapOnPayInvoiceView() {
         viewModel.tapOnPayInvoiceView()
+    }
+
+    override public func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+        if previousTraitCollection?.preferredContentSizeCategory != traitCollection.preferredContentSizeCategory {
+            updateBottomStackOrientation()
+        }
+    }
+
+    private func updateBottomStackOrientation() {
+        let isAccessibilitySize = traitCollection.preferredContentSizeCategory.isAccessibilityCategory
+        bottomStackView.axis = isAccessibilitySize ? .vertical : .horizontal
     }
 }
 

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentComponents/PaymentComponentView.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentComponents/PaymentComponentView.swift
@@ -218,7 +218,7 @@ public final class PaymentComponentView: UIView {
     private func updateBottomStackOrientation() {
         let isAccessibilitySize = traitCollection.preferredContentSizeCategory.isAccessibilityCategory
         bottomStackView.axis = isAccessibilitySize ? .vertical : .horizontal
-        bottomStackView.alignment = isAccessibilitySize ? .leading : .fill
+        poweredByGiniView.configureForVerticalLayout(isAccessibilitySize)
     }
 }
 

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentComponents/PaymentComponentView.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentComponents/PaymentComponentView.swift
@@ -216,6 +216,8 @@ public final class PaymentComponentView: UIView {
     }
 
     private func updateBottomStackOrientation() {
+        /// Axis change only applies when the branded logo is present with a single item the axis has no effect.
+        guard viewModel.shouldShowBrandedView else { return }
         let isAccessibilitySize = traitCollection.preferredContentSizeCategory.isAccessibilityCategory
         bottomStackView.axis = isAccessibilitySize ? .vertical : .horizontal
         poweredByGiniView.configureForVerticalLayout(isAccessibilitySize)

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentComponents/PaymentComponentView.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentComponents/PaymentComponentView.swift
@@ -218,6 +218,7 @@ public final class PaymentComponentView: UIView {
     private func updateBottomStackOrientation() {
         let isAccessibilitySize = traitCollection.preferredContentSizeCategory.isAccessibilityCategory
         bottomStackView.axis = isAccessibilitySize ? .vertical : .horizontal
+        bottomStackView.alignment = isAccessibilitySize ? .leading : .fill
     }
 }
 

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PoweredByGini/PoweredByGiniView.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PoweredByGini/PoweredByGiniView.swift
@@ -33,7 +33,12 @@ public final class PoweredByGiniView: UIView {
         imageView.isAccessibilityElement = false
         return imageView
     }()
-    
+
+    /// Constraints active in the default horizontal layout (label leading → image trailing).
+    private var horizontalLayoutConstraints: [NSLayoutConstraint] = []
+    /// Constraints active in the vertical/accessibility layout (image leading → label trailing).
+    private var verticalLayoutConstraints: [NSLayoutConstraint] = []
+
     public init(viewModel: PoweredByGiniViewModel) {
         self.viewModel = viewModel
         super.init(frame: .zero)
@@ -51,29 +56,56 @@ public final class PoweredByGiniView: UIView {
         mainContainer.addSubview(poweredByGiniLabel)
         mainContainer.addSubview(giniImageView)
         self.addSubview(mainContainer)
-        
+
         NSLayoutConstraint.activate([
             mainContainer.trailingAnchor.constraint(equalTo: trailingAnchor),
             mainContainer.leadingAnchor.constraint(equalTo: leadingAnchor),
             mainContainer.topAnchor.constraint(equalTo: topAnchor),
             mainContainer.bottomAnchor.constraint(equalTo: bottomAnchor),
-            mainContainer.trailingAnchor.constraint(equalTo: giniImageView.trailingAnchor),
-            giniImageView.leadingAnchor.constraint(equalTo: poweredByGiniLabel.trailingAnchor, constant: Constants.spacingImageText),
             giniImageView.centerYAnchor.constraint(equalTo: mainContainer.centerYAnchor),
             giniImageView.widthAnchor.constraint(equalToConstant: Constants.widthGiniLogo),
             giniImageView.heightAnchor.constraint(equalToConstant: Constants.heightGiniLogo),
-            poweredByGiniLabel.leadingAnchor.constraint(equalTo: mainContainer.leadingAnchor),
             // Label top+bottom pins drive mainContainer.height so the scroll view
             // content size is computed correctly at all accessibility font sizes.
             poweredByGiniLabel.topAnchor.constraint(equalTo: mainContainer.topAnchor, constant: Constants.imageTopBottomPadding),
             poweredByGiniLabel.bottomAnchor.constraint(equalTo: mainContainer.bottomAnchor, constant: -Constants.imageTopBottomPadding)
         ])
+
+        horizontalLayoutConstraints = [
+            poweredByGiniLabel.leadingAnchor.constraint(equalTo: mainContainer.leadingAnchor),
+            giniImageView.leadingAnchor.constraint(equalTo: poweredByGiniLabel.trailingAnchor, constant: Constants.spacingImageText),
+            giniImageView.trailingAnchor.constraint(equalTo: mainContainer.trailingAnchor)
+        ]
+
+        verticalLayoutConstraints = [
+            poweredByGiniLabel.leadingAnchor.constraint(equalTo: mainContainer.leadingAnchor),
+            giniImageView.leadingAnchor.constraint(equalTo: poweredByGiniLabel.trailingAnchor, constant: Constants.spacingImageText),
+            giniImageView.trailingAnchor.constraint(lessThanOrEqualTo: mainContainer.trailingAnchor)
+        ]
+
+        NSLayoutConstraint.activate(horizontalLayoutConstraints)
     }
     
     private func setupAccessibility() {
         mainContainer.isAccessibilityElement = true
         mainContainer.accessibilityLabel = viewModel.strings.poweredByGiniText + "Gini"
         mainContainer.accessibilityElements = [poweredByGiniLabel, giniImageView]
+    }
+
+    /**
+     Switches between horizontal (image trailing) and vertical (image leading) layouts.
+     Call with `true` when the view is stacked vertically so the logo and text start from the leading edge.
+     */
+    func configureForVerticalLayout(_ isVertical: Bool) {
+        if isVertical {
+            NSLayoutConstraint.deactivate(horizontalLayoutConstraints)
+            NSLayoutConstraint.activate(verticalLayoutConstraints)
+            poweredByGiniLabel.textAlignment = .natural
+        } else {
+            NSLayoutConstraint.deactivate(verticalLayoutConstraints)
+            NSLayoutConstraint.activate(horizontalLayoutConstraints)
+            poweredByGiniLabel.textAlignment = .right
+        }
     }
 }
 

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PoweredByGini/PoweredByGiniView.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PoweredByGini/PoweredByGiniView.swift
@@ -59,13 +59,14 @@ public final class PoweredByGiniView: UIView {
             mainContainer.bottomAnchor.constraint(equalTo: bottomAnchor),
             mainContainer.trailingAnchor.constraint(equalTo: giniImageView.trailingAnchor),
             giniImageView.leadingAnchor.constraint(equalTo: poweredByGiniLabel.trailingAnchor, constant: Constants.spacingImageText),
-            poweredByGiniLabel.centerYAnchor.constraint(equalTo: giniImageView.centerYAnchor),
+            giniImageView.centerYAnchor.constraint(equalTo: mainContainer.centerYAnchor),
+            giniImageView.widthAnchor.constraint(equalToConstant: Constants.widthGiniLogo),
+            giniImageView.heightAnchor.constraint(equalToConstant: Constants.heightGiniLogo),
             poweredByGiniLabel.leadingAnchor.constraint(equalTo: mainContainer.leadingAnchor),
-            // Top + bottom pins define mainContainer.height unambiguously so that the
-            // parent scroll view content size can be computed via Auto Layout bottom-up.
-            giniImageView.topAnchor.constraint(equalTo: mainContainer.topAnchor, constant: Constants.imageTopBottomPadding),
-            giniImageView.bottomAnchor.constraint(equalTo: mainContainer.bottomAnchor, constant: -Constants.imageTopBottomPadding),
-            giniImageView.widthAnchor.constraint(equalToConstant: Constants.widthGiniLogo)
+            // Label top+bottom pins drive mainContainer.height so the scroll view
+            // content size is computed correctly at all accessibility font sizes.
+            poweredByGiniLabel.topAnchor.constraint(equalTo: mainContainer.topAnchor, constant: Constants.imageTopBottomPadding),
+            poweredByGiniLabel.bottomAnchor.constraint(equalTo: mainContainer.bottomAnchor, constant: -Constants.imageTopBottomPadding)
         ])
     }
     

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PoweredByGini/PoweredByGiniView.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PoweredByGini/PoweredByGiniView.swift
@@ -93,8 +93,10 @@ public final class PoweredByGiniView: UIView {
     }
 
     /**
-     Switches between horizontal (image trailing) and vertical (image leading) layouts.
-     Call with `true` when the view is stacked vertically so the logo and text start from the leading edge.
+     Switches between a compact leading-aligned layout and the default full-width layout.
+     When `isVertical` is `true`, the label starts at the leading edge and the logo follows it
+     without stretching to the trailing edge. When `false`, the label fills the available width
+     and the logo is pinned to the trailing edge.
      */
     func configureForVerticalLayout(_ isVertical: Bool) {
         if isVertical {


### PR DESCRIPTION
## Pull Request Description

<!-- Briefly explain **what** this PR does and **why**. Mention the motivation, feature, or issue it's addressing. -->

[HEAL-410](https://ginis.atlassian.net/browse/HEAL-410)<!-- Closes ticket number PP-####; Replace with JIRA ticket if relevant -->

Updates InternalPaymentSDK UI layout to better handle large Dynamic Type / accessibility font sizes in the payment component’s bottom area (incl. the “Powered by Gini” branding).
<!--

Some description of HOW you achieved it. Perhaps give a high level description of the chnages you did. Did you need to refactor something? What tradeoffs did you take?

-->

## Notes for Reviewers
- Added switchable constraint sets in PoweredByGiniView and a helper to reconfigure alignment depending on layout mode.
- Made PaymentComponentView react to Dynamic Type changes by switching the bottom stack axis (horizontal ↔ vertical) and reconfiguring the branding view accordingly.

<!--

Explain how you verified the changes.
A clear testing scenario helps colleagues who may not be familiar with this part of the code quickly understand and verify the changes. Include steps they can follow to see the impact in action.

You can include: 
- Simulators/Devices you used (e.g. iPhone 13, iPad Pro) 
- iOS versions tested (e.g. 16.0, 17.5) 
- Manual checks (e.g. flow tested: onboarding, permissions, error states) 
- Unit tests added or updated 
 
 Include screenshots, screen recordings, or simulator gifs for UI changes. 
 
 - Optional: Anything that needs extra attention in review? Are there TODOs, known limitations, or follow-up work? 
 
 -->

[HEAL-410]: https://ginis.atlassian.net/browse/HEAL-410?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ