### PR TITLE
Heal 418 alert component

### DIFF
--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/PaymentReviewViewController.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/PaymentReviewViewController.swift
@@ -149,6 +149,9 @@ extension PaymentReviewViewController: PaymentReviewViewModelDelegate {
         let okAction = UIAlertAction(title: model.strings.alertOkButtonTitle,
                                      style: .default)
         alertController.addAction(okAction)
+        // preferredAction must be set after addAction
+        alertController.preferredAction = okAction
+
         giniTopMostViewController().present(alertController, animated: true)
     }
     

--- a/HealthSDK/GiniHealthSDK/Sources/GiniHealthSDK/Core/PaymentComponentsController+Helpers.swift
+++ b/HealthSDK/GiniHealthSDK/Sources/GiniHealthSDK/Core/PaymentComponentsController+Helpers.swift
@@ -793,7 +793,9 @@ extension PaymentComponentsController: PaymentComponentViewProtocol {
         }
         
         alertController.addAction(okAction)
-        
+        // preferredAction must be set after addAction
+        alertController.preferredAction = okAction
+
         navigationControllerProvided?.present(alertController, animated: true)
     }
     

--- a/HealthSDK/GiniHealthSDKExample/GiniHealthSDKExample/AppCoordinator.swift
+++ b/HealthSDK/GiniHealthSDKExample/GiniHealthSDKExample/AppCoordinator.swift
@@ -302,7 +302,7 @@ final class AppCoordinator: Coordinator {
                                                     message: "Dies ist kein gültiges Dokument",
                                                     preferredStyle: .alert)
         
-        let okAction = UIAlertAction(title: "OK", style: .default)
+        let okAction = UIAlertAction(title: NSLocalizedString("gini.health.example.order.detail.alert.ok", comment: ""), style: .default)
         alertViewController.addAction(okAction)
         alertViewController.preferredAction = okAction
         rootViewController.present(alertViewController, animated: true)
@@ -313,7 +313,7 @@ final class AppCoordinator: Coordinator {
                                                     message: message,
                                                     preferredStyle: .alert)
 
-        let okAction = UIAlertAction(title: "OK", style: .default)
+        let okAction = UIAlertAction(title: NSLocalizedString("gini.health.example.order.detail.alert.ok", comment: ""), style: .default)
         alertViewController.addAction(okAction)
         alertViewController.preferredAction = okAction
         rootViewController.present(alertViewController, animated: true)

--- a/HealthSDK/GiniHealthSDKExample/GiniHealthSDKExample/AppCoordinator.swift
+++ b/HealthSDK/GiniHealthSDKExample/GiniHealthSDKExample/AppCoordinator.swift
@@ -302,9 +302,7 @@ final class AppCoordinator: Coordinator {
                                                     message: "Dies ist kein gültiges Dokument",
                                                     preferredStyle: .alert)
         
-        let okAction = UIAlertAction(title: "OK", style: .default) { _ in
-            alertViewController.dismiss(animated: true)
-        }
+        let okAction = UIAlertAction(title: "OK", style: .default)
         alertViewController.addAction(okAction)
         alertViewController.preferredAction = okAction
         rootViewController.present(alertViewController, animated: true)
@@ -315,9 +313,7 @@ final class AppCoordinator: Coordinator {
                                                     message: message,
                                                     preferredStyle: .alert)
 
-        let okAction = UIAlertAction(title: "OK", style: .default) { _ in
-            alertViewController.dismiss(animated: true)
-        }
+        let okAction = UIAlertAction(title: "OK", style: .default)
         alertViewController.addAction(okAction)
         alertViewController.preferredAction = okAction
         rootViewController.present(alertViewController, animated: true)

--- a/HealthSDK/GiniHealthSDKExample/GiniHealthSDKExample/AppCoordinator.swift
+++ b/HealthSDK/GiniHealthSDKExample/GiniHealthSDKExample/AppCoordinator.swift
@@ -289,10 +289,11 @@ final class AppCoordinator: Coordinator {
                                                     "Gini Health SDK verwenden?",
                                                     preferredStyle: .alert)
         
-        alertViewController.addAction(UIAlertAction(title: "Ja", style: .default) { [weak self] _ in
+        let jaAction = UIAlertAction(title: "Ja", style: .default) { [weak self] _ in
             self?.showScreenAPI(with: pages)
-        })
-        
+        }
+        alertViewController.addAction(jaAction)
+        alertViewController.preferredAction = jaAction
         rootViewController.present(alertViewController, animated: true)
     }
     
@@ -301,22 +302,24 @@ final class AppCoordinator: Coordinator {
                                                     message: "Dies ist kein gültiges Dokument",
                                                     preferredStyle: .alert)
         
-        alertViewController.addAction(UIAlertAction(title: "OK", style: .default) { _ in
+        let okAction = UIAlertAction(title: "OK", style: .default) { _ in
             alertViewController.dismiss(animated: true)
-        })
-        
+        }
+        alertViewController.addAction(okAction)
+        alertViewController.preferredAction = okAction
         rootViewController.present(alertViewController, animated: true)
     }
-    
+
     fileprivate func showReturnMessage(message: String) {
         let alertViewController = UIAlertController(title: "Congratulations",
                                                     message: message,
                                                     preferredStyle: .alert)
-        
-        alertViewController.addAction(UIAlertAction(title: "OK", style: .default) { _ in
+
+        let okAction = UIAlertAction(title: "OK", style: .default) { _ in
             alertViewController.dismiss(animated: true)
-        })
-        
+        }
+        alertViewController.addAction(okAction)
+        alertViewController.preferredAction = okAction
         rootViewController.present(alertViewController, animated: true)
     }
     

--- a/HealthSDK/GiniHealthSDKExample/GiniHealthSDKExample/AppCoordinator.swift
+++ b/HealthSDK/GiniHealthSDKExample/GiniHealthSDKExample/AppCoordinator.swift
@@ -289,7 +289,7 @@ final class AppCoordinator: Coordinator {
                                                     "Gini Health SDK verwenden?",
                                                     preferredStyle: .alert)
         
-        let jaAction = UIAlertAction(title: "Ja", style: .default) { [weak self] _ in
+        let jaAction = UIAlertAction(title: NSLocalizedString("gini.health.example.order.detail.alert.ok", comment: ""), style: .default) { [weak self] _ in
             self?.showScreenAPI(with: pages)
         }
         alertViewController.addAction(jaAction)

--- a/HealthSDK/GiniHealthSDKExample/GiniHealthSDKExample/InvoicesList/InvoicesListViewController.swift
+++ b/HealthSDK/GiniHealthSDKExample/GiniHealthSDKExample/InvoicesList/InvoicesListViewController.swift
@@ -193,7 +193,9 @@ extension InvoicesListViewController: InvoicesListViewControllerProtocol {
         let alertController = UIAlertController(title: viewModel.errorTitleText,
                                                 message: error,
                                                 preferredStyle: .alert)
-        alertController.addAction(UIAlertAction(title: "Ok", style: .default))
+        let okAction = UIAlertAction(title: "Ok", style: .default)
+        alertController.addAction(okAction)
+        alertController.preferredAction = okAction
         self.present(alertController, animated: true)
     }
 }

--- a/HealthSDK/GiniHealthSDKExample/GiniHealthSDKExample/InvoicesList/InvoicesListViewController.swift
+++ b/HealthSDK/GiniHealthSDKExample/GiniHealthSDKExample/InvoicesList/InvoicesListViewController.swift
@@ -193,7 +193,7 @@ extension InvoicesListViewController: InvoicesListViewControllerProtocol {
         let alertController = UIAlertController(title: viewModel.errorTitleText,
                                                 message: error,
                                                 preferredStyle: .alert)
-        let okAction = UIAlertAction(title: "Ok", style: .default)
+        let okAction = UIAlertAction(title: NSLocalizedString("gini.health.example.order.detail.alert.ok", comment: ""), style: .default)
         alertController.addAction(okAction)
         alertController.preferredAction = okAction
         self.present(alertController, animated: true)

--- a/HealthSDK/GiniHealthSDKExample/GiniHealthSDKExample/InvoicesList/UIViewController.swift
+++ b/HealthSDK/GiniHealthSDKExample/GiniHealthSDKExample/InvoicesList/UIViewController.swift
@@ -91,13 +91,15 @@ extension UIViewController {
         }))
         
         if let confirmActionTitle = confirmActionTitle, let confirmAction = confirmAction {
-            alertViewController.addAction(UIAlertAction(title: confirmActionTitle,
-                                                        style: .default,
-                                                        handler: { _ in
-                                                            confirmAction()
-            }))
+            let confirmAlertAction = UIAlertAction(title: confirmActionTitle,
+                                                   style: .default,
+                                                   handler: { _ in
+                                                       confirmAction()
+            })
+            alertViewController.addAction(confirmAlertAction)
+            alertViewController.preferredAction = confirmAlertAction
         }
-        
+
         return alertViewController
     }
 }

--- a/HealthSDK/GiniHealthSDKExample/GiniHealthSDKExample/OrdersList/OrderDetailViewController.swift
+++ b/HealthSDK/GiniHealthSDKExample/GiniHealthSDKExample/OrdersList/OrderDetailViewController.swift
@@ -292,10 +292,10 @@ final class OrderDetailViewController: UIViewController {
         let alertController = UIAlertController(title: errorTitleText,
                                                 message: error,
                                                 preferredStyle: .alert)
-        alertController.addAction(
-            UIAlertAction(title: NSLocalizedString("gini.health.example.order.detail.alert.ok", comment: ""),
-                          style: .default)
-        )
+        let okAction = UIAlertAction(title: NSLocalizedString("gini.health.example.order.detail.alert.ok", comment: ""),
+                                         style: .default)
+        alertController.addAction(okAction)
+        alertController.preferredAction = okAction
         self.present(alertController, animated: true)
     }
 

--- a/HealthSDK/GiniHealthSDKExample/GiniHealthSDKExample/OrdersList/OrderListViewController.swift
+++ b/HealthSDK/GiniHealthSDKExample/GiniHealthSDKExample/OrdersList/OrderListViewController.swift
@@ -213,7 +213,7 @@ extension OrderListViewController: OrderListViewControllerProtocol {
         let alertController = UIAlertController(title: viewModel.errorTitleText, 
                                                 message: error,
                                                 preferredStyle: .alert)
-        let okAction = UIAlertAction(title: "Ok", style: .default)
+        let okAction = UIAlertAction(title: NSLocalizedString("gini.health.example.order.detail.alert.ok", comment: ""), style: .default)
         alertController.addAction(okAction)
         alertController.preferredAction = okAction
         self.present(alertController, animated: true)

--- a/HealthSDK/GiniHealthSDKExample/GiniHealthSDKExample/OrdersList/OrderListViewController.swift
+++ b/HealthSDK/GiniHealthSDKExample/GiniHealthSDKExample/OrdersList/OrderListViewController.swift
@@ -213,7 +213,9 @@ extension OrderListViewController: OrderListViewControllerProtocol {
         let alertController = UIAlertController(title: viewModel.errorTitleText, 
                                                 message: error,
                                                 preferredStyle: .alert)
-        alertController.addAction(UIAlertAction(title: "Ok", style: .default))
+        let okAction = UIAlertAction(title: "Ok", style: .default)
+        alertController.addAction(okAction)
+        alertController.preferredAction = okAction
         self.present(alertController, animated: true)
     }
 }

--- a/HealthSDK/GiniHealthSDKExample/GiniHealthSDKExample/UIViewController+Utils.swift
+++ b/HealthSDK/GiniHealthSDKExample/GiniHealthSDKExample/UIViewController+Utils.swift
@@ -13,6 +13,7 @@ extension UIViewController {
                                                 preferredStyle: .alert)
         let action = UIAlertAction(title: "OK", style: .default, handler: nil)
         alertController.addAction(action)
+        alertController.preferredAction = action
         present(alertController, animated: true, completion: nil)
     }
 }


### PR DESCRIPTION
## Pull Request Description

<!-- Briefly explain **what** this PR does and **why**. Mention the motivation, feature, or issue it's addressing. -->

[HEAL-418](https://ginis.atlassian.net/browse/HEAL-418)<!-- Closes ticket number PP-####; Replace with JIRA ticket if relevant -->

This PR updates multiple UIAlertController usages across the Health SDK example app and SDK UI to set a preferredAction, making the primary/OK button the default (e.g., highlighted and triggered by Return on external keyboards).
<!--

Some description of HOW you achieved it. Perhaps give a high level description of the chnages you did. Did you need to refactor something? What tradeoffs did you take?

-->

## Notes for Reviewers
- Set preferredAction for several alert controllers after adding their OK/confirm action.
- Refactor inline addAction(UIAlertAction(...)) calls into named UIAlertAction variables to allow setting preferredAction.
- Add an explicit comment in SDK alert presenters noting preferredAction must be set after addAction.

<!--

Explain how you verified the changes.
A clear testing scenario helps colleagues who may not be familiar with this part of the code quickly understand and verify the changes. Include steps they can follow to see the impact in action.

You can include: 
- Simulators/Devices you used (e.g. iPhone 13, iPad Pro) 
- iOS versions tested (e.g. 16.0, 17.5) 
- Manual checks (e.g. flow tested: onboarding, permissions, error states) 
- Unit tests added or updated 
 
 Include screenshots, screen recordings, or simulator gifs for UI changes. 
 
 - Optional: Anything that needs extra attention in review? Are there TODOs, known limitations, or follow-up work? 
 
 -->

[HEAL-418]: https://ginis.atlassian.net/browse/HEAL-418?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ