### PR TITLE
fix(GiniInternalPaymentSDK): voice over fixed in powered by

### DIFF
--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentComponents/PaymentComponentView.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentComponents/PaymentComponentView.swift
@@ -116,7 +116,7 @@ public final class PaymentComponentView: UIView {
             selectBankButton,
             payInvoiceButton,
             moreInformationView
-        ]
+        ] + (viewModel.shouldShowBrandedView ? [poweredByGiniView] : [])
     }
     
     private func activateAllConstraints() {


### PR DESCRIPTION
## Pull Request Description

<!-- Briefly explain **what** this PR does and **why**. Mention the motivation, feature, or issue it's addressing. -->

[HEAL-421]<!-- Closes ticket number PP-####; Replace with JIRA ticket if relevant -->

This PR fixes VoiceOver navigation in GiniInternalPaymentSDK by ensuring the “Powered by Gini” branded view is reachable when PaymentComponentView explicitly controls the accessibility traversal order.


<!--

Some description of HOW you achieved it. Perhaps give a high level description of the chnages you did. Did you need to refactor something? What tradeoffs did you take?

-->

## Notes for Reviewers

- Add poweredByGiniView to PaymentComponentView.accessibilityElements when viewModel.shouldShowBrandedView is true.
<!--

Explain how you verified the changes.
A clear testing scenario helps colleagues who may not be familiar with this part of the code quickly understand and verify the changes. Include steps they can follow to see the impact in action.

You can include: 
- Simulators/Devices you used (e.g. iPhone 13, iPad Pro) 
- iOS versions tested (e.g. 16.0, 17.5) 
- Manual checks (e.g. flow tested: onboarding, permissions, error states) 
- Unit tests added or updated 
 
 Include screenshots, screen recordings, or simulator gifs for UI changes. 
 
 - Optional: Anything that needs extra attention in review? Are there TODOs, known limitations, or follow-up work? 
 
 -->

[HEAL-421]: https://ginis.atlassian.net/browse/HEAL-421?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ