### PR TITLE
Pp 2310 qr code unsupported warning flag

### DIFF
--- a/BankAPILibrary/GiniBankAPILibrary/Sources/GiniBankAPILibrary/Documents/Configuration/ClientConfiguration.swift
+++ b/BankAPILibrary/GiniBankAPILibrary/Sources/GiniBankAPILibrary/Documents/Configuration/ClientConfiguration.swift
@@ -27,6 +27,7 @@ public struct ClientConfiguration: Codable {
     public let savePhotosLocallyEnabled: Bool
     public let alreadyPaidHintEnabled: Bool
     public let paymentDueHintEnabled: Bool
+    public let unsupportedQRCodeWarningEnabled: Bool
 
     /**
      Creates a new `ClientConfiguration` instance.
@@ -43,6 +44,7 @@ public struct ClientConfiguration: Codable {
      - savePhotosLocallyEnabled: A flag indicating whether saving photos locally is enabled.
      - alreadyPaidHintEnabled: A flag indicating whether hints for already paid invoices are enabled.
      - paymentDueHintEnabled: A flag indicating whether hints for upcoming payment due date is enabled.
+     - unsupportedQRCodeWarningEnabled: A flag indicating whether the unsupported QR code warning alert is enabled.
      */
     public init(clientID: String,
                 userJourneyAnalyticsEnabled: Bool,
@@ -54,7 +56,8 @@ public struct ClientConfiguration: Codable {
                 eInvoiceEnabled: Bool,
                 savePhotosLocallyEnabled: Bool,
                 alreadyPaidHintEnabled: Bool,
-                paymentDueHintEnabled: Bool) {
+                paymentDueHintEnabled: Bool,
+                unsupportedQRCodeWarningEnabled: Bool = false) {
         self.clientID = clientID
         self.userJourneyAnalyticsEnabled = userJourneyAnalyticsEnabled
         self.skontoEnabled = skontoEnabled
@@ -66,5 +69,6 @@ public struct ClientConfiguration: Codable {
         self.savePhotosLocallyEnabled = savePhotosLocallyEnabled
         self.alreadyPaidHintEnabled = alreadyPaidHintEnabled
         self.paymentDueHintEnabled = paymentDueHintEnabled
+        self.unsupportedQRCodeWarningEnabled = unsupportedQRCodeWarningEnabled
     }
 }

--- a/BankAPILibrary/GiniBankAPILibrary/Sources/GiniBankAPILibrary/Documents/Configuration/ClientConfiguration.swift
+++ b/BankAPILibrary/GiniBankAPILibrary/Sources/GiniBankAPILibrary/Documents/Configuration/ClientConfiguration.swift
@@ -57,7 +57,7 @@ public struct ClientConfiguration: Codable {
                 savePhotosLocallyEnabled: Bool,
                 alreadyPaidHintEnabled: Bool,
                 paymentDueHintEnabled: Bool,
-                unsupportedQRCodeWarningEnabled: Bool = false) {
+                unsupportedQRCodeWarningEnabled: Bool) {
         self.clientID = clientID
         self.userJourneyAnalyticsEnabled = userJourneyAnalyticsEnabled
         self.skontoEnabled = skontoEnabled

--- a/BankAPILibrary/GiniBankAPILibrary/Tests/GiniBankAPILibraryTests/ClientConfigurationTests.swift
+++ b/BankAPILibrary/GiniBankAPILibrary/Tests/GiniBankAPILibraryTests/ClientConfigurationTests.swift
@@ -26,7 +26,8 @@ struct ClientConfigurationTests {
                                          eInvoiceEnabled: true,
                                          savePhotosLocallyEnabled: true,
                                          alreadyPaidHintEnabled: true,
-                                         paymentDueHintEnabled: true)
+                                         paymentDueHintEnabled: true,
+                                         unsupportedQRCodeWarningEnabled: true)
 
         #expect(config.clientID == testClientID, "Expected clientID to be \(testClientID)")
         #expect(config.userJourneyAnalyticsEnabled, "Expected userJourneyAnalyticsEnabled to be true")
@@ -38,6 +39,7 @@ struct ClientConfigurationTests {
         #expect(config.eInvoiceEnabled, "Expected eInvoiceEnabled to be true")
         #expect(config.alreadyPaidHintEnabled, "Expected alreadyPaidHintEnabled to be true")
         #expect(config.savePhotosLocallyEnabled, "Expected savePhotosLocallyEnabled to be true")
+        #expect(config.unsupportedQRCodeWarningEnabled, "Expected unsupportedQRCodeWarningEnabled to be true")
     }
 
     @Test("Initialization with all flags disabled")
@@ -52,9 +54,8 @@ struct ClientConfigurationTests {
                                          eInvoiceEnabled: false,
                                          savePhotosLocallyEnabled: false,
                                          alreadyPaidHintEnabled: false,
-                                         paymentDueHintEnabled: false)
-
-        
+                                         paymentDueHintEnabled: false,
+                                         unsupportedQRCodeWarningEnabled: false)
 
         #expect(config.clientID == testClientID, "Expected clientID to be \(testClientID)")
         #expect(!config.userJourneyAnalyticsEnabled, "Expected userJourneyAnalyticsEnabled to be false")
@@ -66,6 +67,7 @@ struct ClientConfigurationTests {
         #expect(!config.eInvoiceEnabled, "Expected eInvoiceEnabled to be false")
         #expect(!config.alreadyPaidHintEnabled, "Expected alreadyPaidHintEnabled to be false")
         #expect(!config.savePhotosLocallyEnabled, "Expected savePhotosLocallyEnabled to be false")
+        #expect(!config.unsupportedQRCodeWarningEnabled, "Expected unsupportedQRCodeWarningEnabled to be false")
     }
 
     // MARK: - JSON Decoding Tests
@@ -87,6 +89,7 @@ struct ClientConfigurationTests {
         #expect(!config.eInvoiceEnabled, "Expected eInvoiceEnabled to be false from JSON")
         #expect(!config.alreadyPaidHintEnabled, "Expected alreadyPaidHintEnabled to be false from JSON")
         #expect(!config.savePhotosLocallyEnabled, "Expected savePhotosLocallyEnabled to be false from JSON")
+        #expect(!config.unsupportedQRCodeWarningEnabled, "Expected unsupportedQRCodeWarningEnabled to be false from JSON")
     }
 
     @Test("Decoding fails when missing required clientID field")
@@ -113,7 +116,8 @@ struct ClientConfigurationTests {
                                          eInvoiceEnabled: true,
                                          savePhotosLocallyEnabled: true,
                                          alreadyPaidHintEnabled: true,
-                                         paymentDueHintEnabled: true)
+                                         paymentDueHintEnabled: true,
+                                         unsupportedQRCodeWarningEnabled: true)
 
         let encoder = JSONEncoder()
 
@@ -140,6 +144,8 @@ struct ClientConfigurationTests {
                 "Expected alreadyPaidHintEnabled to be preserved")
         #expect(decodedConfig.savePhotosLocallyEnabled == config.savePhotosLocallyEnabled,
                 "Expected savePhotosLocallyEnabled to be preserved")
+        #expect(decodedConfig.unsupportedQRCodeWarningEnabled == config.unsupportedQRCodeWarningEnabled,
+                "Expected unsupportedQRCodeWarningEnabled to be preserved")
     }
 
     // MARK: - Property Combinations Tests
@@ -156,7 +162,8 @@ struct ClientConfigurationTests {
                                          eInvoiceEnabled: false,
                                          savePhotosLocallyEnabled: false,
                                          alreadyPaidHintEnabled: true,
-                                         paymentDueHintEnabled: true)
+                                         paymentDueHintEnabled: true,
+                                         unsupportedQRCodeWarningEnabled: true)
 
         #expect(config.userJourneyAnalyticsEnabled, "Expected userJourneyAnalyticsEnabled to be true")
         #expect(!config.skontoEnabled, "Expected skontoEnabled to be false")
@@ -167,5 +174,6 @@ struct ClientConfigurationTests {
         #expect(!config.eInvoiceEnabled, "Expected eInvoiceEnabled to be false")
         #expect(config.alreadyPaidHintEnabled, "Expected alreadyPaidHintEnabled to be true")
         #expect(!config.savePhotosLocallyEnabled, "Expected savePhotosLocallyEnabled to be false")
+        #expect(config.unsupportedQRCodeWarningEnabled, "Expected unsupportedQRCodeWarningEnabled to be true")
     }
 }

--- a/BankAPILibrary/GiniBankAPILibrary/Tests/GiniBankAPILibraryTests/Resources/clientConfiguration.json
+++ b/BankAPILibrary/GiniBankAPILibrary/Tests/GiniBankAPILibraryTests/Resources/clientConfiguration.json
@@ -9,5 +9,6 @@
     "eInvoiceEnabled": false,
     "savePhotosLocallyEnabled": false,
     "alreadyPaidHintEnabled": false,
-    "paymentDueHintEnabled": false
+    "paymentDueHintEnabled": false,
+    "unsupportedQRCodeWarningEnabled": false
 }

--- a/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/GiniBankNetworkingScreenApiCoordinator.swift
+++ b/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/GiniBankNetworkingScreenApiCoordinator.swift
@@ -306,7 +306,8 @@ open class GiniBankNetworkingScreenApiCoordinator: GiniScreenAPICoordinator, Gin
                     GiniCaptureUserDefaultsStorage.qrCodeEducationEnabled = configuration.qrCodeEducationEnabled
                     GiniCaptureUserDefaultsStorage.eInvoiceEnabled = configuration.eInvoiceEnabled
                     GiniCaptureUserDefaultsStorage.savePhotosLocallyEnabled = configuration.savePhotosLocallyEnabled
-                    GiniCaptureUserDefaultsStorage.unsupportedQRCodeWarningEnabled = configuration.unsupportedQRCodeWarningEnabled
+                    GiniCaptureUserDefaultsStorage.unsupportedQRCodeWarningEnabled =
+                        configuration.unsupportedQRCodeWarningEnabled
                     self.initializeAnalytics(with: configuration)
                 }
             case .failure(let error):

--- a/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/GiniBankNetworkingScreenApiCoordinator.swift
+++ b/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/GiniBankNetworkingScreenApiCoordinator.swift
@@ -306,6 +306,7 @@ open class GiniBankNetworkingScreenApiCoordinator: GiniScreenAPICoordinator, Gin
                     GiniCaptureUserDefaultsStorage.qrCodeEducationEnabled = configuration.qrCodeEducationEnabled
                     GiniCaptureUserDefaultsStorage.eInvoiceEnabled = configuration.eInvoiceEnabled
                     GiniCaptureUserDefaultsStorage.savePhotosLocallyEnabled = configuration.savePhotosLocallyEnabled
+                    GiniCaptureUserDefaultsStorage.unsupportedQRCodeWarningEnabled = configuration.unsupportedQRCodeWarningEnabled
                     self.initializeAnalytics(with: configuration)
                 }
             case .failure(let error):

--- a/BankSDK/GiniBankSDK/Tests/GiniBankSDKTests/Helpers/CameraMock.swift
+++ b/BankSDK/GiniBankSDK/Tests/GiniBankSDKTests/Helpers/CameraMock.swift
@@ -56,7 +56,7 @@ final class CameraMock: CameraProtocol {
         // This method will remain empty; no implementation is needed.
     }
     
-    func setup(completion: ((CameraError?) -> Void)) {
+    func setup(completion: @escaping ((CameraError?) -> Void)) {
         switch state {
         case .authorized:
             completion(nil)
@@ -74,6 +74,14 @@ final class CameraMock: CameraProtocol {
     }
     
     func stop() {
+        // This method will remain empty; no implementation is needed.
+    }
+
+    func pauseQRDetection() {
+        // This method will remain empty; no implementation is needed.
+    }
+
+    func resumeQRDetection() {
         // This method will remain empty; no implementation is needed.
     }
 }

--- a/BankSDK/GiniBankSDK/Tests/GiniBankSDKTests/NetworkingScreenApiCoordinatorTests.swift
+++ b/BankSDK/GiniBankSDK/Tests/GiniBankSDKTests/NetworkingScreenApiCoordinatorTests.swift
@@ -362,6 +362,7 @@ extension ClientConfiguration {
                   eInvoiceEnabled: false,
                   savePhotosLocallyEnabled: false,
                   alreadyPaidHintEnabled: alreadyPaidHintEnabled,
-                  paymentDueHintEnabled: paymentDueHintEnabled)
+                  paymentDueHintEnabled: paymentDueHintEnabled,
+                  unsupportedQRCodeWarningEnabled: false)
     }
 }

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Camera/Camera.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Camera/Camera.swift
@@ -296,11 +296,13 @@ final class Camera: NSObject, CameraProtocol {
         }
     }
 
+    #if DEBUG
     // Intended for unit tests only — injects a metadata output without going
     // through full session setup, which is unstable on CI simulators.
     func setQRMetadataOutputForTesting(_ output: AVCaptureMetadataOutput?) {
         qrMetadataOutput = output
     }
+    #endif
 }
 
 // MARK: - Fileprivate

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Camera/Camera.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Camera/Camera.swift
@@ -77,7 +77,7 @@ final class Camera: NSObject, CameraProtocol {
     fileprivate let application: UIApplication
 
     // QR detection
-    private var qrMetadataOutput: AVCaptureMetadataOutput?
+    private(set) var qrMetadataOutput: AVCaptureMetadataOutput?
 
     // IBAN detection
     private var request: VNImageBasedRequest?
@@ -294,6 +294,12 @@ final class Camera: NSObject, CameraProtocol {
                   output.availableMetadataObjectTypes.contains(.qr) else { return }
             output.metadataObjectTypes = [.qr]
         }
+    }
+
+    // Intended for unit tests only — injects a metadata output without going
+    // through full session setup, which is unstable on CI simulators.
+    func setQRMetadataOutputForTesting(_ output: AVCaptureMetadataOutput?) {
+        qrMetadataOutput = output
     }
 }
 

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Camera/Camera.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Camera/Camera.swift
@@ -33,6 +33,8 @@ protocol CameraProtocol: AnyObject {
     func setupQRScanningOutput(completion: @escaping ((CameraError?) -> Void))
     func start()
     func stop()
+    func pauseQRDetection()
+    func resumeQRDetection()
 
     // IBAN detection
     func startOCR()

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Camera/Camera.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Camera/Camera.swift
@@ -76,6 +76,9 @@ final class Camera: NSObject, CameraProtocol {
 
     fileprivate let application: UIApplication
 
+    // QR detection
+    private var qrMetadataOutput: AVCaptureMetadataOutput?
+
     // IBAN detection
     private var request: VNImageBasedRequest?
     private var textOrientation = CGImagePropertyOrientation.up
@@ -274,7 +277,23 @@ final class Camera: NSObject, CameraProtocol {
         if qrOutput.availableMetadataObjectTypes.contains(.qr) {
             qrOutput.metadataObjectTypes = [.qr]
         }
+        qrMetadataOutput = qrOutput
         session.commitConfiguration()
+    }
+
+    func pauseQRDetection() {
+        sessionQueue.async { [weak self] in
+            self?.qrMetadataOutput?.metadataObjectTypes = []
+        }
+    }
+
+    func resumeQRDetection() {
+        sessionQueue.async { [weak self] in
+            guard let self = self,
+                  let output = self.qrMetadataOutput,
+                  output.availableMetadataObjectTypes.contains(.qr) else { return }
+            output.metadataObjectTypes = [.qr]
+        }
     }
 }
 

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Camera/Camera/CameraViewController.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Camera/Camera/CameraViewController.swift
@@ -677,13 +677,13 @@ final class CameraViewController: UIViewController {
         sendGiniAnalyticsEventForInvalidQRCode()
         playVoiceOverMessage(success: false)
 
-        let alert = UIAlertController(title: "This is not a payment QR code",
+        let alert = UIAlertController(title: Strings.unsupportedQRAlertTitle,
                                       message: nil,
                                       preferredStyle: .alert)
-        alert.addAction(UIAlertAction(title: "Scan another QR code", style: .default) { [weak self] _ in
+        alert.addAction(UIAlertAction(title: Strings.scanAnotherQRCode, style: .default) { [weak self] _ in
             self?.handleScanAnotherQRCode()
         })
-        alert.addAction(UIAlertAction(title: "Take photo of document", style: .default) { [weak self] _ in
+        alert.addAction(UIAlertAction(title: Strings.takePhotoOfDocument, style: .default) { [weak self] _ in
             self?.handleTakePhotoOfDocument()
         })
 
@@ -828,6 +828,21 @@ private extension CameraViewController {
                                                                    comment: "Info label")
         static let cameraTitle = NSLocalizedStringPreferredFormat("ginicapture.navigationbar.camera.title",
                                                                   comment: "Camera title")
+
+        static let unsupportedQRAlertTitleKey = "ginicapture.QRscanning.alert.title"
+        static let unsupportedQRAlertTitleComment = "Unsupported QR code alert title"
+        static let unsupportedQRAlertTitle = NSLocalizedStringPreferredFormat(unsupportedQRAlertTitleKey,
+                                                                              comment: unsupportedQRAlertTitleComment)
+
+        static let scanAnotherQRCodeKey = "ginicapture.QRscanning.alert.scanAnother"
+        static let scanAnotherQRCodeComment = "Scan another QR code button"
+        static let scanAnotherQRCode = NSLocalizedStringPreferredFormat(scanAnotherQRCodeKey,
+                                                                        comment: scanAnotherQRCodeComment)
+
+        static let takePhotoOfDocumentKey = "ginicapture.QRscanning.alert.takePhoto"
+        static let takePhotoOfDocumentComment = "Take photo of document button"
+        static let takePhotoOfDocument = NSLocalizedStringPreferredFormat(takePhotoOfDocumentKey,
+                                                                          comment: takePhotoOfDocumentComment)
     }
 }
 // swiftlint:enable type_body_length

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Camera/Camera/CameraViewController.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Camera/Camera/CameraViewController.swift
@@ -46,6 +46,10 @@ final class CameraViewController: UIViewController {
     private var isPresentedOnScreen = false
 
     private var isValidIBANDetected: Bool = false
+    // Snapshot of the backend flag taken on the first invalid QR scan.
+    // Stays fixed for the session so all repeated scans show the same feedback type.
+    private var sessionUnsupportedQRCodeWarningEnabled: Bool?
+    private var isWarningFlagSnapshotted = false
     // Analytics
     private var invalidQRCodeOverlayFirstAppearance: Bool = true
     private var ibanOverlayFirstAppearance: Bool = true
@@ -600,12 +604,18 @@ final class CameraViewController: UIViewController {
             DispatchQueue.main.asyncAfter(deadline: .now() + 1.5, execute: hideQRCodeTask!)
         } else {
             if !isValidIBANDetected {
-                if GiniCaptureUserDefaultsStorage.unsupportedQRCodeWarningEnabled == true {
-                    // Backend flag enabled: show the new unsupported QR code warning alert.
-                    // QR detection is paused inside the alert and resumed/kept paused based on user action.
+                // Snapshot the flag once so the feedback type stays consistent across
+                // repeated scans in the same session. A separate boolean guards the snapshot
+                // because assigning nil to a Bool? still leaves it nil, making a nil-check
+                // unreliable as a "has snapshotted" gate.
+                if !isWarningFlagSnapshotted {
+                    sessionUnsupportedQRCodeWarningEnabled = GiniCaptureUserDefaultsStorage.unsupportedQRCodeWarningEnabled
+                    isWarningFlagSnapshotted = true
+                }
+
+                if sessionUnsupportedQRCodeWarningEnabled == true {
                     showUnsupportedQRCodeAlert()
                 } else {
-                    // Backend flag disabled: show the existing yellow QR code overlay (legacy behavior).
                     showInvalidQRCodeFeedback()
                     hideQRCodeTask = DispatchWorkItem(block: {
                         self.resetQRCodeScanning(isValid: false)

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Camera/Camera/CameraViewController.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Camera/Camera/CameraViewController.swift
@@ -49,7 +49,7 @@ final class CameraViewController: UIViewController {
     // Snapshot of the backend flag taken on the first invalid QR scan.
     // Stays fixed for the session so all repeated scans show the same feedback type.
     private var sessionUnsupportedQRCodeWarningEnabled: Bool?
-    private var isWarningFlagSnapshotted = false
+    private var didCaptureSessionUnsupportedQRCodeWarning = false
     // Analytics
     private var invalidQRCodeOverlayFirstAppearance: Bool = true
     private var ibanOverlayFirstAppearance: Bool = true
@@ -609,13 +609,11 @@ final class CameraViewController: UIViewController {
     private func handleInvalidQRCode() {
         guard !isValidIBANDetected else { return }
 
-        // Snapshot the flag once so the feedback type stays consistent across
-        // repeated scans in the same session. A separate boolean guards the snapshot
-        // because assigning nil to a Bool? still leaves it nil, making a nil-check
-        // unreliable as a "has snapshotted" gate.
-        if !isWarningFlagSnapshotted {
+        // A separate Bool gates the capture because nil on Bool? is a legitimate
+        // captured value — nil-check alone can't tell "not captured yet" from "captured as nil".
+        if !didCaptureSessionUnsupportedQRCodeWarning {
             sessionUnsupportedQRCodeWarningEnabled = GiniCaptureUserDefaultsStorage.unsupportedQRCodeWarningEnabled
-            isWarningFlagSnapshotted = true
+            didCaptureSessionUnsupportedQRCodeWarning = true
         }
 
         if sessionUnsupportedQRCodeWarningEnabled == true {
@@ -735,9 +733,10 @@ final class CameraViewController: UIViewController {
     }
 
     private func resetQRCodeScanning(isValid: Bool) {
-        resetQRCodeTask = DispatchWorkItem(block: {
+        let task = DispatchWorkItem(block: {
             self.detectedQRCodeDocument = nil
         })
+        resetQRCodeTask = task
 
         if isValid {
             cameraPreviewViewController.cameraFrameView.isHidden = true
@@ -750,7 +749,7 @@ final class CameraViewController: UIViewController {
                 self.cameraPaneHorizontal?.isUserInteractionEnabled = true
             }
 
-            DispatchQueue.main.asyncAfter(deadline: .now() + Constants.resetQRCodeDelay, execute: resetQRCodeTask!)
+            DispatchQueue.main.asyncAfter(deadline: .now() + Constants.resetQRCodeDelay, execute: task)
         }
     }
 }

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Camera/Camera/CameraViewController.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Camera/Camera/CameraViewController.swift
@@ -739,14 +739,14 @@ final class CameraViewController: UIViewController {
             cameraPreviewViewController.cameraFrameView.isHidden = true
             qrCodeOverLay.showAnimation()
         } else {
-            UIView.animate(withDuration: 0.3) {
+            UIView.animate(withDuration: Constants.qrResetAnimationDuration) {
                 self.cameraPreviewViewController.changeQRFrameColor(to: .GiniCapture.light1)
                 self.qrCodeOverLay.isHidden = true
                 self.cameraPane.isUserInteractionEnabled = true
                 self.cameraPaneHorizontal?.isUserInteractionEnabled = true
             }
 
-            DispatchQueue.main.asyncAfter(deadline: .now() + 1, execute: resetQRCodeTask!)
+            DispatchQueue.main.asyncAfter(deadline: .now() + Constants.resetQRCodeDelay, execute: resetQRCodeTask!)
         }
     }
 }
@@ -823,6 +823,8 @@ private extension CameraViewController {
         static let phoneSwitcherSize: CGSize = CGSize(width: 124, height: 40)
         static let tableSwitcherSize: CGSize = CGSize(width: 40, height: 124)
         static let hideQRCodeDelay: TimeInterval = 1.5
+        static let resetQRCodeDelay: TimeInterval = 1
+        static let qrResetAnimationDuration: TimeInterval = 0.3
     }
 
     private struct Strings {

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Camera/Camera/CameraViewController.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Camera/Camera/CameraViewController.swift
@@ -594,14 +594,15 @@ final class CameraViewController: UIViewController {
         detectedQRCodeDocument = document
 
         if isValid {
-            hideQRCodeTask = DispatchWorkItem(block: {
+            let task = DispatchWorkItem(block: {
                 self.resetQRCodeScanning(isValid: true)
                 if let QRDocument = self.detectedQRCodeDocument {
                     self.didPick(QRDocument)
                 }
             })
+            hideQRCodeTask = task
             showValidQRCodeFeedback()
-            DispatchQueue.main.asyncAfter(deadline: .now() + 1.5, execute: hideQRCodeTask!)
+            DispatchQueue.main.asyncAfter(deadline: .now() + Constants.hideQRCodeDelay, execute: task)
         } else {
             if !isValidIBANDetected {
                 // Snapshot the flag once so the feedback type stays consistent across
@@ -617,10 +618,11 @@ final class CameraViewController: UIViewController {
                     showUnsupportedQRCodeAlert()
                 } else {
                     showInvalidQRCodeFeedback()
-                    hideQRCodeTask = DispatchWorkItem(block: {
+                    let task = DispatchWorkItem(block: {
                         self.resetQRCodeScanning(isValid: false)
                     })
-                    DispatchQueue.main.asyncAfter(deadline: .now() + 1.5, execute: hideQRCodeTask!)
+                    hideQRCodeTask = task
+                    DispatchQueue.main.asyncAfter(deadline: .now() + Constants.hideQRCodeDelay, execute: task)
                 }
             }
         }
@@ -817,6 +819,7 @@ private extension CameraViewController {
         static let switcherPadding: CGFloat = 8
         static let phoneSwitcherSize: CGSize = CGSize(width: 124, height: 40)
         static let tableSwitcherSize: CGSize = CGSize(width: 40, height: 124)
+        static let hideQRCodeDelay: TimeInterval = 1.5
     }
 
     private struct Strings {

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Camera/Camera/CameraViewController.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Camera/Camera/CameraViewController.swift
@@ -651,6 +651,39 @@ final class CameraViewController: UIViewController {
         qrCodeOverLay.configureQrCodeOverlay(withCorrectQrCode: false)
     }
 
+    private func showUnsupportedQRCodeAlert() {
+        let generator = UINotificationFeedbackGenerator()
+        generator.notificationOccurred(.warning)
+
+        cameraPreviewViewController.camera.pauseQRDetection()
+
+        sendGiniAnalyticsEventForInvalidQRCode()
+        playVoiceOverMessage(success: false)
+
+        let alert = UIAlertController(title: "This is not a payment QR code",
+                                      message: nil,
+                                      preferredStyle: .alert)
+        alert.addAction(UIAlertAction(title: "Scan another QR code", style: .default) { [weak self] _ in
+            self?.handleScanAnotherQRCode()
+        })
+        alert.addAction(UIAlertAction(title: "Take photo of document", style: .default) { [weak self] _ in
+            self?.handleTakePhotoOfDocument()
+        })
+
+        present(alert, animated: true)
+    }
+
+    private func handleScanAnotherQRCode() {
+        cameraPreviewViewController.camera.resumeQRDetection()
+        detectedQRCodeDocument = nil
+    }
+
+    private func handleTakePhotoOfDocument() {
+        // QR detection stays paused — resuming here would immediately re-trigger the alert
+        cameraPreviewViewController.cameraFrameView.isHidden = false
+        detectedQRCodeDocument = nil
+    }
+
     private func isAccessibilityLargeTextEnabled() -> Bool {
         let contentSizeCategory = UIApplication.shared.preferredContentSizeCategory
         return contentSizeCategory.isAccessibilityCategory

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Camera/Camera/CameraViewController.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Camera/Camera/CameraViewController.swift
@@ -594,15 +594,13 @@ final class CameraViewController: UIViewController {
         detectedQRCodeDocument = document
 
         if isValid {
-            let task = DispatchWorkItem(block: {
+            showValidQRCodeFeedback()
+            scheduleHideQRCodeTask {
                 self.resetQRCodeScanning(isValid: true)
                 if let QRDocument = self.detectedQRCodeDocument {
                     self.didPick(QRDocument)
                 }
-            })
-            hideQRCodeTask = task
-            showValidQRCodeFeedback()
-            DispatchQueue.main.asyncAfter(deadline: .now() + Constants.hideQRCodeDelay, execute: task)
+            }
         } else {
             if !isValidIBANDetected {
                 // Snapshot the flag once so the feedback type stays consistent across
@@ -618,11 +616,9 @@ final class CameraViewController: UIViewController {
                     showUnsupportedQRCodeAlert()
                 } else {
                     showInvalidQRCodeFeedback()
-                    let task = DispatchWorkItem(block: {
+                    scheduleHideQRCodeTask {
                         self.resetQRCodeScanning(isValid: false)
-                    })
-                    hideQRCodeTask = task
-                    DispatchQueue.main.asyncAfter(deadline: .now() + Constants.hideQRCodeDelay, execute: task)
+                    }
                 }
             }
         }
@@ -726,6 +722,12 @@ final class CameraViewController: UIViewController {
                                    screenName: .camera,
                                    properties: [GiniAnalyticsProperty(key: .qrCodeValid, value: false)])
         invalidQRCodeOverlayFirstAppearance = false
+    }
+
+    private func scheduleHideQRCodeTask(_ work: @escaping () -> Void) {
+        let task = DispatchWorkItem(block: work)
+        hideQRCodeTask = task
+        DispatchQueue.main.asyncAfter(deadline: .now() + Constants.hideQRCodeDelay, execute: task)
     }
 
     private func resetQRCodeScanning(isValid: Bool) {

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Camera/Camera/CameraViewController.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Camera/Camera/CameraViewController.swift
@@ -675,9 +675,6 @@ final class CameraViewController: UIViewController {
         // are still queued before pauseQRDetection takes effect on the session queue.
         guard presentedViewController == nil else { return }
 
-        let generator = UINotificationFeedbackGenerator()
-        generator.notificationOccurred(.warning)
-
         cameraPreviewViewController.camera.pauseQRDetection()
 
         sendGiniAnalyticsEventForInvalidQRCode()

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Camera/Camera/CameraViewController.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Camera/Camera/CameraViewController.swift
@@ -671,6 +671,10 @@ final class CameraViewController: UIViewController {
     }
 
     private func showUnsupportedQRCodeAlert() {
+        // Skip duplicate side-effects when the alert is already on screen and more frames
+        // are still queued before pauseQRDetection takes effect on the session queue.
+        guard presentedViewController == nil else { return }
+
         let generator = UINotificationFeedbackGenerator()
         generator.notificationOccurred(.warning)
 

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Camera/Camera/CameraViewController.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Camera/Camera/CameraViewController.swift
@@ -589,24 +589,31 @@ final class CameraViewController: UIViewController {
         resetQRCodeTask?.cancel()
         detectedQRCodeDocument = document
 
-        hideQRCodeTask = DispatchWorkItem(block: {
-            self.resetQRCodeScanning(isValid: isValid)
-
-            if let QRDocument = self.detectedQRCodeDocument {
-                if isValid {
+        if isValid {
+            hideQRCodeTask = DispatchWorkItem(block: {
+                self.resetQRCodeScanning(isValid: true)
+                if let QRDocument = self.detectedQRCodeDocument {
                     self.didPick(QRDocument)
                 }
-            }
-        })
-
-        if isValid {
+            })
             showValidQRCodeFeedback()
+            DispatchQueue.main.asyncAfter(deadline: .now() + 1.5, execute: hideQRCodeTask!)
         } else {
             if !isValidIBANDetected {
-                showInvalidQRCodeFeedback()
+                if GiniCaptureUserDefaultsStorage.unsupportedQRCodeWarningEnabled == true {
+                    // Backend flag enabled: show the new unsupported QR code warning alert.
+                    // QR detection is paused inside the alert and resumed/kept paused based on user action.
+                    showUnsupportedQRCodeAlert()
+                } else {
+                    // Backend flag disabled: show the existing yellow QR code overlay (legacy behavior).
+                    showInvalidQRCodeFeedback()
+                    hideQRCodeTask = DispatchWorkItem(block: {
+                        self.resetQRCodeScanning(isValid: false)
+                    })
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 1.5, execute: hideQRCodeTask!)
+                }
             }
         }
-        DispatchQueue.main.asyncAfter(deadline: .now() + 1.5, execute: hideQRCodeTask!)
     }
 
     private func showValidQRCodeFeedback() {

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Camera/Camera/CameraViewController.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Camera/Camera/CameraViewController.swift
@@ -602,24 +602,28 @@ final class CameraViewController: UIViewController {
                 }
             }
         } else {
-            if !isValidIBANDetected {
-                // Snapshot the flag once so the feedback type stays consistent across
-                // repeated scans in the same session. A separate boolean guards the snapshot
-                // because assigning nil to a Bool? still leaves it nil, making a nil-check
-                // unreliable as a "has snapshotted" gate.
-                if !isWarningFlagSnapshotted {
-                    sessionUnsupportedQRCodeWarningEnabled = GiniCaptureUserDefaultsStorage.unsupportedQRCodeWarningEnabled
-                    isWarningFlagSnapshotted = true
-                }
+            handleInvalidQRCode()
+        }
+    }
 
-                if sessionUnsupportedQRCodeWarningEnabled == true {
-                    showUnsupportedQRCodeAlert()
-                } else {
-                    showInvalidQRCodeFeedback()
-                    scheduleHideQRCodeTask {
-                        self.resetQRCodeScanning(isValid: false)
-                    }
-                }
+    private func handleInvalidQRCode() {
+        guard !isValidIBANDetected else { return }
+
+        // Snapshot the flag once so the feedback type stays consistent across
+        // repeated scans in the same session. A separate boolean guards the snapshot
+        // because assigning nil to a Bool? still leaves it nil, making a nil-check
+        // unreliable as a "has snapshotted" gate.
+        if !isWarningFlagSnapshotted {
+            sessionUnsupportedQRCodeWarningEnabled = GiniCaptureUserDefaultsStorage.unsupportedQRCodeWarningEnabled
+            isWarningFlagSnapshotted = true
+        }
+
+        if sessionUnsupportedQRCodeWarningEnabled == true {
+            showUnsupportedQRCodeAlert()
+        } else {
+            showInvalidQRCodeFeedback()
+            scheduleHideQRCodeTask {
+                self.resetQRCodeScanning(isValid: false)
             }
         }
     }

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Camera/CameraPreviewViewController.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Camera/CameraPreviewViewController.swift
@@ -73,7 +73,7 @@ final class CameraPreviewViewController: UIViewController {
     private var notAuthorizedView: UIView?
     private let giniConfiguration: GiniConfiguration
     private typealias FocusIndicator = UIImageView
-    private var camera: CameraProtocol
+    var camera: CameraProtocol
     private var defaultImageView: UIImageView?
     private var focusIndicatorImageView: UIImageView?
 

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Camera/CameraPreviewViewController.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Camera/CameraPreviewViewController.swift
@@ -73,7 +73,7 @@ final class CameraPreviewViewController: UIViewController {
     private var notAuthorizedView: UIView?
     private let giniConfiguration: GiniConfiguration
     private typealias FocusIndicator = UIImageView
-    var camera: CameraProtocol
+    private(set) var camera: CameraProtocol
     private var defaultImageView: UIImageView?
     private var focusIndicatorImageView: UIImageView?
 

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Storage/GiniCaptureUserDefaultsStorage.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Storage/GiniCaptureUserDefaultsStorage.swift
@@ -32,6 +32,11 @@ public struct GiniCaptureUserDefaultsStorage {
                      defaultValue: nil)
     public static var savePhotosLocallyEnabled: Bool?
 
+    // Configuration flag for the unsupported QR code warning alert
+    @GiniUserDefault("ginicapture.defaults.clientConfigurations.unsupportedQRCodeWarningEnabled",
+                     defaultValue: nil)
+    public static var unsupportedQRCodeWarningEnabled: Bool?
+
     // User preference for the Save photos locally feature
     @GiniUserDefault("ginicapture.defaults.userSettings.savePhotosSwitchOn",
                      defaultValue: nil)

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Resources/de.lproj/Localizable.strings
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Resources/de.lproj/Localizable.strings
@@ -220,6 +220,9 @@
 "ginicapture.QRscanning.correct" = "QR-Code erkannt";
 "ginicapture.QRscanning.incorrect.title" = "Unbekannter QR-Code";
 "ginicapture.QRscanning.incorrect.description" = "Dieser Code enthält keine Zahlungsinformationen. Bitte anderen QR-Code oder Rechnung abfotografieren.";
+"ginicapture.QRscanning.alert.title" = "Dieser QR-Code ist kein Zahlungs-QR-Code";
+"ginicapture.QRscanning.alert.scanAnother" = "Anderen QR-Code scannen";
+"ginicapture.QRscanning.alert.takePhoto" = "Dokument fotografieren";
 "ginicapture.QRscanning.loading" = "Rechnung wird übermittelt";
 "ginicapture.QRscanning.education.loading.captureTip" = "Fotografieren Sie direkt ein Zahlungsformular oder eine Rechnung - auch ohne QR-Code";
 

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Resources/en.lproj/Localizable.strings
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Resources/en.lproj/Localizable.strings
@@ -217,6 +217,9 @@
 "ginicapture.QRscanning.correct" = "QR code detected";
 "ginicapture.QRscanning.incorrect.title" = "Unknown QR code";
 "ginicapture.QRscanning.incorrect.description" = "This code does not contain any payment details. Please use another QR code or take an image of your invoice.";
+"ginicapture.QRscanning.alert.title" = "This is not a payment QR code";
+"ginicapture.QRscanning.alert.scanAnother" = "Scan another QR code";
+"ginicapture.QRscanning.alert.takePhoto" = "Take photo of document";
 "ginicapture.QRscanning.loading" = "Retrieving invoice";
 "ginicapture.QRscanning.education.loading.captureTip" = "You can take photos of receipts or remittance slips – even without a QR code";
 

--- a/CaptureSDK/GiniCaptureSDK/Tests/GiniCaptureSDKTests/CameraMock.swift
+++ b/CaptureSDK/GiniCaptureSDK/Tests/GiniCaptureSDKTests/CameraMock.swift
@@ -10,6 +10,14 @@ import AVFoundation
 @testable import GiniCaptureSDK
 
 final class CameraMock: CameraProtocol {
+    func pauseQRDetection() {
+        // This method will remain empty; no implementation is needed.
+    }
+    
+    func resumeQRDetection() {
+        // This method will remain empty; no implementation is needed.
+    }
+    
     func setupIBANDetection(textOrientation: CGImagePropertyOrientation,
                             regionOfInterest: CGRect?,
                             videoPreviewLayer: AVCaptureVideoPreviewLayer?,
@@ -57,7 +65,7 @@ final class CameraMock: CameraProtocol {
         // This method will remain empty; no implementation is needed.
     }
     
-    func setup(completion: ((CameraError?) -> Void)) {
+    func setup(completion: @escaping ((CameraError?) -> Void)) {
         switch state {
         case .authorized:
             completion(nil)

--- a/CaptureSDK/GiniCaptureSDK/Tests/GiniCaptureSDKTests/CameraPreviewViewControllerTests.swift
+++ b/CaptureSDK/GiniCaptureSDK/Tests/GiniCaptureSDKTests/CameraPreviewViewControllerTests.swift
@@ -50,16 +50,9 @@ final class CameraPreviewViewControllerTests: XCTestCase {
         cameraPreviewViewController = CameraPreviewViewController(giniConfiguration: giniConfiguration)
         _ = cameraPreviewViewController.view
         let bottomAnchor = cameraPreviewViewController.view.bottomAnchor
+        // Verifies setupCamera does not crash when QR scanning is enabled.
+        // QR metadata output is configured separately via setupQRScanningOutput (called by CameraViewController).
         cameraPreviewViewController.setupCamera(bottomAnchor: bottomAnchor)
-        
-        DispatchQueue.main.async {
-            let metadataOutput = self.cameraPreviewViewController.previewView.session
-                .outputs
-                .compactMap { $0 as? AVCaptureMetadataOutput }
-                .first
-            
-            XCTAssertNotNil(metadataOutput, "the camera session should have the metadata output")
-        }
     }
     
     func testCaptureImage() {
@@ -106,46 +99,10 @@ final class CameraPreviewViewControllerTests: XCTestCase {
         wait(for: [expect], timeout: timeout)
     }
 
-    private func setupQROutput(on camera: Camera, timeout: TimeInterval = 2.0) {
-        let expect = expectation(description: "QR scanning output configured")
-        camera.setupQRScanningOutput { _ in
-            expect.fulfill()
-        }
-        wait(for: [expect], timeout: timeout)
-    }
-
-    private func metadataOutput(of camera: Camera) -> AVCaptureMetadataOutput? {
-        return camera.session.outputs.compactMap { $0 as? AVCaptureMetadataOutput }.first
-    }
-
-    func testPauseQRDetectionClearsMetadataObjectTypes() {
-        let camera = makeCamera()
-        setupQROutput(on: camera)
-
-        camera.pauseQRDetection()
-        flushSessionQueue(camera)
-
-        let output = metadataOutput(of: camera)
-        XCTAssertNotNil(output, "QR metadata output should exist after setupQRScanningOutput")
-        XCTAssertTrue(output?.metadataObjectTypes.isEmpty ?? false,
-                      "metadataObjectTypes should be empty after pauseQRDetection")
-    }
-
     func testPauseQRDetectionBeforeSetupDoesNotCrash() {
         let camera = makeCamera()
 
         camera.pauseQRDetection()
-        flushSessionQueue(camera)
-    }
-
-    func testResumeQRDetectionAfterPauseDoesNotCrash() {
-        let camera = makeCamera()
-        setupQROutput(on: camera)
-
-        camera.pauseQRDetection()
-        flushSessionQueue(camera)
-
-        camera.resumeQRDetection()
         flushSessionQueue(camera)
     }
 

--- a/CaptureSDK/GiniCaptureSDK/Tests/GiniCaptureSDKTests/CameraPreviewViewControllerTests.swift
+++ b/CaptureSDK/GiniCaptureSDK/Tests/GiniCaptureSDKTests/CameraPreviewViewControllerTests.swift
@@ -138,4 +138,16 @@ final class CameraPreviewViewControllerTests: XCTestCase {
         XCTAssertTrue(output.metadataObjectTypes.isEmpty,
                       "metadataObjectTypes should remain unchanged when .qr is unavailable")
     }
+
+    func testSetupQRScanningOutputAssignsMetadataOutput() {
+        let camera = makeCamera()
+
+        // Trigger setup but don't wait for the main-queue completion callback —
+        // just flush the serial sessionQueue, which runs after configureQROutput finishes.
+        camera.setupQRScanningOutput { _ in }
+        flushSessionQueue(camera, timeout: 10.0)
+
+        XCTAssertNotNil(camera.qrMetadataOutput,
+                        "qrMetadataOutput should be assigned after configureQROutput runs")
+    }
 }

--- a/CaptureSDK/GiniCaptureSDK/Tests/GiniCaptureSDKTests/CameraPreviewViewControllerTests.swift
+++ b/CaptureSDK/GiniCaptureSDK/Tests/GiniCaptureSDKTests/CameraPreviewViewControllerTests.swift
@@ -83,12 +83,76 @@ final class CameraPreviewViewControllerTests: XCTestCase {
         let defaultFlashState = camera.isFlashOn
         let giniConfiguration = GiniConfiguration()
         giniConfiguration.flashToggleEnabled = true
-        
+
         cameraPreviewViewController = CameraPreviewViewController(giniConfiguration: giniConfiguration,
                                                                   camera: camera)
         _ = cameraPreviewViewController.view
         cameraPreviewViewController.isFlashOn = false
-        
+
         XCTAssertNotEqual(defaultFlashState, camera.isFlashOn, "camera flash state should change it after toggle it")
+    }
+
+    // MARK: - QR Detection Pause/Resume
+
+    private func makeCamera() -> Camera {
+        return Camera(giniConfiguration: GiniConfiguration())
+    }
+
+    private func flushSessionQueue(_ camera: Camera, timeout: TimeInterval = 2.0) {
+        let expect = expectation(description: "session queue flushed")
+        camera.sessionQueue.async {
+            expect.fulfill()
+        }
+        wait(for: [expect], timeout: timeout)
+    }
+
+    private func setupQROutput(on camera: Camera, timeout: TimeInterval = 2.0) {
+        let expect = expectation(description: "QR scanning output configured")
+        camera.setupQRScanningOutput { _ in
+            expect.fulfill()
+        }
+        wait(for: [expect], timeout: timeout)
+    }
+
+    private func metadataOutput(of camera: Camera) -> AVCaptureMetadataOutput? {
+        return camera.session.outputs.compactMap { $0 as? AVCaptureMetadataOutput }.first
+    }
+
+    func testPauseQRDetectionClearsMetadataObjectTypes() {
+        let camera = makeCamera()
+        setupQROutput(on: camera)
+
+        camera.pauseQRDetection()
+        flushSessionQueue(camera)
+
+        let output = metadataOutput(of: camera)
+        XCTAssertNotNil(output, "QR metadata output should exist after setupQRScanningOutput")
+        XCTAssertTrue(output?.metadataObjectTypes.isEmpty ?? false,
+                      "metadataObjectTypes should be empty after pauseQRDetection")
+    }
+
+    func testPauseQRDetectionBeforeSetupDoesNotCrash() {
+        let camera = makeCamera()
+
+        camera.pauseQRDetection()
+        flushSessionQueue(camera)
+    }
+
+    func testResumeQRDetectionAfterPauseDoesNotCrash() {
+        let camera = makeCamera()
+        setupQROutput(on: camera)
+
+        camera.pauseQRDetection()
+        flushSessionQueue(camera)
+
+        camera.resumeQRDetection()
+        flushSessionQueue(camera)
+    }
+
+    func testResumeQRDetectionBeforeSetupDoesNotCrash() {
+        let camera = makeCamera()
+
+        camera.resumeQRDetection()
+        flushSessionQueue(camera)
     }
 }

--- a/CaptureSDK/GiniCaptureSDK/Tests/GiniCaptureSDKTests/CameraPreviewViewControllerTests.swift
+++ b/CaptureSDK/GiniCaptureSDK/Tests/GiniCaptureSDKTests/CameraPreviewViewControllerTests.swift
@@ -150,4 +150,31 @@ final class CameraPreviewViewControllerTests: XCTestCase {
         XCTAssertNotNil(camera.qrMetadataOutput,
                         "qrMetadataOutput should be assigned after configureQROutput runs")
     }
+
+    func testResumeQRDetectionEnablesQRTypeWhenAvailable() {
+        let camera = makeCamera()
+        let output = FakeQRAvailableMetadataOutput()
+        camera.setQRMetadataOutputForTesting(output)
+
+        camera.resumeQRDetection()
+        flushSessionQueue(camera)
+
+        XCTAssertEqual(output.metadataObjectTypes, [.qr],
+                       "metadataObjectTypes should be set to [.qr] when .qr is available")
+    }
+}
+
+// Test stub that pretends .qr is supported, allowing the `availableMetadataObjectTypes.contains(.qr)`
+// guard branch in resumeQRDetection to be exercised on CI simulators (which have no real camera).
+private final class FakeQRAvailableMetadataOutput: AVCaptureMetadataOutput {
+    private var _objectTypes: [AVMetadataObject.ObjectType]? = []
+
+    override var availableMetadataObjectTypes: [AVMetadataObject.ObjectType] {
+        return [.qr]
+    }
+
+    override var metadataObjectTypes: [AVMetadataObject.ObjectType]! {
+        get { _objectTypes }
+        set { _objectTypes = newValue }
+    }
 }

--- a/CaptureSDK/GiniCaptureSDK/Tests/GiniCaptureSDKTests/CameraPreviewViewControllerTests.swift
+++ b/CaptureSDK/GiniCaptureSDK/Tests/GiniCaptureSDKTests/CameraPreviewViewControllerTests.swift
@@ -112,4 +112,30 @@ final class CameraPreviewViewControllerTests: XCTestCase {
         camera.resumeQRDetection()
         flushSessionQueue(camera)
     }
+
+    func testPauseQRDetectionClearsMetadataObjectTypes() {
+        let camera = makeCamera()
+        let output = AVCaptureMetadataOutput()
+        camera.setQRMetadataOutputForTesting(output)
+
+        camera.pauseQRDetection()
+        flushSessionQueue(camera)
+
+        XCTAssertTrue(output.metadataObjectTypes.isEmpty,
+                      "metadataObjectTypes should be empty after pauseQRDetection")
+    }
+
+    func testResumeQRDetectionGuardsAgainstUnavailableQRType() {
+        let camera = makeCamera()
+        let output = AVCaptureMetadataOutput()
+        camera.setQRMetadataOutputForTesting(output)
+
+        camera.resumeQRDetection()
+        flushSessionQueue(camera)
+
+        // On CI simulators .qr is not in availableMetadataObjectTypes, so the guard
+        // returns and metadataObjectTypes stays at its default (empty).
+        XCTAssertTrue(output.metadataObjectTypes.isEmpty,
+                      "metadataObjectTypes should remain unchanged when .qr is unavailable")
+    }
 }

--- a/CaptureSDK/GiniCaptureSDK/Tests/GiniCaptureSDKTests/CameraPreviewViewControllerTests.swift
+++ b/CaptureSDK/GiniCaptureSDK/Tests/GiniCaptureSDKTests/CameraPreviewViewControllerTests.swift
@@ -91,7 +91,7 @@ final class CameraPreviewViewControllerTests: XCTestCase {
         return Camera(giniConfiguration: GiniConfiguration())
     }
 
-    private func flushSessionQueue(_ camera: Camera, timeout: TimeInterval = 2.0) {
+    private func cleanSessionQueue(_ camera: Camera, timeout: TimeInterval = 2.0) {
         let expect = expectation(description: "session queue flushed")
         camera.sessionQueue.async {
             expect.fulfill()
@@ -103,14 +103,14 @@ final class CameraPreviewViewControllerTests: XCTestCase {
         let camera = makeCamera()
 
         camera.pauseQRDetection()
-        flushSessionQueue(camera)
+        cleanSessionQueue(camera)
     }
 
     func testResumeQRDetectionBeforeSetupDoesNotCrash() {
         let camera = makeCamera()
 
         camera.resumeQRDetection()
-        flushSessionQueue(camera)
+        cleanSessionQueue(camera)
     }
 
     func testPauseQRDetectionClearsMetadataObjectTypes() {
@@ -119,7 +119,7 @@ final class CameraPreviewViewControllerTests: XCTestCase {
         camera.setQRMetadataOutputForTesting(output)
 
         camera.pauseQRDetection()
-        flushSessionQueue(camera)
+        cleanSessionQueue(camera)
 
         XCTAssertTrue(output.metadataObjectTypes.isEmpty,
                       "metadataObjectTypes should be empty after pauseQRDetection")
@@ -131,7 +131,7 @@ final class CameraPreviewViewControllerTests: XCTestCase {
         camera.setQRMetadataOutputForTesting(output)
 
         camera.resumeQRDetection()
-        flushSessionQueue(camera)
+        cleanSessionQueue(camera)
 
         // On CI simulators .qr is not in availableMetadataObjectTypes, so the guard
         // returns and metadataObjectTypes stays at its default (empty).
@@ -145,7 +145,7 @@ final class CameraPreviewViewControllerTests: XCTestCase {
         // Trigger setup but don't wait for the main-queue completion callback —
         // just flush the serial sessionQueue, which runs after configureQROutput finishes.
         camera.setupQRScanningOutput { _ in }
-        flushSessionQueue(camera, timeout: 10.0)
+        cleanSessionQueue(camera, timeout: 10.0)
 
         XCTAssertNotNil(camera.qrMetadataOutput,
                         "qrMetadataOutput should be assigned after configureQROutput runs")
@@ -157,7 +157,7 @@ final class CameraPreviewViewControllerTests: XCTestCase {
         camera.setQRMetadataOutputForTesting(output)
 
         camera.resumeQRDetection()
-        flushSessionQueue(camera)
+        cleanSessionQueue(camera)
 
         XCTAssertEqual(output.metadataObjectTypes, [.qr],
                        "metadataObjectTypes should be set to [.qr] when .qr is available")


### PR DESCRIPTION
## Pull Request Description

<!-- Briefly explain **what** this PR does and **why**. Mention the motivation, feature, or issue it's addressing. -->

[PP-2310](https://ginis.atlassian.net/browse/PP-2310)<!-- Closes ticket number PP-####; Replace with JIRA ticket if relevant -->

This PR introduces a new remote configuration flag (unsupportedQRCodeWarningEnabled) to change how invalid QR codes are handled in the Capture camera flow, showing an “unsupported payment QR code” alert (with actions) when enabled.
<!--

Some description of HOW you achieved it. Perhaps give a high level description of the chnages you did. Did you need to refactor something? What tradeoffs did you take?

-->

## Notes for Reviewers

- Add unsupportedQRCodeWarningEnabled to ClientConfiguration (API + JSON test fixtures) and propagate it into GiniCaptureUserDefaultsStorage.
- Update camera QR handling to optionally present an alert for unsupported QR codes and temporarily pause/resume QR detection.
- Add new localized strings (EN/DE) for the alert title and actions.
<!--

Explain how you verified the changes.
A clear testing scenario helps colleagues who may not be familiar with this part of the code quickly understand and verify the changes. Include steps they can follow to see the impact in action.

You can include: 
- Simulators/Devices you used (e.g. iPhone 13, iPad Pro) 
- iOS versions tested (e.g. 16.0, 17.5) 
- Manual checks (e.g. flow tested: onboarding, permissions, error states) 
- Unit tests added or updated 
 
 Include screenshots, screen recordings, or simulator gifs for UI changes. 
 
 - Optional: Anything that needs extra attention in review? Are there TODOs, known limitations, or follow-up work? 
 
 -->

[PP-2310]: https://ginis.atlassian.net/browse/PP-2310?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ