### PR TITLE
Heal 416 select bank sheet size isssue

### DIFF
--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/BanksView/BanksBottomView.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/BanksView/BanksBottomView.swift
@@ -267,9 +267,7 @@ public final class BanksBottomView: GiniBottomSheetViewController {
     }
 
     private func updateLayoutForCurrentOrientation(screenSize: CGSize) {
-        // Use the incoming size to determine orientation instead of UIDevice.isPortrait(),
-        // which still reflects the old orientation during viewWillTransition.
-        let isPortrait = screenSize.height > screenSize.width
+        let isPortrait = UIDevice.isPortrait()
         let isAccessibilitySize = traitCollection.preferredContentSizeCategory.isAccessibilityCategory
         // In landscape with an accessibility font size 200%, the description label is hidden
         // to prevent it consuming the limited vertical space above the bank list.

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/BanksView/BanksBottomView.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/BanksView/BanksBottomView.swift
@@ -145,8 +145,9 @@ public final class BanksBottomView: GiniBottomSheetViewController {
     }
 
     private func setupView() {
-        configureBottomSheet()
-        updateBottomSheetHeight(Constants.bottomSheetHeight(view.bounds.height))
+        // Use .large() detent so the sheet fills the screen and automatically
+        // adapts to orientation changes without manual viewWillTransition updates.
+        configureBottomSheet(shouldIncludeLargeDetent: true)
         setupViewHierarchy()
         setupViewAttributes()
         setupLayout()
@@ -261,10 +262,6 @@ public final class BanksBottomView: GiniBottomSheetViewController {
             self.setupTableViewConstraints()
             self.setupPoweredByGiniConstraints()
             self.setupViewAttributes()
-            // Pass the full incoming height so UISheetPresentationController clamps it to its
-            // maximumDetentValue, matching the full-screen appearance of the initial portrait presentation.
-            // Using 90% of the height (Constants.bottomSheetHeight) leaves a visible gap after rotation.
-            self.updateBottomSheetHeight(size.height)
             self.view.layoutIfNeeded()
         }, completion: nil)
     }

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/BanksView/BanksBottomView.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/BanksView/BanksBottomView.swift
@@ -303,7 +303,6 @@ extension BanksBottomView {
         static let topAnchorPoweredByGiniConstraint = 5.0
         static let bottomViewHeight = 44.0
         static let landscapePaddingRatio = 0.15
-        static let bottomSheetHeight: (CGFloat) -> CGFloat = { screenHeight in screenHeight * 0.9 }
         static let titleMaxFontSize = 22.0
         static let descriptionMaxFontSize = 20.0
     }

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/BanksView/BanksBottomView.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/BanksView/BanksBottomView.swift
@@ -146,7 +146,6 @@ public final class BanksBottomView: GiniBottomSheetViewController {
 
     private func setupView() {
         // Use .large() detent so the sheet fills the screen and automatically
-        // adapts to orientation changes without manual viewWillTransition updates.
         configureBottomSheet(shouldIncludeLargeDetent: true)
         setupViewHierarchy()
         setupViewAttributes()

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/BanksView/BanksBottomView.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/BanksView/BanksBottomView.swift
@@ -261,12 +261,18 @@ public final class BanksBottomView: GiniBottomSheetViewController {
             self.setupTableViewConstraints()
             self.setupPoweredByGiniConstraints()
             self.setupViewAttributes()
+            // Pass the full incoming height so UISheetPresentationController clamps it to its
+            // maximumDetentValue, matching the full-screen appearance of the initial portrait presentation.
+            // Using 90% of the height (Constants.bottomSheetHeight) leaves a visible gap after rotation.
+            self.updateBottomSheetHeight(size.height)
             self.view.layoutIfNeeded()
         }, completion: nil)
     }
 
     private func updateLayoutForCurrentOrientation(screenSize: CGSize) {
-        let isPortrait = UIDevice.isPortrait()
+        // Use the incoming size to determine orientation instead of UIDevice.isPortrait(),
+        // which still reflects the old orientation during viewWillTransition.
+        let isPortrait = screenSize.height > screenSize.width
         let isAccessibilitySize = traitCollection.preferredContentSizeCategory.isAccessibilityCategory
         // In landscape with an accessibility font size 200%, the description label is hidden
         // to prevent it consuming the limited vertical space above the bank list.


### PR DESCRIPTION
## Pull Request Description

<!-- Briefly explain **what** this PR does and **why**. Mention the motivation, feature, or issue it's addressing. -->

[HEAL-416](https://ginis.atlassian.net/browse/HEAL-416)<!-- Closes ticket number PP-####; Replace with JIRA ticket if relevant -->
Adjusts the InternalPaymentSDK bank selection bottom sheet to better handle sizing/orientation, aiming to resolve the “select bank sheet size” issue referenced in the PR title.


<!--

Some description of HOW you achieved it. Perhaps give a high level description of the chnages you did. Did you need to refactor something? What tradeoffs did you take?

-->

## Notes for Reviewers

- Switches the bank selection sheet to use a .large() detent rather than a custom 90% height.

<!--

Explain how you verified the changes.
A clear testing scenario helps colleagues who may not be familiar with this part of the code quickly understand and verify the changes. Include steps they can follow to see the impact in action.

You can include: 
- Simulators/Devices you used (e.g. iPhone 13, iPad Pro) 
- iOS versions tested (e.g. 16.0, 17.5) 
- Manual checks (e.g. flow tested: onboarding, permissions, error states) 
- Unit tests added or updated 
 
 Include screenshots, screen recordings, or simulator gifs for UI changes. 
 
 - Optional: Anything that needs extra attention in review? Are there TODOs, known limitations, or follow-up work? 
 
 -->

[HEAL-416]: https://ginis.atlassian.net/browse/HEAL-416?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ