### PR TITLE
fix(GiniInternalPaymentSDK): Remove unused orientation parameter in g…

### DIFF
--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/ShareInvoice/ShareInvoiceBottomView.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/ShareInvoice/ShareInvoiceBottomView.swift
@@ -435,13 +435,13 @@ public final class ShareInvoiceBottomView: GiniBottomSheetViewController {
         dynamicInfoLabels.removeAll()
         let stackView = createStackView(distribution: .fill, spacing: Constants.viewPaddingConstraint, orientation: .vertical)
         [
-            generateRecipientIbanStackView(orientation: orientation),
+            generateRecipientIbanStackView(),
             generateAmountPurposeStackView()
         ].forEach { stackView.addArrangedSubview($0) }
         return stackView
     }
     
-    private func generateRecipientIbanStackView(orientation: NSLayoutConstraint.Axis) -> UIStackView {
+    private func generateRecipientIbanStackView() -> UIStackView {
         // Always stack vertically: the IBAN is too long to share a row without breaking mid-number.
         let recipientIBANStackView = createStackView(distribution: .fill, spacing: Constants.viewPaddingConstraint, orientation: .vertical)
         

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/ShareInvoice/ShareInvoiceBottomView.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/ShareInvoice/ShareInvoiceBottomView.swift
@@ -293,7 +293,7 @@ public final class ShareInvoiceBottomView: GiniBottomSheetViewController {
         splitStacKView.orientation(orientation).spacing(orientation == .vertical ? 0 : Constants.viewPaddingConstraint)
         splitStacKView.alignment = orientation == .horizontal ? .top : .fill
 
-        paymentInfoStackView = generatePaymentInfoViews(orientation: orientation)
+        paymentInfoStackView = generatePaymentInfoViews()
         updatePaymentInfoView()
 
         let isPortrait = orientation == .vertical
@@ -431,7 +431,7 @@ public final class ShareInvoiceBottomView: GiniBottomSheetViewController {
         }
     }
     
-    private func generatePaymentInfoViews(orientation: NSLayoutConstraint.Axis) -> UIStackView {
+    private func generatePaymentInfoViews() -> UIStackView {
         dynamicInfoLabels.removeAll()
         let stackView = createStackView(distribution: .fill, spacing: Constants.viewPaddingConstraint, orientation: .vertical)
         [


### PR DESCRIPTION

## Pull Request Description

<!-- Briefly explain **what** this PR does and **why**. Mention the motivation, feature, or issue it's addressing. -->

[SonarCubeError](https://sonarcloud.io/project/issues?sinceLeakPeriod=true&issueStatuses=OPEN%2CCONFIRMED&pullRequest=1128&id=gini_mobile_ios_internal_payment_sdk&open=AZ5Ozlz-qBSANC54qjJP)<!-- Closes ticket number PP-####; Replace with JIRA ticket if relevant -->

This PR addresses sonar cube 'iOS Internal Payment SDK' is failing at [release/health_refactor_error_codes](https://github.com/gini/gini-mobile-ios/tree/release/health_refactor_error_codes) with Remove the unused function parameter "orientation" or name it "_". 


<!--

Some description of HOW you achieved it. Perhaps give a high level description of the chnages you did. Did you need to refactor something? What tradeoffs did you take?

-->

## Notes for Reviewers

<!--

Explain how you verified the changes.
A clear testing scenario helps colleagues who may not be familiar with this part of the code quickly understand and verify the changes. Include steps they can follow to see the impact in action.

You can include: 
- Simulators/Devices you used (e.g. iPhone 13, iPad Pro) 
- iOS versions tested (e.g. 16.0, 17.5) 
- Manual checks (e.g. flow tested: onboarding, permissions, error states) 
- Unit tests added or updated 
 
 Include screenshots, screen recordings, or simulator gifs for UI changes. 
 
 - Optional: Anything that needs extra attention in review? Are there TODOs, known limitations, or follow-up work? 
 
 -->