### PR TITLE
Heal 423 vo issue powered by

### DIFF
--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/InstallApp/InstallAppBottomView.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/InstallApp/InstallAppBottomView.swift
@@ -192,7 +192,7 @@ public final class InstallAppBottomView: GiniBottomSheetViewController {
             moreInformationLabel,
             appStoreImageView,
             continueButton
-        ]
+        ] + (viewModel.shouldShowBrandedView ? [poweredByGiniView] : [])
     }
     
     private func setupViewHierarchy() {

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/InstallApp/InstallAppBottomView.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/InstallApp/InstallAppBottomView.swift
@@ -186,7 +186,8 @@ public final class InstallAppBottomView: GiniBottomSheetViewController {
 
     private func setupAccessibility() {
         view.accessibilityViewIsModal = true
-        view.accessibilityElements = [
+        // Set on `contentView` (scroll view) so VoiceOver can auto-scroll off-screen elements in landscape.
+        contentView.accessibilityElements = [
             titleLabel,
             bankIconImageView,
             moreInformationLabel,

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/ShareInvoice/ShareInvoiceBottomView.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/ShareInvoice/ShareInvoiceBottomView.swift
@@ -173,13 +173,20 @@ public final class ShareInvoiceBottomView: GiniBottomSheetViewController {
     
     private func setupAccessibility() {
         view.accessibilityViewIsModal = true
-        view.accessibilityElements = [
+        // Elements are assigned to scrollView (not view) so that UIKit recognises the
+        // UIScrollView as the accessibility container. This causes VoiceOver to automatically
+        // call scrollRectToVisible when navigating to an off-screen element in landscape,
+        // where the sheet height is reduced and content overflows below the visible area.
+        // Setting view.accessibilityElements = [scrollView] keeps the modal trap intact
+        // while routing all traversal through the scroll view.
+        scrollView.accessibilityElements = [
             titleLabel,
             qrImageView
         ] + (viewModel.shouldShowBrandedView ? [poweredByGiniView] : []) + [
             continueButton,
             descriptionLabel
         ] + dynamicInfoLabels
+        view.accessibilityElements = [scrollView]
     }
 
     private func setupViewHierarchy() {

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/ShareInvoice/ShareInvoiceBottomView.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/ShareInvoice/ShareInvoiceBottomView.swift
@@ -175,7 +175,8 @@ public final class ShareInvoiceBottomView: GiniBottomSheetViewController {
         view.accessibilityViewIsModal = true
         view.accessibilityElements = [
             titleLabel,
-            qrImageView,
+            qrImageView
+        ] + (viewModel.shouldShowBrandedView ? [poweredByGiniView] : []) + [
             continueButton,
             descriptionLabel
         ] + dynamicInfoLabels

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Tests/GiniInternalPaymentSDKTests/AccessibilityTests.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Tests/GiniInternalPaymentSDKTests/AccessibilityTests.swift
@@ -15,6 +15,7 @@
 
 import Testing
 import UIKit
+import GiniHealthAPILibrary
 @testable import GiniInternalPaymentSDK
 
 // MARK: - View controller factories
@@ -42,6 +43,33 @@ private func makeShareInvoiceBottomView() -> ShareInvoiceBottomView {
                                                 paymentInfo: nil,
                                                 paymentRequestId: "test-request-id",
                                                 clientConfiguration: nil)
+    return ShareInvoiceBottomView(viewModel: viewModel,
+                                  bottomSheetConfiguration: .test)
+}
+
+private func makeInstallAppBottomViewWithBranding() -> InstallAppBottomView {
+    let viewModel = InstallAppBottomViewModel(selectedPaymentProvider: nil,
+                                              installAppConfiguration: .test,
+                                              strings: .test,
+                                              primaryButtonConfiguration: .test,
+                                              poweredByGiniConfiguration: .test,
+                                              poweredByGiniStrings: .test,
+                                              clientConfiguration: .test(ingredientBrandType: .fullVisible))
+    return InstallAppBottomView(viewModel: viewModel,
+                                bottomSheetConfiguration: .test)
+}
+
+private func makeShareInvoiceBottomViewWithBranding() -> ShareInvoiceBottomView {
+    let viewModel = ShareInvoiceBottomViewModel(selectedPaymentProvider: nil,
+                                                configuration: .test,
+                                                strings: .test,
+                                                primaryButtonConfiguration: .test,
+                                                poweredByGiniConfiguration: .test,
+                                                poweredByGiniStrings: .test,
+                                                qrCodeData: Data(),
+                                                paymentInfo: nil,
+                                                paymentRequestId: "test-request-id",
+                                                clientConfiguration: .test(ingredientBrandType: .fullVisible))
     return ShareInvoiceBottomView(viewModel: viewModel,
                                   bottomSheetConfiguration: .test)
 }
@@ -142,6 +170,42 @@ struct AccessibilityTests {
             vc.view.accessibilityViewIsModal == false,
             "[\(viewType.testDescription)] accessibilityViewIsModal must be cleared in viewWillDisappear"
         )
+    }
+
+    // MARK: Branded view — accessibilityElements ordering
+
+    /// Verifies that `ShareInvoiceBottomView` with `.fullVisible` client configuration routes
+    /// VoiceOver through the scroll view and includes `PoweredByGiniView` in the element order.
+    @Test("ShareInvoiceBottomView routes accessibility through scrollView and includes PoweredByGiniView when fullVisible")
+    func shareInvoiceBrandedViewAccessibilityElements() throws {
+        let vc = makeShareInvoiceBottomViewWithBranding()
+        vc.loadViewIfNeeded()
+
+        let scrollView = try #require(
+            vc.view.accessibilityElements?.first as? UIScrollView,
+            "view.accessibilityElements must route VoiceOver through the scroll view"
+        )
+        #expect(
+            vc.view.accessibilityElements?.count == 1,
+            "view.accessibilityElements must contain only the scroll view to maintain the modal trap"
+        )
+        let hasBrandedView = scrollView.accessibilityElements?.contains(where: { $0 is PoweredByGiniView }) == true
+        #expect(hasBrandedView, "PoweredByGiniView must be present in scrollView.accessibilityElements when ingredientBrandType is .fullVisible")
+    }
+
+    /// Verifies that `InstallAppBottomView` with `.fullVisible` client configuration includes
+    /// `PoweredByGiniView` in the content scroll view's accessibility element order.
+    @Test("InstallAppBottomView includes PoweredByGiniView in contentView accessibilityElements when fullVisible")
+    func installAppBrandedViewAccessibilityElements() throws {
+        let vc = makeInstallAppBottomViewWithBranding()
+        vc.loadViewIfNeeded()
+
+        let scrollView = try #require(
+            vc.view.subviews.first(where: { $0 is UIScrollView }),
+            "InstallAppBottomView must add contentView (EmptyScrollView) as a subview of view"
+        )
+        let hasBrandedView = scrollView.accessibilityElements?.contains(where: { $0 is PoweredByGiniView }) == true
+        #expect(hasBrandedView, "PoweredByGiniView must be present in contentView.accessibilityElements when ingredientBrandType is .fullVisible")
     }
 
     // MARK: PaymentComponentBottomView


### PR DESCRIPTION
## Pull Request Description

<!-- Briefly explain **what** this PR does and **why**. Mention the motivation, feature, or issue it's addressing. -->

[HEAL-423](https://ginis.atlassian.net/browse/HEAL-423)
[HEAL-422](https://ginis.atlassian.net/browse/HEAL-422)
Improves VoiceOver navigation for InternalPaymentSDK bottom sheets, targeting the “Powered by Gini” branding element and landscape/overflow behavior.
<!--

Some description of HOW you achieved it. Perhaps give a high level description of the chnages you did. Did you need to refactor something? What tradeoffs did you take?

-->

## Notes for Reviewers

- ShareInvoiceBottomView: routes accessibility traversal through the embedded scroll view (to enable automatic scrolling to off-screen elements) and conditionally inserts PoweredByGiniView into the ordered accessibility elements.
- InstallAppBottomView: conditionally appends PoweredByGiniView to the ordered accessibility elements.
<!--

Explain how you verified the changes.
A clear testing scenario helps colleagues who may not be familiar with this part of the code quickly understand and verify the changes. Include steps they can follow to see the impact in action.

You can include: 
- Simulators/Devices you used (e.g. iPhone 13, iPad Pro) 
- iOS versions tested (e.g. 16.0, 17.5) 
- Manual checks (e.g. flow tested: onboarding, permissions, error states) 
- Unit tests added or updated 
 
 Include screenshots, screen recordings, or simulator gifs for UI changes. 
 
 - Optional: Anything that needs extra attention in review? Are there TODOs, known limitations, or follow-up work? 
 
 -->

[HEAL-423]: https://ginis.atlassian.net/browse/HEAL-423?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[HEAL-422]: https://ginis.atlassian.net/browse/HEAL-422?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ