### PR TITLE
fix(GiniInternalPaymentSDK): Fix landscape layout issues in ShareInvoiceBottomView

### DIFF
--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Package.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Package.swift
@@ -29,6 +29,6 @@ let package = Package(
             dependencies: ["GiniHealthAPILibrary", "GiniUtilites"]),
         .testTarget(
             name: "GiniInternalPaymentSDKTests",
-            dependencies: ["GiniInternalPaymentSDK", "GiniHealthAPILibrary", "GiniUtilites"]),
+            dependencies: ["GiniInternalPaymentSDK"]),
     ]
 )

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Package.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Package.swift
@@ -29,6 +29,6 @@ let package = Package(
             dependencies: ["GiniHealthAPILibrary", "GiniUtilites"]),
         .testTarget(
             name: "GiniInternalPaymentSDKTests",
-            dependencies: ["GiniInternalPaymentSDK"]),
+            dependencies: ["GiniInternalPaymentSDK", "GiniHealthAPILibrary", "GiniUtilites"]),
     ]
 )

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentButton/PaymentPrimaryButton.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentButton/PaymentPrimaryButton.swift
@@ -93,7 +93,19 @@ public final class PaymentPrimaryButton: UIButton {
         titleTrailingConstraint?.isActive = false
         buttonTitleLabel.trailingAnchor.constraint(equalTo: rightImageView.leadingAnchor).isActive = true
     }
-        
+
+    public override func layoutSubviews() {
+        super.layoutSubviews()
+        // `preferredMaxLayoutWidth` defaults to 0, causing the label to compute its
+        // intrinsic height as a single line before Auto Layout resolves the frame.
+        // Updating it here lets the label wrap correctly and drives the button's height.
+        let width = buttonTitleLabel.frame.width
+        if width > 0, buttonTitleLabel.preferredMaxLayoutWidth != width {
+            buttonTitleLabel.preferredMaxLayoutWidth = width
+            invalidateIntrinsicContentSize()
+        }
+    }
+
     @objc private func tapOnPayInvoiceView() {
         didTapButton?()
     }

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/ShareInvoice/ShareInvoiceBottomView.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/ShareInvoice/ShareInvoiceBottomView.swift
@@ -259,7 +259,7 @@ public final class ShareInvoiceBottomView: GiniBottomSheetViewController {
     }
 
     private func updateLayoutForCurrentOrientation() {
-        if UIDevice.isPortrait() {
+        if traitCollection.preferredContentSizeCategory.isAccessibilityCategory || UIDevice.isPortrait() {
             setupPortraitConstraints()
         } else {
             setupLandscapeConstraints()
@@ -274,14 +274,15 @@ public final class ShareInvoiceBottomView: GiniBottomSheetViewController {
         // Update the split stack view and payment info stack view
         setupSplitStackViewHierarchy()
         splitStacKView.orientation(orientation).spacing(orientation == .vertical ? 0 : Constants.viewPaddingConstraint)
-        
+        splitStacKView.alignment = orientation == .horizontal ? .top : .fill
+
         paymentInfoStackView = generatePaymentInfoViews(orientation: orientation)
         updatePaymentInfoView()
-        
+
         let isPortrait = orientation == .vertical
-        
+
         let qrCodeSize = isPortrait ? Constants.qrCodeImageSizePortrait : Constants.qrCodeImageSizeLandscape
-        let contentPadding = isPortrait ? 0 : (Constants.landscapePaddingRatio * view.frame.width)
+        let contentPadding: CGFloat = 0
         
         let sharedConstraints = [
             contentStackView.leadingAnchor.constraint(equalTo: scrollView.leadingAnchor,
@@ -426,9 +427,8 @@ public final class ShareInvoiceBottomView: GiniBottomSheetViewController {
     }
     
     private func generateRecipientIbanStackView(orientation: NSLayoutConstraint.Axis) -> UIStackView {
-        let isAccessibility = traitCollection.preferredContentSizeCategory.isAccessibilityCategory
-        let resolvedOrientation: NSLayoutConstraint.Axis = isAccessibility ? .vertical : orientation
-        let recipientIBANStackView = createStackView(distribution: .fill, spacing: Constants.viewPaddingConstraint, orientation: resolvedOrientation)
+        // Always stack vertically: the IBAN is too long to share a row without breaking mid-number.
+        let recipientIBANStackView = createStackView(distribution: .fill, spacing: Constants.viewPaddingConstraint, orientation: .vertical)
         
         let recipientStackView = generateInfoStackView(title: viewModel.strings.recipientLabelText, subtitle: viewModel.paymentInfo?.recipient)
         let ibanStackView = generateInfoStackView(title: viewModel.strings.ibanLabelText, subtitle: viewModel.paymentInfo?.iban)

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/ShareInvoice/ShareInvoiceBottomView.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/ShareInvoice/ShareInvoiceBottomView.swift
@@ -291,15 +291,13 @@ public final class ShareInvoiceBottomView: GiniBottomSheetViewController {
         let isPortrait = orientation == .vertical
 
         let qrCodeSize = isPortrait ? Constants.qrCodeImageSizePortrait : Constants.qrCodeImageSizeLandscape
-        let contentPadding: CGFloat = 0
-        
         let sharedConstraints = [
             contentStackView.leadingAnchor.constraint(equalTo: scrollView.leadingAnchor,
-                                                      constant: contentPadding),
+                                                      constant: Constants.contentPadding),
             contentStackView.trailingAnchor.constraint(equalTo: scrollView.trailingAnchor,
-                                                       constant: -contentPadding),
+                                                       constant: -Constants.contentPadding),
             contentStackView.widthAnchor.constraint(equalTo: scrollView.widthAnchor,
-                                                    constant: -2 * contentPadding),
+                                                    constant: -2 * Constants.contentPadding),
             qrImageView.widthAnchor.constraint(equalToConstant: qrCodeSize),
             qrImageView.heightAnchor.constraint(equalToConstant: qrCodeSize),
             paymentInfoStackView.leadingAnchor.constraint(equalTo: paymentInfoView.leadingAnchor,
@@ -550,5 +548,6 @@ extension ShareInvoiceBottomView {
         static let paymentInfoCornerRadius = 16.0
         static let paymentInfoFieldsSpacing = 4.0
         static let landscapePaddingRatio = 0.15
+        static let contentPadding: CGFloat = 0
     }
 }

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/ShareInvoice/ShareInvoiceBottomView.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/ShareInvoice/ShareInvoiceBottomView.swift
@@ -253,13 +253,22 @@ public final class ShareInvoiceBottomView: GiniBottomSheetViewController {
         updateLayoutForCurrentOrientation()
     }
     
-    public func updateViews() {
-        updateLayoutForCurrentOrientation()
+    public func updateViews(for targetSize: CGSize? = nil) {
+        updateLayoutForCurrentOrientation(for: targetSize)
         view.layoutIfNeeded()
     }
 
-    private func updateLayoutForCurrentOrientation() {
-        if traitCollection.preferredContentSizeCategory.isAccessibilityCategory || UIDevice.isPortrait() {
+    private func updateLayoutForCurrentOrientation(for targetSize: CGSize? = nil) {
+        let usePortrait: Bool
+        if traitCollection.preferredContentSizeCategory.isAccessibilityCategory {
+            usePortrait = true
+        } else if let size = targetSize {
+            usePortrait = size.width <= size.height
+        } else {
+            usePortrait = UIDevice.isPortrait()
+        }
+
+        if usePortrait {
             setupPortraitConstraints()
         } else {
             setupLandscapeConstraints()
@@ -511,9 +520,11 @@ public final class ShareInvoiceBottomView: GiniBottomSheetViewController {
     public override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
         super.viewWillTransition(to: size, with: coordinator)
 
-        // Perform layout updates with animation
+        // Perform layout updates with animation, passing the known target size so
+        // that constraint selection uses the incoming dimensions rather than the
+        // device orientation, which can lag behind during the transition.
         coordinator.animate(alongsideTransition: { [weak self] context in
-            self?.updateViews()
+            self?.updateViews(for: size)
         }, completion: { [weak self] _ in
             self?.notifyLayoutChanged()
         })

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Tests/GiniInternalPaymentSDKTests/PaymentPrimaryButtonTests.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Tests/GiniInternalPaymentSDKTests/PaymentPrimaryButtonTests.swift
@@ -31,9 +31,9 @@ struct PaymentPrimaryButtonTests {
         var tapped = false
         sut.didTapButton = { tapped = true }
 
-        /// `sendActions(for:)` dispatches through `UIApplication` which is unreliable
-        /// in headless tests. Call the registered @objc action directly via the
-        /// Obj-C runtime to test the callback wiring without UIKit event machinery.
+        // `sendActions(for:)` dispatches through `UIApplication` which is unreliable
+        // in headless tests. Call the registered @objc action directly via the
+        // Obj-C runtime to test the callback wiring without UIKit event machinery.
         _ = sut.perform(NSSelectorFromString("tapOnPayInvoiceView"))
 
         #expect(tapped, "didTapButton closure must be called when touchUpInside is sent")

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Tests/GiniInternalPaymentSDKTests/PaymentPrimaryButtonTests.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Tests/GiniInternalPaymentSDKTests/PaymentPrimaryButtonTests.swift
@@ -1,0 +1,113 @@
+//
+//  PaymentPrimaryButtonTests.swift
+//  GiniInternalPaymentSDKTests
+//
+//  Copyright © 2026 Gini GmbH. All rights reserved.
+//
+
+import Testing
+import UIKit
+@testable import GiniInternalPaymentSDK
+
+@Suite("PaymentPrimaryButton")
+@MainActor
+struct PaymentPrimaryButtonTests {
+
+    // MARK: - Helpers
+
+    /** Recursively collects all `UILabel`s in the given view's subview tree. */
+    private func allLabels(in view: UIView) -> [UILabel] {
+        var result: [UILabel] = []
+        if let label = view as? UILabel { result.append(label) }
+        view.subviews.forEach { result += allLabels(in: $0) }
+        return result
+    }
+
+    // MARK: - Tap callback
+
+    @Test("didTapButton fires when touchUpInside is sent")
+    func didTapButtonFiresOnTouchUpInside() {
+        let sut = PaymentPrimaryButton()
+        var tapped = false
+        sut.didTapButton = { tapped = true }
+
+        sut.sendActions(for: .touchUpInside)
+
+        #expect(tapped, "didTapButton closure must be called when touchUpInside is sent")
+    }
+
+    @Test("didTapButton is nil by default and sendActions does not crash")
+    func defaultNilDidTapButtonDoesNotCrash() {
+        let sut = PaymentPrimaryButton()
+        #expect(sut.didTapButton == nil)
+        sut.sendActions(for: .touchUpInside) // must not crash
+    }
+
+    // MARK: - configure
+
+    @Test("configure does not crash with a test ButtonConfiguration")
+    func configureDoesNotCrash() {
+        let sut = PaymentPrimaryButton()
+        sut.configure(with: .test) // must not throw or crash
+    }
+
+    // MARK: - customConfigure
+
+    @Test("customConfigure sets the title label text")
+    func customConfigureSetsTitleText() {
+        let sut = PaymentPrimaryButton()
+        sut.customConfigure(text: "Pay with Sparkasse",
+                            textColor: .white,
+                            backgroundColor: .systemBlue)
+
+        let labels = allLabels(in: sut)
+        #expect(labels.contains { $0.text == "Pay with Sparkasse" },
+                "A UILabel with the configured text must exist in the button's subview tree")
+    }
+
+    @Test("customConfigure with right image data does not crash")
+    func customConfigureWithRightImageDataDoesNotCrash() {
+        let sut = PaymentPrimaryButton()
+        sut.customConfigure(text: "Continue",
+                            textColor: .black,
+                            backgroundColor: .white,
+                            rightImageData: Data())
+    }
+
+    @Test("customConfigure with left image data does not crash")
+    func customConfigureWithLeftImageDataDoesNotCrash() {
+        let sut = PaymentPrimaryButton()
+        sut.customConfigure(text: "Continue",
+                            textColor: .black,
+                            backgroundColor: .white,
+                            leftImageData: Data())
+    }
+
+    // MARK: - layoutSubviews / preferredMaxLayoutWidth
+
+    @Test("layoutSubviews sets positive preferredMaxLayoutWidth on title label after frame is resolved")
+    func layoutSubviewsSetsPreferredMaxLayoutWidth() {
+        let sut = PaymentPrimaryButton()
+        sut.configure(with: .test)
+        sut.customConfigure(text: "Pay with Sparkasse",
+                            textColor: .white,
+                            backgroundColor: .systemBlue)
+
+        // Add to a UIWindow with a concrete frame so Auto Layout resolves widths
+        let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 375, height: 60))
+        window.addSubview(sut)
+        sut.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            sut.leadingAnchor.constraint(equalTo: window.leadingAnchor, constant: 16),
+            sut.trailingAnchor.constraint(equalTo: window.trailingAnchor, constant: -16),
+            sut.topAnchor.constraint(equalTo: window.topAnchor),
+            sut.heightAnchor.constraint(equalToConstant: 56)
+        ])
+        window.layoutIfNeeded()
+
+        let titleLabel = allLabels(in: sut).first { $0.text == "Pay with Sparkasse" }
+        #expect(titleLabel != nil, "Title label must be present after customConfigure")
+        #expect((titleLabel?.preferredMaxLayoutWidth ?? 0) > 0,
+                "layoutSubviews must update preferredMaxLayoutWidth to a positive value once the label frame is resolved")
+    }
+}

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Tests/GiniInternalPaymentSDKTests/PaymentPrimaryButtonTests.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Tests/GiniInternalPaymentSDKTests/PaymentPrimaryButtonTests.swift
@@ -31,7 +31,10 @@ struct PaymentPrimaryButtonTests {
         var tapped = false
         sut.didTapButton = { tapped = true }
 
-        sut.sendActions(for: .touchUpInside)
+        /// `sendActions(for:)` dispatches through `UIApplication` which is unreliable
+        /// in headless tests. Call the registered @objc action directly via the
+        /// Obj-C runtime to test the callback wiring without UIKit event machinery.
+        _ = sut.perform(NSSelectorFromString("tapOnPayInvoiceView"))
 
         #expect(tapped, "didTapButton closure must be called when touchUpInside is sent")
     }

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Tests/GiniInternalPaymentSDKTests/ShareInvoiceBottomViewTests.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Tests/GiniInternalPaymentSDKTests/ShareInvoiceBottomViewTests.swift
@@ -7,6 +7,7 @@
 
 import Testing
 import UIKit
+import GiniHealthAPILibrary
 @testable import GiniInternalPaymentSDK
 
 @Suite("ShareInvoiceBottomView")

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Tests/GiniInternalPaymentSDKTests/ShareInvoiceBottomViewTests.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Tests/GiniInternalPaymentSDKTests/ShareInvoiceBottomViewTests.swift
@@ -1,0 +1,125 @@
+//
+//  ShareInvoiceBottomViewTests.swift
+//  GiniInternalPaymentSDKTests
+//
+//  Copyright © 2026 Gini GmbH. All rights reserved.
+//
+
+import Testing
+import UIKit
+@testable import GiniInternalPaymentSDK
+
+@Suite("ShareInvoiceBottomView")
+@MainActor
+struct ShareInvoiceBottomViewTests {
+
+    // MARK: - Helpers
+
+    private func makeSUT(provider: PaymentProvider? = .fixture(name: "Test Bank")) -> ShareInvoiceBottomView {
+        let viewModel = ShareInvoiceBottomViewModel(selectedPaymentProvider: provider,
+                                                    configuration: .test,
+                                                    strings: .test,
+                                                    primaryButtonConfiguration: .test,
+                                                    poweredByGiniConfiguration: .test,
+                                                    poweredByGiniStrings: .test,
+                                                    qrCodeData: Data(),
+                                                    paymentInfo: nil,
+                                                    paymentRequestId: "req-123",
+                                                    clientConfiguration: nil)
+        let sut = ShareInvoiceBottomView(viewModel: viewModel, bottomSheetConfiguration: .test)
+        _ = sut.view // force view load
+        return sut
+    }
+
+    /**
+     Recursively searches `root` for the split-stack view: the first `UIStackView`
+     whose two arranged subviews are themselves `UIStackView`s.
+     This uniquely identifies the private `splitStacKView` property.
+     */
+    private func findSplitStackView(in root: UIView) -> UIStackView? {
+        if let stack = root as? UIStackView,
+           stack.arrangedSubviews.count == 2,
+           stack.arrangedSubviews.allSatisfy({ $0 is UIStackView }) {
+            return stack
+        }
+        for sub in root.subviews {
+            if let found = findSplitStackView(in: sub) {
+                return found
+            }
+        }
+        return nil
+    }
+
+    // MARK: - Portrait layout via targetSize
+
+    @Test("portrait targetSize produces a vertical split-stack with fill alignment")
+    func portraitTargetSizeUsesVerticalLayout() {
+        let sut = makeSUT()
+
+        sut.updateViews(for: CGSize(width: 390, height: 844))
+
+        let split = findSplitStackView(in: sut.view)
+        #expect(split != nil, "Split stack view should be present in the view hierarchy")
+        #expect(split?.axis == .vertical,
+                "Portrait targetSize must produce a vertical split-stack axis")
+        #expect(split?.alignment == .fill,
+                "Portrait split-stack alignment must be .fill")
+    }
+
+    @Test("square targetSize (width == height) is treated as portrait")
+    func squareTargetSizeIsPortrait() {
+        let sut = makeSUT()
+
+        sut.updateViews(for: CGSize(width: 500, height: 500))
+
+        let split = findSplitStackView(in: sut.view)
+        #expect(split?.axis == .vertical,
+                "Equal-dimension targetSize (w == h) must use portrait (vertical) layout")
+    }
+
+    // MARK: - Landscape layout via targetSize
+
+    @Test("landscape targetSize produces a horizontal split-stack with top alignment")
+    func landscapeTargetSizeUsesHorizontalLayoutWithTopAlignment() {
+        let sut = makeSUT()
+
+        sut.updateViews(for: CGSize(width: 844, height: 390))
+
+        let split = findSplitStackView(in: sut.view)
+        #expect(split != nil, "Split stack view should be present in the view hierarchy")
+        #expect(split?.axis == .horizontal,
+                "Landscape targetSize must produce a horizontal split-stack axis")
+        #expect(split?.alignment == .top,
+                "Landscape split-stack alignment must be .top (regression fix: was .fill)")
+    }
+
+    // MARK: - nil targetSize
+
+    @Test("nil targetSize does not crash")
+    func nilTargetSizeDoesNotCrash() {
+        let sut = makeSUT()
+        // Must not crash; orientation falls back to UIDevice.isPortrait()
+        sut.updateViews(for: nil)
+    }
+
+    // MARK: - Switching orientations
+
+    @Test("layout switches correctly when updateViews is called multiple times")
+    func layoutSwitchesBetweenOrientations() {
+        let sut = makeSUT()
+
+        sut.updateViews(for: CGSize(width: 390, height: 844)) // portrait
+        let afterPortrait = findSplitStackView(in: sut.view)
+        #expect(afterPortrait?.axis == .vertical)
+
+        sut.updateViews(for: CGSize(width: 844, height: 390)) // landscape
+        let afterLandscape = findSplitStackView(in: sut.view)
+        #expect(afterLandscape?.axis == .horizontal)
+        #expect(afterLandscape?.alignment == .top)
+
+        sut.updateViews(for: CGSize(width: 390, height: 844)) // back to portrait
+        let afterPortraitAgain = findSplitStackView(in: sut.view)
+        #expect(afterPortraitAgain?.axis == .vertical)
+        #expect(afterPortraitAgain?.alignment == .fill)
+    }
+}


### PR DESCRIPTION
[HEAL-412](https://ginis.atlassian.net/browse/HEAL-412)

Fixes three landscape layout regressions introduced when the Powered by Gini logo was added to `ShareInvoiceBottomView`, and restores two previously reverted fixes in `PaymentPrimaryButton`.

### What changed and why

**`ShareInvoiceBottomView`**

- **`splitStackView.alignment = .top` in landscape** — the horizontal split stack used the default `.fill` alignment, which forces both columns to the same height. With the QR column now being 202pt tall (158pt QR + 44pt logo), the right column was clamped to 202pt. Since `paymentInfoView` has `clipsToBounds = true` (set by `roundCorners`), the top ~140pt of the payment info stack (Empfänger + IBAN) was clipped and invisible. Changing to `.top` lets each column size independently to its content.

- **`contentPadding = 0`** — the previous formula `0.15 × view.frame.width` read the full-screen landscape width (~776pt) rather than the sheet's actual width (~420pt), producing a 116pt padding on each side. This left only ~13pt for the right column, making the continue-button trailing constraint unsatisfiable. The sheet is never shown full-screen in landscape (`shouldShowInFullScreenInLandscapeMode = false`), so percentage-based padding is not needed.

- **Always-vertical IBAN stack** — the IBAN number is too long to share a row with the recipient name without breaking mid-number. It is now always stacked vertically.

- **Restored accessibility font size check** — `updateLayoutForCurrentOrientation` now uses portrait layout for large Dynamic Type sizes (`isAccessibilityCategory`), matching the intended behaviour before the revert.

**`PaymentPrimaryButton`**

- **Restored `layoutSubviews` override** — sets `preferredMaxLayoutWidth` on the custom `buttonTitleLabel` to the label's resolved width, allowing multi-line wrapping and driving the correct button height via the constraint chain. Without this, the label computed single-line intrinsic height before the frame was resolved.

### Notes for Reviewers

**Test scenarios:**
1. Open the Share Invoice sheet in landscape with a payment provider that shows the Powered by Gini logo — all four payment info fields (Empfänger, IBAN, Betrag, Verwendungszweck) must be visible inside the rounded box.
2. Rotate between portrait and landscape — no constraint warnings in the console, content stays within the sheet bounds.
3. Verify the continue button wraps to two lines in landscape when the bank name is long.
4. Enable a large Dynamic Type size — the sheet must use portrait layout regardless of device orientation.

**No unit tests added** — the fixes are purely layout/constraint changes with no business logic impact.

[HEAL-412]: https://ginis.atlassian.net/browse/HEAL-412?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ