### PR TITLE
Pp 2563 photo permission dialog issue

### DIFF
--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Review/ReviewViewController.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Review/ReviewViewController.swift
@@ -494,7 +494,7 @@ extension ReviewViewController {
     }
 
     private func saveToGalleryValueDidChange() {
-        saveToGalleryView.$valueChanged.sink { isOn in
+        saveToGalleryView.$valueChanged.dropFirst().sink { isOn in
             GiniCaptureUserDefaultsStorage.userSettingsSavePhotosSwitchOn = isOn
             if isOn {
                 self.handleSaveToGalleryToggle()

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Review/ReviewViewController.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Review/ReviewViewController.swift
@@ -494,12 +494,11 @@ extension ReviewViewController {
     }
 
     private func saveToGalleryValueDidChange() {
-        saveToGalleryView.$valueChanged.dropFirst().sink { isOn in
+        saveToGalleryView.$valueChanged.dropFirst().sink { [weak self] isOn in
             GiniCaptureUserDefaultsStorage.userSettingsSavePhotosSwitchOn = isOn
             if isOn {
-                self.handleSaveToGalleryToggle()
+                self?.handleSaveToGalleryToggle()
             }
-
         }.store(in: &cancellables)
     }
 

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Review/Views/SaveToGalleryView.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Review/Views/SaveToGalleryView.swift
@@ -52,7 +52,7 @@ final class SaveToGalleryView: UIView {
         }
     }
 
-    @Published var valueChanged = false
+    @Published private(set) var valueChanged = false
 
     override init(frame: CGRect) {
         super.init(frame: frame)

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Review/Views/SaveToGalleryView.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Review/Views/SaveToGalleryView.swift
@@ -52,6 +52,7 @@ final class SaveToGalleryView: UIView {
         }
     }
 
+    /// Externally read-only; `false` suppresses the initial Combine emission to avoid triggering photo permission on load.
     @Published private(set) var valueChanged = false
 
     override init(frame: CGRect) {

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Review/Views/SaveToGalleryView.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Review/Views/SaveToGalleryView.swift
@@ -52,7 +52,7 @@ final class SaveToGalleryView: UIView {
         }
     }
 
-    @Published var valueChanged = GiniCaptureUserDefaultsStorage.userSettingsSavePhotosSwitchOn == true
+    @Published var valueChanged = false
 
     override init(frame: CGRect) {
         super.init(frame: frame)

--- a/CaptureSDK/GiniCaptureSDK/Tests/GiniCaptureSDKTests/ReviewViewControllerTests.swift
+++ b/CaptureSDK/GiniCaptureSDK/Tests/GiniCaptureSDKTests/ReviewViewControllerTests.swift
@@ -151,7 +151,28 @@ final class ReviewViewControllerTests: XCTestCase {
     }
 
 
-// MARK: - Fix the test with tap event simulation
+    // MARK: - Regression Guards
+
+    func testSaveToGalleryViewValueChangedInitialisesToFalse() {
+        let saveToGalleryView = SaveToGalleryView()
+        XCTAssertFalse(saveToGalleryView.valueChanged,
+                       "valueChanged must start as false to prevent the initial Combine emission from triggering the permission flow on view load (PP-2563)")
+    }
+
+    func testUserDefaultsSavePhotosSwitchNotOverwrittenOnViewLoad() {
+        GiniCaptureUserDefaultsStorage.userSettingsSavePhotosSwitchOn = true
+
+        let vc = ReviewViewController(pages: imagePages,
+                                      giniConfiguration: giniConfiguration)
+        _ = vc.view
+
+        XCTAssertEqual(GiniCaptureUserDefaultsStorage.userSettingsSavePhotosSwitchOn, true,
+                       "userSettingsSavePhotosSwitchOn must not be overwritten on view load — dropFirst() must suppress the initial emission (PP-2563 / PP-2171 regression guard)")
+
+        GiniCaptureUserDefaultsStorage.userSettingsSavePhotosSwitchOn = nil
+    }
+
+    // MARK: - Fix the test with tap event simulation
 
 //    func testDatasourceOnDelete() {
 //        let vc = ReviewViewController(pages: imagePages,


### PR DESCRIPTION
## Pull Request Description

<!-- Briefly explain **what** this PR does and **why**. Mention the motivation, feature, or issue it's addressing. -->

[PP-2563](https://ginis.atlassian.net/browse/PP-2563)<!-- Closes ticket number PP-####; Replace with JIRA ticket if relevant -->

This PR adjusts the “Save to gallery” toggle observation on the Review screen to prevent unintended side effects when subscribing to the toggle’s state changes (related to the photo permission dialog behavior).

<!--

Some description of HOW you achieved it. Perhaps give a high level description of the chnages you did. Did you need to refactor something? What tradeoffs did you take?

-->

## Notes for Reviewers

- Initialize SaveToGalleryView.valueChanged with a neutral default (false) instead of a persisted value.
- Ignore the initial @Published emission by applying dropFirst() before persisting the user’s choice / triggering permission handling.
<!--

Explain how you verified the changes.
A clear testing scenario helps colleagues who may not be familiar with this part of the code quickly understand and verify the changes. Include steps they can follow to see the impact in action.

You can include: 
- Simulators/Devices you used (e.g. iPhone 13, iPad Pro) 
- iOS versions tested (e.g. 16.0, 17.5) 
- Manual checks (e.g. flow tested: onboarding, permissions, error states) 
- Unit tests added or updated 
 
 Include screenshots, screen recordings, or simulator gifs for UI changes. 
 
 - Optional: Anything that needs extra attention in review? Are there TODOs, known limitations, or follow-up work? 
 
 -->

[PP-2563]: https://ginis.atlassian.net/browse/PP-2563?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ