### PR TITLE
test(GiniInternalPaymentSDK): Add missing dependencies to the package…

### DIFF
--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Package.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Package.swift
@@ -29,6 +29,6 @@ let package = Package(
             dependencies: ["GiniHealthAPILibrary", "GiniUtilites"]),
         .testTarget(
             name: "GiniInternalPaymentSDKTests",
-            dependencies: ["GiniInternalPaymentSDK", "GiniHealthAPILibrary", "GiniUtilites"]),
+            dependencies: ["GiniInternalPaymentSDK"]),
     ]
 )

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Package.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Package.swift
@@ -29,6 +29,6 @@ let package = Package(
             dependencies: ["GiniHealthAPILibrary", "GiniUtilites"]),
         .testTarget(
             name: "GiniInternalPaymentSDKTests",
-            dependencies: ["GiniInternalPaymentSDK"]),
+            dependencies: ["GiniInternalPaymentSDK", "GiniHealthAPILibrary", "GiniUtilites"]),
     ]
 )

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Tests/GiniInternalPaymentSDKTests/PaymentPrimaryButtonTests.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Tests/GiniInternalPaymentSDKTests/PaymentPrimaryButtonTests.swift
@@ -31,9 +31,9 @@ struct PaymentPrimaryButtonTests {
         var tapped = false
         sut.didTapButton = { tapped = true }
 
-        /// `sendActions(for:)` dispatches through `UIApplication` which is unreliable
-        /// in headless tests. Call the registered @objc action directly via the
-        /// Obj-C runtime to test the callback wiring without UIKit event machinery.
+        // `sendActions(for:)` dispatches through `UIApplication` which is unreliable
+        // in headless tests. Call the registered @objc action directly via the
+        // Obj-C runtime to test the callback wiring without UIKit event machinery.
         _ = sut.perform(NSSelectorFromString("tapOnPayInvoiceView"))
 
         #expect(tapped, "didTapButton closure must be called when touchUpInside is sent")

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Tests/GiniInternalPaymentSDKTests/PaymentPrimaryButtonTests.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Tests/GiniInternalPaymentSDKTests/PaymentPrimaryButtonTests.swift
@@ -31,7 +31,10 @@ struct PaymentPrimaryButtonTests {
         var tapped = false
         sut.didTapButton = { tapped = true }
 
-        sut.sendActions(for: .touchUpInside)
+        /// `sendActions(for:)` dispatches through `UIApplication` which is unreliable
+        /// in headless tests. Call the registered @objc action directly via the
+        /// Obj-C runtime to test the callback wiring without UIKit event machinery.
+        _ = sut.perform(NSSelectorFromString("tapOnPayInvoiceView"))
 
         #expect(tapped, "didTapButton closure must be called when touchUpInside is sent")
     }

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Tests/GiniInternalPaymentSDKTests/ShareInvoiceBottomViewTests.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Tests/GiniInternalPaymentSDKTests/ShareInvoiceBottomViewTests.swift
@@ -7,6 +7,7 @@
 
 import Testing
 import UIKit
+import GiniHealthAPILibrary
 @testable import GiniInternalPaymentSDK
 
 @Suite("ShareInvoiceBottomView")


### PR DESCRIPTION

HEAL-412

## Pull Request Description

<!-- Briefly explain **what** this PR does and **why**. Mention the motivation, feature, or issue it's addressing. -->


This PR updates the Swift Package Manager manifest for GiniInternalPaymentSDK to declare missing direct dependencies for the test target, so tests can import those modules explicitly.


<!--

Some description of HOW you achieved it. Perhaps give a high level description of the chnages you did. Did you need to refactor something? What tradeoffs did you take?

-->

## Notes for Reviewers
- Add GiniHealthAPILibrary and GiniUtilites as explicit dependencies of GiniInternalPaymentSDKTests in Package.swift.

<!--

Explain how you verified the changes.
A clear testing scenario helps colleagues who may not be familiar with this part of the code quickly understand and verify the changes. Include steps they can follow to see the impact in action.

You can include: 
- Simulators/Devices you used (e.g. iPhone 13, iPad Pro) 
- iOS versions tested (e.g. 16.0, 17.5) 
- Manual checks (e.g. flow tested: onboarding, permissions, error states) 
- Unit tests added or updated 
 
 Include screenshots, screen recordings, or simulator gifs for UI changes. 
 
 - Optional: Anything that needs extra attention in review? Are there TODOs, known limitations, or follow-up work? 
 
 -->