### PR TITLE
ci: introduce reusable sdk.release.yml workflow with GitHub App auth

### DIFF
--- a/.github/workflows/bank-api-library.release.yml
+++ b/.github/workflows/bank-api-library.release.yml
@@ -17,37 +17,19 @@ jobs:
 
   release:
     needs: check
-    runs-on: macos-latest  
-    steps:
-    - uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd # v1.6.0
-      with:
-        xcode-version: '16.4'
+    permissions:
+      contents: write
+    uses: ./.github/workflows/sdk.release.yml
+    with:
+      project_folder: 'BankAPILibrary'
+      package_folder: 'GiniBankAPILibrary'
+      version_file_path: 'BankAPILibrary/GiniBankAPILibrary/Sources/GiniBankAPILibrary/GiniBankAPILibraryVersion.swift'
+      git_tag: ${{ github.ref }}
+      repo_url: 'https://github.com/gini/bank-api-library-ios.git'
+    secrets:
+      MOBILE_CI_APP_ID: ${{ secrets.MOBILE_CI_APP_ID }}
+      MOBILE_CI_APP_PRIVATE_KEY: ${{ secrets.MOBILE_CI_APP_PRIVATE_KEY }}
 
-    - name: Checkout
-      uses: actions/checkout@v4
-
-    - name: setup ruby
-      uses: ruby/setup-ruby@dffc446db9ba5a0c4446edb5bca1c5c473a806c5 # v1.245.0
-      with:
-        ruby-version: '3.2.0'
-        bundler-cache: true
-
-    - name: Publish GiniBankAPILibrary package to the release repo
-      uses: maierj/fastlane-action@5a3b971aaa26776459bb26894d6c1a1a84a311a7 # v3.1.0
-      with:
-        lane: 'publish_swift_package'
-        options: >
-          { 
-            "project_folder": "BankAPILibrary",
-            "package_folder": "GiniBankAPILibrary",
-            "version_file_path": "BankAPILibrary/GiniBankAPILibrary/Sources/GiniBankAPILibrary/GiniBankAPILibraryVersion.swift",
-            "git_tag": "${{ github.ref }}", 
-            "repo_url": "https://github.com/gini/bank-api-library-ios.git", 
-            "repo_user": "${{ secrets.RELEASE_GITHUB_USER }}",
-            "repo_password": "${{ secrets.RELEASE_GITHUB_PASSWORD }}",
-            "ci": "true"
-          }
-    
   release-documentation:
     needs: release
     uses: gini/gini-mobile-ios/.github/workflows/bank-api-library.publish.docs.yml@main

--- a/.github/workflows/bank-sdk.release.yml
+++ b/.github/workflows/bank-sdk.release.yml
@@ -18,36 +18,18 @@ jobs:
   
   release:
     needs: check
-    runs-on: macos-latest
-    steps:
-    - uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd # v1.6.0
-      with:
-        xcode-version: '16.4'
-
-    - name: Checkout
-      uses: actions/checkout@v4
-
-    - name: setup ruby
-      uses: ruby/setup-ruby@dffc446db9ba5a0c4446edb5bca1c5c473a806c5 # v1.245.0
-      with:
-        ruby-version: '3.2.0'
-        bundler-cache: true
-
-    - name: Publish GiniBankSDK package to the release repo
-      uses: maierj/fastlane-action@5a3b971aaa26776459bb26894d6c1a1a84a311a7 # v3.1.0
-      with:
-        lane: 'publish_swift_package'
-        options: >
-          { 
-            "project_folder": "BankSDK",
-            "package_folder": "GiniBankSDK",
-            "version_file_path": "BankSDK/GiniBankSDK/Sources/GiniBankSDK/GiniBankSDKVersion.swift",
-            "git_tag": "${{ github.ref }}", 
-            "repo_url": "https://github.com/gini/bank-sdk-ios.git", 
-            "repo_user": "${{ secrets.RELEASE_GITHUB_USER }}",
-            "repo_password": "${{ secrets.RELEASE_GITHUB_PASSWORD }}",
-            "ci": "true"
-          }
+    permissions:
+      contents: write
+    uses: ./.github/workflows/sdk.release.yml
+    with:
+      project_folder: 'BankSDK'
+      package_folder: 'GiniBankSDK'
+      version_file_path: 'BankSDK/GiniBankSDK/Sources/GiniBankSDK/GiniBankSDKVersion.swift'
+      git_tag: ${{ github.ref }}
+      repo_url: 'https://github.com/gini/bank-sdk-ios.git'
+    secrets:
+      MOBILE_CI_APP_ID: ${{ secrets.MOBILE_CI_APP_ID }}
+      MOBILE_CI_APP_PRIVATE_KEY: ${{ secrets.MOBILE_CI_APP_PRIVATE_KEY }}
 
   release-documentation:
     needs: release

--- a/.github/workflows/capture-sdk.release.yml
+++ b/.github/workflows/capture-sdk.release.yml
@@ -17,36 +17,18 @@ jobs:
 
   release:
     needs: check
-    runs-on: macos-latest
-    steps:
-    - uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd # v1.6.0
-      with:
-        xcode-version: '16.4'
-
-    - name: Checkout
-      uses: actions/checkout@v4
-
-    - name: setup ruby
-      uses: ruby/setup-ruby@dffc446db9ba5a0c4446edb5bca1c5c473a806c5 # v1.245.0
-      with:
-        ruby-version: '3.2.0'
-        bundler-cache: true
-
-    - name: Publish GiniCaptureSDK package to the release repo
-      uses: maierj/fastlane-action@5a3b971aaa26776459bb26894d6c1a1a84a311a7 # v3.1.0
-      with:
-        lane: 'publish_swift_package'
-        options: >
-          { 
-            "project_folder": "CaptureSDK",
-            "package_folder": "GiniCaptureSDK",
-            "version_file_path": "CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/GiniCaptureSDKVersion.swift",
-            "git_tag": "${{ github.ref }}", 
-            "repo_url": "https://github.com/gini/capture-sdk-ios.git", 
-            "repo_user": "${{ secrets.RELEASE_GITHUB_USER }}",
-            "repo_password": "${{ secrets.RELEASE_GITHUB_PASSWORD }}",
-            "ci": "true"
-          }
+    permissions:
+      contents: write
+    uses: ./.github/workflows/sdk.release.yml
+    with:
+      project_folder: 'CaptureSDK'
+      package_folder: 'GiniCaptureSDK'
+      version_file_path: 'CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/GiniCaptureSDKVersion.swift'
+      git_tag: ${{ github.ref }}
+      repo_url: 'https://github.com/gini/capture-sdk-ios.git'
+    secrets:
+      MOBILE_CI_APP_ID: ${{ secrets.MOBILE_CI_APP_ID }}
+      MOBILE_CI_APP_PRIVATE_KEY: ${{ secrets.MOBILE_CI_APP_PRIVATE_KEY }}
 
   release-documentation:
     needs: release

--- a/.github/workflows/health-api-library.release.yml
+++ b/.github/workflows/health-api-library.release.yml
@@ -16,36 +16,18 @@ jobs:
 
   release:
     needs: check
-    runs-on: macos-latest  
-    steps:
-    - uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd # v1.6.0
-      with:
-        xcode-version: '16.4'
-
-    - name: Checkout
-      uses: actions/checkout@v4
-
-    - name: setup ruby
-      uses: ruby/setup-ruby@dffc446db9ba5a0c4446edb5bca1c5c473a806c5 # v1.245.0
-      with:
-        ruby-version: '3.2.0'
-        bundler-cache: true
-
-    - name: Publish GiniHealthAPILibrary package to the release repo
-      uses: maierj/fastlane-action@5a3b971aaa26776459bb26894d6c1a1a84a311a7 # v3.1.0
-      with:
-        lane: 'publish_swift_package'
-        options: >
-          { 
-            "project_folder": "HealthAPILibrary",
-            "package_folder": "GiniHealthAPILibrary",
-            "version_file_path": "HealthAPILibrary/GiniHealthAPILibrary/Sources/GiniHealthAPILibrary/GiniHealthAPILibraryVersion.swift",
-            "git_tag": "${{ github.ref }}", 
-            "repo_url": "https://github.com/gini/health-api-library-ios.git", 
-            "repo_user": "${{ secrets.RELEASE_GITHUB_USER }}",
-            "repo_password": "${{ secrets.RELEASE_GITHUB_PASSWORD }}",
-            "ci": "true"
-          }
+    permissions:
+      contents: write
+    uses: ./.github/workflows/sdk.release.yml
+    with:
+      project_folder: 'HealthAPILibrary'
+      package_folder: 'GiniHealthAPILibrary'
+      version_file_path: 'HealthAPILibrary/GiniHealthAPILibrary/Sources/GiniHealthAPILibrary/GiniHealthAPILibraryVersion.swift'
+      git_tag: ${{ github.ref }}
+      repo_url: 'https://github.com/gini/health-api-library-ios.git'
+    secrets:
+      MOBILE_CI_APP_ID: ${{ secrets.MOBILE_CI_APP_ID }}
+      MOBILE_CI_APP_PRIVATE_KEY: ${{ secrets.MOBILE_CI_APP_PRIVATE_KEY }}
 
 
   release-documentation:

--- a/.github/workflows/health-sdk.release.yml
+++ b/.github/workflows/health-sdk.release.yml
@@ -14,36 +14,18 @@ jobs:
 
   release:
     needs: check
-    runs-on: macos-latest  
-    steps:
-    - uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd # v1.6.0
-      with:
-        xcode-version: '16.4'
-
-    - name: Checkout
-      uses: actions/checkout@v4
-
-    - name: setup ruby
-      uses: ruby/setup-ruby@dffc446db9ba5a0c4446edb5bca1c5c473a806c5 # v1.245.0
-      with:
-        ruby-version: '3.2.0'
-        bundler-cache: true
-
-    - name: Publish GiniHealthSDK package to the release repo
-      uses: maierj/fastlane-action@5a3b971aaa26776459bb26894d6c1a1a84a311a7 # v3.1.0
-      with:
-        lane: 'publish_swift_package'
-        options: >
-          { 
-            "project_folder": "HealthSDK",
-            "package_folder": "GiniHealthSDK",
-            "version_file_path": "HealthSDK/GiniHealthSDK/Sources/GiniHealthSDK/GiniHealthSDKVersion.swift",
-            "git_tag": "${{ github.ref }}", 
-            "repo_url": "https://github.com/gini/health-sdk-ios.git", 
-            "repo_user": "${{ secrets.RELEASE_GITHUB_USER }}",
-            "repo_password": "${{ secrets.RELEASE_GITHUB_PASSWORD }}",
-            "ci": "true"
-          }
+    permissions:
+      contents: write
+    uses: ./.github/workflows/sdk.release.yml
+    with:
+      project_folder: 'HealthSDK'
+      package_folder: 'GiniHealthSDK'
+      version_file_path: 'HealthSDK/GiniHealthSDK/Sources/GiniHealthSDK/GiniHealthSDKVersion.swift'
+      git_tag: ${{ github.ref }}
+      repo_url: 'https://github.com/gini/health-sdk-ios.git'
+    secrets:
+      MOBILE_CI_APP_ID: ${{ secrets.MOBILE_CI_APP_ID }}
+      MOBILE_CI_APP_PRIVATE_KEY: ${{ secrets.MOBILE_CI_APP_PRIVATE_KEY }}
 
   release-documentation:
     needs: release

--- a/.github/workflows/internal-payment-sdk.release.yml
+++ b/.github/workflows/internal-payment-sdk.release.yml
@@ -15,33 +15,15 @@ jobs:
 
   release:
     needs: check
-    runs-on: macos-latest   
-    steps:
-    - uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd # v1.6.0
-      with:
-        xcode-version: '16.4'
-
-    - name: Checkout
-      uses: actions/checkout@v4
-
-    - name: setup ruby
-      uses: ruby/setup-ruby@dffc446db9ba5a0c4446edb5bca1c5c473a806c5 # v1.245.0
-      with:
-        ruby-version: '3.2.0'
-        bundler-cache: true
-
-    - name: Publish GiniInternalPaymentSDK package to the release repo
-      uses: maierj/fastlane-action@5a3b971aaa26776459bb26894d6c1a1a84a311a7 # v3.1.0
-      with:
-        lane: 'publish_swift_package'
-        options: >
-          { 
-            "project_folder": "GiniComponents/InternalPaymentSDK",
-            "package_folder": "GiniInternalPaymentSDK",
-            "version_file_path": "GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/GiniInternalPaymentSDKVersion.swift",
-            "git_tag": "${{ github.ref }}", 
-            "repo_url": "https://github.com/gini/internal-payment-sdk-ios.git",
-            "repo_user": "${{ secrets.RELEASE_GITHUB_USER }}",
-            "repo_password": "${{ secrets.RELEASE_GITHUB_PASSWORD }}",
-            "ci": "true"
-          }
+    permissions:
+      contents: write
+    uses: ./.github/workflows/sdk.release.yml
+    with:
+      project_folder: 'GiniComponents/InternalPaymentSDK'
+      package_folder: 'GiniInternalPaymentSDK'
+      version_file_path: 'GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/GiniInternalPaymentSDKVersion.swift'
+      git_tag: ${{ github.ref }}
+      repo_url: 'https://github.com/gini/internal-payment-sdk-ios.git'
+    secrets:
+      MOBILE_CI_APP_ID: ${{ secrets.MOBILE_CI_APP_ID }}
+      MOBILE_CI_APP_PRIVATE_KEY: ${{ secrets.MOBILE_CI_APP_PRIVATE_KEY }}

--- a/.github/workflows/sdk.release.yml
+++ b/.github/workflows/sdk.release.yml
@@ -1,0 +1,80 @@
+name: Release SDK (Reusable)
+
+permissions:
+  contents: read
+
+on:
+  workflow_call:
+    inputs:
+      project_folder:
+        description: 'The folder containing the project to release'
+        required: true
+        type: string
+      package_folder:
+        description: 'The folder containing the package'
+        required: true
+        type: string
+      version_file_path:
+        description: 'The path to the version file'
+        required: true
+        type: string
+      git_tag:
+        description: 'The Git tag for the release'
+        required: true
+        type: string
+      repo_url:
+        description: 'The URL of the release repository'
+        required: true
+        type: string
+    secrets:
+      MOBILE_CI_APP_ID:
+        required: true
+      MOBILE_CI_APP_PRIVATE_KEY:
+        required: true
+
+jobs:
+  release:
+    runs-on: macos-latest
+
+    steps:
+      - uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd # v1.6.0
+        with:
+          xcode-version: '16.4'
+
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@dffc446db9ba5a0c4446edb5bca1c5c473a806c5 # v1.245.0
+        with:
+          ruby-version: '3.2.0'
+          bundler-cache: true
+
+      - name: Generate a token
+        id: generate-token
+        uses: actions/create-github-app-token@064492a9a1762067169d50c792a7dc02bc3d1254 # v2.0.0
+        with:
+          app-id: ${{ secrets.MOBILE_CI_APP_ID }}
+          private-key: ${{ secrets.MOBILE_CI_APP_PRIVATE_KEY }}
+          owner: gini
+
+      - name: Configure the git client
+        run: |
+          git config --global user.name '${{ steps.generate-token.outputs.app-slug }}[bot]'
+          git config --global user.email '${{ steps.generate-token.outputs.app-slug }}[bot]@users.noreply.github.com'
+
+      - name: Publish package
+        uses: maierj/fastlane-action@5a3b971aaa26776459bb26894d6c1a1a84a311a7 # v3.1.0
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+        with:
+          lane: publish_swift_package
+          options: >
+            {
+              "project_folder": "${{ inputs.project_folder }}",
+              "package_folder": "${{ inputs.package_folder }}",
+              "version_file_path": "${{ inputs.version_file_path }}",
+              "git_tag": "${{ inputs.git_tag }}",
+              "repo_url": "${{ inputs.repo_url }}",
+              "ci": true
+            }

--- a/.github/workflows/sdk.release.yml
+++ b/.github/workflows/sdk.release.yml
@@ -75,6 +75,5 @@ jobs:
               "package_folder": "${{ inputs.package_folder }}",
               "version_file_path": "${{ inputs.version_file_path }}",
               "git_tag": "${{ inputs.git_tag }}",
-              "repo_url": "${{ inputs.repo_url }}",
-              "ci": true
+              "repo_url": "${{ inputs.repo_url }}"
             }

--- a/.github/workflows/utilites.release.yml
+++ b/.github/workflows/utilites.release.yml
@@ -15,33 +15,15 @@ jobs:
       
   release:
     needs: check
-    runs-on: macos-latest   
-    steps:
-    - uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd # v1.6.0
-      with:
-        xcode-version: '16.4'
-
-    - name: Checkout
-      uses: actions/checkout@v4
-
-    - name: setup ruby
-      uses: ruby/setup-ruby@dffc446db9ba5a0c4446edb5bca1c5c473a806c5 # v1.245.0
-      with:
-        ruby-version: '3.2.0'
-        bundler-cache: true
-
-    - name: Publish GiniUtilites package to the release repo
-      uses: maierj/fastlane-action@5a3b971aaa26776459bb26894d6c1a1a84a311a7 # v3.1.0
-      with:
-        lane: 'publish_swift_package'
-        options: >
-          { 
-            "project_folder": "GiniComponents/Utilities",
-            "package_folder": "GiniUtilites",
-            "version_file_path": "GiniComponents/Utilities/GiniUtilites/Sources/GiniUtilites/GiniUtilitesVersion.swift",
-            "git_tag": "${{ github.ref }}", 
-            "repo_url": "https://github.com/gini/utilites-ios.git", 
-            "repo_user": "${{ secrets.RELEASE_GITHUB_USER }}",
-            "repo_password": "${{ secrets.RELEASE_GITHUB_PASSWORD }}",
-            "ci": "true"
-          }
+    permissions:
+      contents: write
+    uses: ./.github/workflows/sdk.release.yml
+    with:
+      project_folder: 'GiniComponents/Utilities'
+      package_folder: 'GiniUtilites'
+      version_file_path: 'GiniComponents/Utilities/GiniUtilites/Sources/GiniUtilites/GiniUtilitesVersion.swift'
+      git_tag: ${{ github.ref }}
+      repo_url: 'https://github.com/gini/utilites-ios.git'
+    secrets:
+      MOBILE_CI_APP_ID: ${{ secrets.MOBILE_CI_APP_ID }}
+      MOBILE_CI_APP_PRIVATE_KEY: ${{ secrets.MOBILE_CI_APP_PRIVATE_KEY }}

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -27,21 +27,22 @@ import "Fastfile_archiving"
 platform :ios do
   desc <<~DOC
     Publish a swift package to our release repository.
-    
+
     Parameters:
       project_folder        - the folder of the project to be released (e.g., HealthAPILibrary, HealthSDK)"
       package_folder        - the folder to the swift package to be released (e.g., GiniHealthAPILibrary, GiniHealthAPILibraryPinning)"
       version_file_path     - the path to the file containing the package version
       git_tag               - the git tag name used to release the project
       repo_url              - the url of the release repository
-      repo_user             - the username to use for authentication
-      repo_password         - the password to use for authentication
-      ci                    - set to "true" if running on a CI machine
+      ci                    - set to true if running on a CI machine
 
   DOC
   lane :publish_swift_package do |options|
-    (project_folder, package_folder, version_file_path, git_tag, repo_url, repo_user, repo_password, ci) = 
-      check_and_get_options(options, [:project_folder, :package_folder, :version_file_path, :git_tag, :repo_url, :repo_user, :repo_password, :ci], UI)
+    (project_folder, package_folder, version_file_path, git_tag, repo_url, ci) =
+      check_and_get_options(options, [:project_folder, :package_folder, :version_file_path, :git_tag, :repo_url, :ci], UI)
+
+      # Coerce boolean strings to actual booleans
+      ci = ci.to_s.downcase == "true"
 
       tag_version = get_project_version_from_tag(package_folder, git_tag, UI)
       package_version = get_project_version_from_version_file(version_file_path, UI)
@@ -51,7 +52,7 @@ platform :ios do
           Version in the tag is different from the package version:
             * tag       : #{tag_version}
             * project   : #{package_version}
-          
+
           Change the version in the tag or update the packages's version in "#{version_file_path}".
         MESSAGE
       end
@@ -64,16 +65,14 @@ platform :ios do
           * version         : #{package_version}
       MESSAGE
 
-      if ci
-        configure_git_on_ci_machines("Team Mobile Schorsch", "valentina.iancu@gini.net")
+      with_git_token_auth do
+        release_repo_path = checkout_release_repo(repo_url)
+
+        copy_swift_package_to_release_repo(release_repo_path, project_folder, package_folder)
+
+        update_release_repo(release_repo_path, package_version)
       end
 
-      release_repo_path = checkout_release_repo(repo_url, repo_user, repo_password)
-
-      copy_swift_package_to_release_repo(release_repo_path, project_folder, package_folder)
-
-      update_release_repo(release_repo_path, package_version)
-      
       UI.success <<~MESSAGE
         Successfully released to the release repository:
           * repository url  : #{repo_url}
@@ -175,20 +174,7 @@ platform :ios do
       # Clear gh-pages directory 
       sh("rm -rf gh-pages")
 
-      # Create a temporary credential helper script that uses GH_TOKEN
-      # This approach keeps the token out of command lines and process listings
-      credential_helper = "/tmp/git-credential-helper-#{Process.pid}.sh"
-      
-      begin
-        File.write(credential_helper, <<~SCRIPT)
-          #!/bin/bash
-          echo "username=x-access-token"
-          echo "password=${GH_TOKEN}"
-        SCRIPT
-        sh("chmod +x #{credential_helper}")
-        
-        # Configure git to use the credential helper and clone
-        sh("git config --global credential.helper '#{credential_helper}'")
+      with_git_token_auth do
         sh("git clone -b gh-pages https://github.com/gini/gini-mobile-ios.git gh-pages")
 
         destination_path = "#{package_folder}/#{package_version}"
@@ -229,7 +215,7 @@ platform :ios do
             UI.message "Skipping root index.html update (not a stable release)"
           end
 
-          if !dry_run 
+          if !dry_run
             UI.message "Commit and push the new documentation"
             sh("git add --all")
             sh("git diff --quiet --exit-code --cached || git commit -m 'Release #{package_folder} documentation for tag #{git_tag}' --author='Team Mobile <team-mobile@gini.net>'")
@@ -238,10 +224,6 @@ platform :ios do
             UI.message "Skipping commit and push (dry run)"
           end
         end
-      ensure
-        # Clean up credential helper and git config
-        sh("git config --global --unset credential.helper || true")
-        sh("rm -f #{credential_helper}")
       end
 
       UI.success <<~MESSAGE

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -34,15 +34,11 @@ platform :ios do
       version_file_path     - the path to the file containing the package version
       git_tag               - the git tag name used to release the project
       repo_url              - the url of the release repository
-      ci                    - set to true if running on a CI machine
 
   DOC
   lane :publish_swift_package do |options|
-    (project_folder, package_folder, version_file_path, git_tag, repo_url, ci) =
-      check_and_get_options(options, [:project_folder, :package_folder, :version_file_path, :git_tag, :repo_url, :ci], UI)
-
-      # Coerce boolean strings to actual booleans
-      ci = ci.to_s.downcase == "true"
+    (project_folder, package_folder, version_file_path, git_tag, repo_url) =
+      check_and_get_options(options, [:project_folder, :package_folder, :version_file_path, :git_tag, :repo_url], UI)
 
       tag_version = get_project_version_from_tag(package_folder, git_tag, UI)
       package_version = get_project_version_from_version_file(version_file_path, UI)

--- a/fastlane/util/git.rb
+++ b/fastlane/util/git.rb
@@ -1,4 +1,27 @@
 ##
+# Configures a temporary git credential helper that reads GH_TOKEN from the environment,
+# yields to the given block, then cleans up the helper and git config on exit.
+#
+# Keeps the token out of command lines and process listings.
+#
+def with_git_token_auth
+  credential_helper = "/tmp/git-credential-helper-#{Process.pid}.sh"
+  begin
+    File.write(credential_helper, <<~SCRIPT)
+      #!/bin/bash
+      echo "username=x-access-token"
+      echo "password=${GH_TOKEN}"
+    SCRIPT
+    sh("chmod +x #{credential_helper}")
+    sh("git config --global credential.helper '#{credential_helper}'")
+    yield
+  ensure
+    sh("git config --global --unset credential.helper || true")
+    sh("rm -f #{credential_helper}")
+  end
+end
+
+##
 # Configure git on CI machines.
 #
 # Usually CI machines start with a "clean slate" and we need to set

--- a/fastlane/util/swift_package_releases.rb
+++ b/fastlane/util/swift_package_releases.rb
@@ -3,9 +3,8 @@
 # 
 # Returns the relative path to the release repo.
 #
-def checkout_release_repo(release_repo_url, repo_user, repo_password)
+def checkout_release_repo(release_repo_url)
   sh("rm -rf release-repo")
-  release_repo_url["://"] = "://#{repo_user}:#{repo_password}@"
   sh("git clone #{release_repo_url} release-repo")
   "release-repo"
 end


### PR DESCRIPTION
## Pull Request Description

Consolidates duplicated release jobs into a single reusable workflow (`sdk.release.yml`) and migrates authentication from hardcoded user/password secrets to GitHub App tokens.

[PP-2291](https://ginis.atlassian.net/browse/PP-2291)

**Key changes:**

- **Reusable workflow**: Centralized `sdk.release.yml` replaces duplicated release jobs across Bank, Health, Capture, InternalPayment and Utilities SDK workflows
- **GitHub App authentication**: Uses `MOBILE_CI_APP_ID`/`MOBILE_CI_APP_PRIVATE_KEY` to generate short-lived tokens instead of `RELEASE_GITHUB_USER`/`RELEASE_GITHUB_PASSWORD`
- **Security**: `with_git_token_auth` helper (extracted to `git.rb`) sets up a temporary credential helper script that keeps the token out of command lines and process listings — same pattern already applied to `publish_docs` in #1037
- **Reuse**: `with_git_token_auth` is now shared between `publish_swift_package` and `publish_docs`, removing the duplicated `begin/ensure` boilerplate
- **Removed `ci` param from `publish_swift_package`**: Previously used solely to guard `configure_git_on_ci_machines` (setting `git user.name/email` on CI runners before committing). The reusable workflow now has a dedicated "Configure the git client" step that sets the git identity before Fastlane runs, making the param redundant

**Fastfile changes:**

```ruby
# Before: credentials embedded in clone URL (token exposed in logs)
def checkout_release_repo(release_repo_url, repo_user, repo_password)
  release_repo_url["://"] = "://#{repo_user}:#{repo_password}@"
  sh("git clone #{release_repo_url} release-repo")
end

# After: plain clone, token injected via credential helper
with_git_token_auth do
  release_repo_path = checkout_release_repo(repo_url)
  ...
end
```

## Notes for Reviewers

- `merchant-sdk.release.yml` is intentionally excluded — it will be removed in a separate PR
- The `with_git_token_auth` helper is the same mechanism introduced for `publish_docs` in #1037; cleanup (unset credential helper, delete temp script) is guaranteed via `ensure`
- All secrets are passed explicitly — no `secrets: inherit` used

[PP-2291]: https://ginis.atlassian.net/browse/PP-2291?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ