### PR TITLE
fix(GiniCaptureSDK): Use safe area layout guide for QR banner top constraint

### DIFF
--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Camera/Views/QRCodeOverlay.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Camera/Views/QRCodeOverlay.swift
@@ -281,7 +281,7 @@ final class QRCodeOverlay: UIView {
         NSLayoutConstraint.activate([
             correctQRFeedback.centerXAnchor.constraint(equalTo: cameraFrame.centerXAnchor),
             correctQRCenterYAnchor,
-            correctQRFeedback.topAnchor.constraint(greaterThanOrEqualTo: viewController.view.topAnchor,
+            correctQRFeedback.topAnchor.constraint(greaterThanOrEqualTo: viewController.view.safeAreaLayoutGuide.topAnchor,
                                                    constant: Constants.topSpacing),
             correctQRFeedback.leadingAnchor.constraint(greaterThanOrEqualTo: leadingAnchor,
                                                        constant: Constants.expandedSpacing),


### PR DESCRIPTION
## Pull Request Description

<!-- Briefly explain **what** this PR does and **why**. Mention the motivation, feature, or issue it's addressing. -->

[PP-2560](https://ginis.atlassian.net/browse/PP-2560)<!-- Closes ticket number PP-####; Replace with JIRA ticket if relevant -->

<!--

Some description of HOW you achieved it. Perhaps give a high level description of the chnages you did. Did you need to refactor something? What tradeoffs did you take?

-->

The "QR-Code erkannt" banner was being rendered behind the navigation bar and getting cut off. The floor constraint for `correctQRFeedback` used `viewController.view.topAnchor` with only 2 pt of clearance — the raw top of the screen, which sits behind the navigation bar. Changing the anchor to `viewController.view.safeAreaLayoutGuide.topAnchor` ensures the banner always appears below the navigation bar.

One-line change in `QRCodeOverlay.layoutCorrectQRCode(centeringBy:on:)`.

## Notes for Reviewers

<!--

Explain how you verified the changes.
A clear testing scenario helps colleagues who may not be familiar with this part of the code quickly understand and verify the changes. Include steps they can follow to see the impact in action.

You can include: 
- Simulators/Devices you used (e.g. iPhone 13, iPad Pro) 
- iOS versions tested (e.g. 16.0, 17.5) 
- Manual checks (e.g. flow tested: onboarding, permissions, error states) 
- Unit tests added or updated 
 
 Include screenshots, screen recordings, or simulator gifs for UI changes. 
 
 - Optional: Anything that needs extra attention in review? Are there TODOs, known limitations, or follow-up work? 
 
 -->

To verify:
1. Run the BankSDK example app with QR code scanning enabled.
2. Point the camera at a valid QR code.
3. Confirm the green "QR-Code erkannt" banner appears fully visible below the navigation bar (not clipped behind it).

No unit tests added — this is a layout constraint fix with no logic change. No known limitations or follow-up work.

[PP-2560]: https://ginis.atlassian.net/browse/PP-2560?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ