### PR TITLE
ci: migrate generate-sboms to GitHub App auth and drop archived pinning repos

### DIFF
--- a/.github/workflows/generate-sboms.yml
+++ b/.github/workflows/generate-sboms.yml
@@ -25,16 +25,23 @@ jobs:
           ruby-version: '3.2.0'
           bundler-cache: true
 
+      - name: Generate a token
+        id: generate-token
+        uses: actions/create-github-app-token@064492a9a1762067169d50c792a7dc02bc3d1254 # v2.0.0
+        with:
+          app-id: ${{ secrets.MOBILE_CI_APP_ID }}
+          private-key: ${{ secrets.MOBILE_CI_APP_PRIVATE_KEY }}
+          owner: gini
+
       - name: generate a cyclonedx sbom for each project
         uses: maierj/fastlane-action@5a3b971aaa26776459bb26894d6c1a1a84a311a7 # v3.1.0
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
         with:
           lane: 'generate_sboms'
           options: >
-            { 
-              "swift_package_repo_urls": "https://github.com/gini/bank-api-library-ios.git,https://github.com/gini/bank-api-library-pinning-ios.git,https://github.com/gini/bank-sdk-ios.git,https://github.com/gini/bank-sdk-pinning-ios.git,https://github.com/gini/capture-sdk-ios.git,https://github.com/gini/capture-sdk-pinning-ios.git,https://github.com/gini/health-api-library-ios.git,https://github.com/gini/health-api-library-pinning-ios.git,https://github.com/gini/health-sdk-ios.git,https://github.com/gini/health-sdk-pinning-ios.git",
-              "repo_user": "${{ secrets.RELEASE_GITHUB_USER }}",
-              "repo_password": "${{ secrets.RELEASE_GITHUB_PASSWORD }}",
-              "ci": "true"
+            {
+              "swift_package_repo_urls": "https://github.com/gini/bank-api-library-ios.git,https://github.com/gini/bank-sdk-ios.git,https://github.com/gini/capture-sdk-ios.git,https://github.com/gini/health-api-library-ios.git,https://github.com/gini/health-sdk-ios.git,https://github.com/gini/internal-payment-sdk-ios.git,https://github.com/gini/utilites-ios.git"
             }
 
       - name: validate cyclonedx sboms
@@ -43,15 +50,12 @@ jobs:
           curl -Lo cyclonedx https://github.com/CycloneDX/cyclonedx-cli/releases/download/v0.25.0/cyclonedx-linux-x64
           chmod +x cyclonedx
           ./cyclonedx validate --input-file fastlane/bank-api-library-ios/GiniBankAPILibrary-sbom.json
-          ./cyclonedx validate --input-file fastlane/bank-api-library-pinning-ios/GiniBankAPILibraryPinning-sbom.json
           ./cyclonedx validate --input-file fastlane/bank-sdk-ios/GiniBankSDK-sbom.json
-          ./cyclonedx validate --input-file fastlane/bank-sdk-pinning-ios/GiniBankSDKPinning-sbom.json
           ./cyclonedx validate --input-file fastlane/capture-sdk-ios/GiniCaptureSDK-sbom.json
-          ./cyclonedx validate --input-file fastlane/capture-sdk-pinning-ios/GiniCaptureSDKPinning-sbom.json
           ./cyclonedx validate --input-file fastlane/health-api-library-ios/GiniHealthAPILibrary-sbom.json
-          ./cyclonedx validate --input-file fastlane/health-api-library-pinning-ios/GiniHealthAPILibraryPinning-sbom.json
           ./cyclonedx validate --input-file fastlane/health-sdk-ios/GiniHealthSDK-sbom.json
-          ./cyclonedx validate --input-file fastlane/health-sdk-pinning-ios/GiniHealthSDKPinning-sbom.json
+          ./cyclonedx validate --input-file fastlane/internal-payment-sdk-ios/GiniInternalPaymentSDK-sbom.json
+          ./cyclonedx validate --input-file fastlane/utilites-ios/GiniUtilites-sbom.json
 
       - name: archive the cyclonedx sboms
         uses: actions/upload-artifact@v4

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Package-release.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Package-release.swift
@@ -26,7 +26,7 @@ let package = Package(
             name: "GiniInternalPaymentSDK",
             dependencies: ["GiniHealthAPILibrary", "GiniUtilites"]),
         .testTarget(
-            name: "GiniInternalPaymentTests",
+            name: "GiniInternalPaymentSDKTests",
             dependencies: ["GiniInternalPaymentSDK"]),
     ]
 )

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -413,46 +413,41 @@ platform :ios do
 
   desc <<~DOC
     Generate CycloneDX SBOMS for all swift packages. The SBOMs are zipped and uploaded to GitHub.
-    
+
     Parameters:
       swift_package_repo_urls     - the list of swift package repository urls
-      repo_user                   - the username to use for authentication
-      repo_password               - the password to use for authentication
-      ci                          - set to "true" if running on a CI machine
 
   DOC
   lane :generate_sboms do |options|
-    (swift_package_repo_urls, repo_user, repo_password, ci) = 
-      check_and_get_options(options, [:swift_package_repo_urls, :repo_user, :repo_password, :ci], UI)
+    swift_package_repo_urls =
+      check_and_get_options(options, [:swift_package_repo_urls], UI)
 
       UI.message <<~MESSAGE
         Will generate CycloneDX SBOMs for swift packages:
           * swift package repository urls  : #{swift_package_repo_urls}
       MESSAGE
 
-      if ci
-        configure_git_on_ci_machines("Team Mobile Schorsch", "valentina.iancu@gini.net")
-      end
-
       sbom_paths = []
 
       swift_package_repos = swift_package_repo_urls.split(",").map(&:strip)
 
-      swift_package_repos.each do |repo_url|
-        release_repo_path = clone_repo(repo_url, repo_user, repo_password, 1)
-        sbom_path = generate_sbom(release_repo_path)
+      with_git_token_auth do
+        swift_package_repos.each do |repo_url|
+          release_repo_path = clone_repo(repo_url, 1)
+          sbom_path = generate_sbom(release_repo_path)
 
-        sbom_paths.push sbom_path
+          sbom_paths.push sbom_path
+        end
       end
 
       all_sboms_zip_file_name = "sbom-jsons.zip"
-      
+
       sh("zip -rj #{all_sboms_zip_file_name} #{sbom_paths.join(" ")}")
-      
+
       UI.success <<~MESSAGE
         Successfully generated CycloneDX SBOMS for all swift packages:
           * swift package repository urls   : #{swift_package_repo_urls}
-          * generated sbom paths                 : #{sbom_paths.map{ |path| "fastlane/#{path}" }.join(", ")}
+          * generated sbom paths            : #{sbom_paths.map{ |path| "fastlane/#{path}" }.join(", ")}
           * location of zip with all sboms  : "fastlane/#{all_sboms_zip_file_name}"
       MESSAGE
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -419,8 +419,8 @@ platform :ios do
 
   DOC
   lane :generate_sboms do |options|
-    swift_package_repo_urls =
-      check_and_get_options(options, [:swift_package_repo_urls], UI).first
+    (swift_package_repo_urls,) =
+      check_and_get_options(options, [:swift_package_repo_urls], UI)
 
       UI.message <<~MESSAGE
         Will generate CycloneDX SBOMs for swift packages:

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -420,7 +420,7 @@ platform :ios do
   DOC
   lane :generate_sboms do |options|
     swift_package_repo_urls =
-      check_and_get_options(options, [:swift_package_repo_urls], UI)
+      check_and_get_options(options, [:swift_package_repo_urls], UI).first
 
       UI.message <<~MESSAGE
         Will generate CycloneDX SBOMs for swift packages:

--- a/fastlane/util/git.rb
+++ b/fastlane/util/git.rb
@@ -127,10 +127,10 @@ end
 
 ##
 # Creates a fresh clone of a Git repository. If the target folder already exists it will be deleted.
-# 
+#
 # Returns the relative path to the release repo.
 #
-def clone_repo(release_repo_url, repo_user, repo_password, depth = 0, target_dir = "")
+def clone_repo(release_repo_url, depth = 0, target_dir = "")
   repo_dir = if target_dir != ""
     target_dir
   else
@@ -138,8 +138,7 @@ def clone_repo(release_repo_url, repo_user, repo_password, depth = 0, target_dir
   end
 
   sh("rm -rf #{repo_dir}")
-  release_repo_url["://"] = "://#{repo_user}:#{repo_password}@"
   sh("git clone #{if depth > 0 then "--depth #{depth}" end} #{release_repo_url} #{target_dir}")
-  
+
   repo_dir
 end


### PR DESCRIPTION
[PP-2292](https://ginis.atlassian.net/browse/PP-2292)

Migrates the `generate-sboms` workflow and its supporting Fastlane lane away from static `RELEASE_GITHUB_USER`/`RELEASE_GITHUB_PASSWORD` credentials, and removes the 5 archived pinning repos that no longer exist.

The workflow now generates a short-lived GitHub App token via `actions/create-github-app-token` (same pattern already used in `sdk.release.yml` from #1166) and passes it as `GH_TOKEN` to Fastlane. The `with_git_token_auth` helper (introduced in the parent branch) wraps the clone loop, keeping the token out of command lines and process listings. `clone_repo` in `git.rb` is simplified to remove the `repo_user`/`repo_password` parameters, since authentication is now handled by the credential helper. Two previously missing repos (`internal-payment-sdk-ios`, `utilites-ios`) are also added to the SBOM run.

### Notes for Reviewers

No automated tests cover CI workflow changes — verification is by inspection:

- `clone_repo` signature change: confirm no other callers pass `repo_user`/`repo_password` (only `generate_sboms` used it)
- Pinning repos removed: all 5 (`bank-api-library-pinning-ios`, `bank-sdk-pinning-ios`, `capture-sdk-pinning-ios`, `health-api-library-pinning-ios`, `health-sdk-pinning-ios`) are confirmed archived on GitHub
- New repos added: `internal-payment-sdk-ios` and `utilites-ios` are active and their package names (`GiniInternalPaymentSDK`, `GiniUtilites`) match `Package.swift` in each repo
- Workflow can be validated by triggering `Generate SBOMs for all projects` manually via `workflow_dispatch` after merge
- This PR targets `fix/PP-2291` and depends on `with_git_token_auth` being present in `git.rb` from that branch

[PP-2292]: https://ginis.atlassian.net/browse/PP-2292?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ