### PR TITLE
fix(GiniInternalPaymentSDK): Fix gini logo clipped at bottom in InstallAppBottomView

### DIFF
--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/InstallApp/InstallAppBottomView.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/InstallApp/InstallAppBottomView.swift
@@ -341,7 +341,8 @@ public final class InstallAppBottomView: GiniBottomSheetViewController {
         NSLayoutConstraint.activate([
             contentStackView.topAnchor.constraint(equalTo: contentView.topAnchor,
                                                   constant: Constants.contentViewTopPadding),
-            contentStackView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
+            contentStackView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor,
+                                                     constant: -Constants.viewPaddingConstraint),
             titleLabel.leadingAnchor.constraint(equalTo: titleView.leadingAnchor, constant: Constants.viewPaddingConstraint),
             titleLabel.trailingAnchor.constraint(equalTo: titleView.trailingAnchor, constant: -Constants.viewPaddingConstraint),
             titleLabel.topAnchor.constraint(equalTo: titleView.topAnchor, constant: Constants.viewPaddingConstraint),
@@ -400,7 +401,11 @@ public final class InstallAppBottomView: GiniBottomSheetViewController {
         contentView.$size
             .receive(on: DispatchQueue.main)
             .sink { [weak self] updatedSize in
-                self?.updateBottomSheetHeight(updatedSize.height)
+                guard let self else { return }
+                // Include the safe-area bottom inset so the sheet is tall enough
+                // to reveal the full content above the home indicator.
+                let safeAreaBottom = view.safeAreaInsets.bottom
+                updateBottomSheetHeight(updatedSize.height + safeAreaBottom)
             }.store(in: &cancellables)
     }
     


### PR DESCRIPTION
[HEAL-425](https://ginis.atlassian.net/browse/HEAL-425)

The "Powered by gini" logo in `InstallAppBottomView` was being clipped or positioned too close to the bottom edge of the sheet in both portrait and landscape.

**Root cause:** `EmptyScrollView.$size` publishes `contentSize` (the total scrollable content height). `setContent` pinned `contentView.bottom == view.safeAreaLayoutGuide.bottomAnchor`, so the scroll view frame was `safeAreaInsets.bottom` (34 pt on home-indicator devices) shorter than the content — the bottom 34 pt of content, including the gini logo, was clipped off-screen. In landscape the safe area bottom is 0, so the logo sat flush against the sheet edge with only 2 pt of visual padding.

**Changes:**

- `bindToContentSizeUpdates`: adds `view.safeAreaInsets.bottom` to the height passed to `updateBottomSheetHeight` so the sheet detent is tall enough to display all content above the home indicator (portrait fix)
- `setupTitleViewConstraints`: adds `-Constants.viewPaddingConstraint` (−16 pt) to `contentStackView.bottomAnchor` so the logo has consistent breathing room in both portrait and landscape

### Notes for Reviewers

**Test scenarios:**

1. Open `InstallAppBottomView` (bank not installed → App Store button shown) on an iPhone with a home indicator (e.g. iPhone 14) — portrait
   - **Before:** "Powered by gini" cut off at the bottom of the sheet
   - **After:** logo fully visible with ~16 pt of space below it
2. Rotate to landscape — logo should remain fully visible with breathing room
3. Test on iPhone SE (no home indicator) — logo should sit ~16 pt from the bottom edge in both orientations
4. Test with bank installed (`continueButton` visible instead of App Store button) — same expectations

No unit tests added; this is a pure layout constraint fix with no logic changes.

[HEAL-425]: https://ginis.atlassian.net/browse/HEAL-425?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ