### PR TITLE
Heal 512 auto dismiss alert issue

### DIFF
--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/GiniAlertWindowPresenter.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/GiniAlertWindowPresenter.swift
@@ -1,0 +1,56 @@
+//
+//  GiniAlertWindowPresenter.swift
+//
+//  Copyright © 2026 Gini GmbH. All rights reserved.
+//
+
+import UIKit
+
+/**
+ Manages a dedicated UIWindow at `.alert` level for presenting UIAlertControllers.
+
+ Presenting alerts on their own window keeps them outside any active sheet's
+ presentation chain, so they survive the sheet being dismissed (e.g. on rotation).
+ */
+final class GiniAlertWindowPresenter {
+
+    private var alertWindow: UIWindow?
+
+    var isPresenting: Bool { alertWindow != nil }
+
+    /**
+     Presents an alert controller on a dedicated alert-level window.
+
+     - Parameters:
+       - alertController: The `UIAlertController` to present.
+       - sourceViewController: A VC from the main window, used to obtain the `UIWindowScene`.
+     */
+    func present(_ alertController: UIAlertController,
+                 from sourceViewController: UIViewController) {
+        guard !isPresenting,
+              let windowScene = sourceViewController.view.window?.windowScene else { return }
+
+        let window = UIWindow(windowScene: windowScene)
+        let rootVC = UIViewController()
+        rootVC.view.backgroundColor = .clear
+        window.rootViewController = rootVC
+        window.windowLevel = .alert
+        window.makeKeyAndVisible()
+        alertWindow = window
+
+        rootVC.present(alertController, animated: true)
+    }
+
+    /**
+     Tears down the alert window. Call this from the alert's action handler
+     and from the host view controller's `viewDidDisappear`.
+     */
+    func dismiss() {
+        let window = alertWindow
+        alertWindow = nil
+        DispatchQueue.main.async {
+            window?.isHidden = true
+            window?.rootViewController = nil
+        }
+    }
+}

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/GiniAlertWindowPresenter.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/GiniAlertWindowPresenter.swift
@@ -27,8 +27,17 @@ final class GiniAlertWindowPresenter {
      */
     func present(_ alertController: UIAlertController,
                  from sourceViewController: UIViewController) {
-        guard !isPresenting,
-              let windowScene = sourceViewController.view.window?.windowScene else { return }
+        guard !isPresenting else { return }
+
+        // Prefer the source VC's window scene; fall back to the foreground active scene
+        // so the alert is still shown if the source VC isn't yet attached to a window
+        // (e.g. during a transition).
+        let windowScene = sourceViewController.view.window?.windowScene
+            ?? UIApplication.shared.connectedScenes
+                .compactMap { $0 as? UIWindowScene }
+                .first { $0.activationState == .foregroundActive }
+
+        guard let windowScene else { return }
 
         let window = UIWindow(windowScene: windowScene)
         let rootVC = UIViewController()
@@ -46,6 +55,20 @@ final class GiniAlertWindowPresenter {
      and from the host view controller's `viewDidDisappear`.
      */
     func dismiss() {
+        guard let rootVC = alertWindow?.rootViewController else {
+            tearDown()
+            return
+        }
+        if let presented = rootVC.presentedViewController {
+            presented.dismiss(animated: false) { [weak self] in
+                self?.tearDown()
+            }
+        } else {
+            tearDown()
+        }
+    }
+
+    private func tearDown() {
         let window = alertWindow
         alertWindow = nil
         DispatchQueue.main.async {

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/PaymentReviewViewController.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/PaymentReviewViewController.swift
@@ -22,6 +22,7 @@ public enum DisplayMode: Int {
 public final class PaymentReviewViewController: UIHostingController<PaymentReviewContentView> {
 
     private let overlayPresenter = GiniOverlayWindowPresenter()
+    private let alertPresenter = GiniAlertWindowPresenter()
     // Stored so viewWillTransition can set isDismissingForRotation before dismissing the sheet.
     private let observableModel: PaymentReviewObservableModel
 
@@ -105,6 +106,7 @@ public final class PaymentReviewViewController: UIHostingController<PaymentRevie
     public override func viewDidDisappear(_ animated: Bool) {
         super.viewDidDisappear(animated)
         overlayPresenter.dismiss(animated: false)
+        alertPresenter.dismiss()
         model.viewDidDisappear()
     }
 }
@@ -147,12 +149,13 @@ extension PaymentReviewViewController: PaymentReviewViewModelDelegate {
                                                 message: message,
                                                 preferredStyle: .alert)
         let okAction = UIAlertAction(title: model.strings.alertOkButtonTitle,
-                                     style: .default)
+                                     style: .default) { [weak self] _ in
+            self?.alertPresenter.dismiss()
+        }
         alertController.addAction(okAction)
-        // preferredAction must be set after addAction
         alertController.preferredAction = okAction
 
-        giniTopMostViewController().present(alertController, animated: true)
+        alertPresenter.present(alertController, from: self)
     }
     
     private func dismissScreen() {

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/PaymentReviewViewController.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/PaymentReviewViewController.swift
@@ -153,6 +153,7 @@ extension PaymentReviewViewController: PaymentReviewViewModelDelegate {
             self?.alertPresenter.dismiss()
         }
         alertController.addAction(okAction)
+        // preferredAction must be set after addAction
         alertController.preferredAction = okAction
 
         alertPresenter.present(alertController, from: self)

--- a/GiniComponents/InternalPaymentSDK/sonar-project.properties
+++ b/GiniComponents/InternalPaymentSDK/sonar-project.properties
@@ -26,6 +26,7 @@ sonar.test.exclusions=**/Pods/**,**/*.xcassets/**
 #   GiniBottomSheetModifier.swift      — SwiftUI ViewModifier (UI bridge)
 #   GiniZoomableImageViewCoordinator.swift — UIScrollViewDelegate coordinator
 #   GiniOverlayWindowPresenter.swift   — UIWindow/scene management (live only)
+#   GiniAlertWindowPresenter.swift     — UIWindow/scene management (live only)
 #   PaymentSecondaryButton.swift       — UIButton appearance subclass
 sonar.coverage.exclusions=**/Pods/**,\
   **/*View.swift,\
@@ -37,6 +38,7 @@ sonar.coverage.exclusions=**/Pods/**,\
   **/GiniBottomSheetModifier.swift,\
   **/GiniZoomableImageViewCoordinator.swift,\
   **/GiniOverlayWindowPresenter.swift,\
+  **/GiniAlertWindowPresenter.swift,\
   **/PaymentSecondaryButton.swift
 
 sonar.sourceEncoding=UTF-8


### PR DESCRIPTION
## Pull Request Description

<!-- Briefly explain **what** this PR does and **why**. Mention the motivation, feature, or issue it's addressing. -->

[HEAL-512](https://ginis.atlassian.net/browse/HEAL-512)<!-- Closes ticket number PP-####; Replace with JIRA ticket if relevant -->

This PR fixes an issue where error alerts were auto-dismissed when the user rotated the device to landscape, because the alert was presented inside the payment form sheet's presentation chain — rotating caused the sheet to be dismissed imperatively, taking the alert with it. The fix presents UIAlertController from a dedicated .alert-level UIWindow instead, keeping it outside any sheet hierarchy so it survives rotation.

<!--

Some description of HOW you achieved it. Perhaps give a high level description of the chnages you did. Did you need to refactor something? What tradeoffs did you take?

-->

## Notes for Reviewers

- Added GiniAlertWindowPresenter to manage presenting UIAlertController on a dedicated alert-level UIWindow
- Updated PaymentReviewViewController to present and dismiss error alerts via the new presenter instead of giniTopMostViewController().
- Excluded GiniAlertWindowPresenter from SonarCloud coverage (UIWindow/scene management, same rationale as GiniOverlayWindowPresenter).
<!--

Explain how you verified the changes.
A clear testing scenario helps colleagues who may not be familiar with this part of the code quickly understand and verify the changes. Include steps they can follow to see the impact in action.

You can include: 
- Simulators/Devices you used (e.g. iPhone 13, iPad Pro) 
- iOS versions tested (e.g. 16.0, 17.5) 
- Manual checks (e.g. flow tested: onboarding, permissions, error states) 
- Unit tests added or updated 
 
 Include screenshots, screen recordings, or simulator gifs for UI changes. 
 
 - Optional: Anything that needs extra attention in review? Are there TODOs, known limitations, or follow-up work? 
 
 -->

[HEAL-512]: https://ginis.atlassian.net/browse/HEAL-512?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ