### PR TITLE
feat(GiniHealthSDK): Add customizable navigation bar title to Payment Review Screen

### DIFF
--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/PaymentReviewConfiguration.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/PaymentReviewConfiguration.swift
@@ -66,6 +66,7 @@ public struct PaymentReviewStrings {
     public let closeButtonAccessibilityHint: String
     public let sheetGrabberAccessibilityLabel: String
     public let sheetGrabberAccessibilityHint: String
+    public let paymentReviewScreenTitle: String
 
     public init(alertOkButtonTitle: String,
                 infoBarMessage: String,
@@ -75,7 +76,8 @@ public struct PaymentReviewStrings {
                 closeButtonAccessibilityLabel: String,
                 closeButtonAccessibilityHint: String,
                 sheetGrabberAccessibilityLabel: String,
-                sheetGrabberAccessibilityHint: String) {
+                sheetGrabberAccessibilityHint: String,
+                paymentReviewScreenTitle: String) {
         self.alertOkButtonTitle = alertOkButtonTitle
         self.infoBarMessage = infoBarMessage
         self.defaultErrorMessage = defaultErrorMessage
@@ -85,5 +87,6 @@ public struct PaymentReviewStrings {
         self.closeButtonAccessibilityHint = closeButtonAccessibilityHint
         self.sheetGrabberAccessibilityLabel = sheetGrabberAccessibilityLabel
         self.sheetGrabberAccessibilityHint = sheetGrabberAccessibilityHint
+        self.paymentReviewScreenTitle = paymentReviewScreenTitle
     }
 }

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/PaymentReviewConfiguration.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/PaymentReviewConfiguration.swift
@@ -77,7 +77,7 @@ public struct PaymentReviewStrings {
                 closeButtonAccessibilityHint: String,
                 sheetGrabberAccessibilityLabel: String,
                 sheetGrabberAccessibilityHint: String,
-                paymentReviewScreenTitle: String) {
+                paymentReviewScreenTitle: String = "") {
         self.alertOkButtonTitle = alertOkButtonTitle
         self.infoBarMessage = infoBarMessage
         self.defaultErrorMessage = defaultErrorMessage

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/PaymentReviewViewController.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/PaymentReviewViewController.swift
@@ -58,17 +58,19 @@ public final class PaymentReviewViewController: UIHostingController<PaymentRevie
     }
     
     private func setupNavigationBar() {
-        guard model.showPaymentReviewCloseButton,
-              model.displayMode == .documentCollection else { return }
-        
+        guard model.displayMode == .documentCollection else { return }
+
+        navigationItem.title = model.strings.paymentReviewScreenTitle
+
+        guard model.showPaymentReviewCloseButton else { return }
+
         let closeImage = model.configuration.paymentReviewClose.withRenderingMode(.alwaysTemplate)
         let closeButton = UIBarButtonItem(image: closeImage,
                                           style: .plain,
                                           target: self,
                                           action: #selector(closeButtonTapped))
-        
         closeButton.accessibilityLabel = model.strings.closeButtonAccessibilityLabel
-        closeButton.accessibilityHint =  model.strings.closeButtonAccessibilityHint
+        closeButton.accessibilityHint = model.strings.closeButtonAccessibilityHint
         navigationItem.rightBarButtonItem = closeButton
     }
     

--- a/HealthSDK/GiniHealthSDK/Sources/GiniHealthSDK/Core/GiniHealth+PaymentComponentsStringsProvider.swift
+++ b/HealthSDK/GiniHealthSDK/Sources/GiniHealthSDK/Core/GiniHealth+PaymentComponentsStringsProvider.swift
@@ -185,7 +185,9 @@ extension GiniHealth: PaymentComponentsStringsProvider {
             sheetGrabberAccessibilityLabel: NSLocalizedStringPreferredFormat("gini.health.bottomSheet.grabber.accessibility.label",
                                                                              comment: "Sheet grabber accessibility label"),
             sheetGrabberAccessibilityHint: NSLocalizedStringPreferredFormat("gini.health.bottomSheet.grabber.accessibility.hint",
-                                                                            comment: "Sheet grabber accessibility hint text")
+                                                                            comment: "Sheet grabber accessibility hint text"),
+            paymentReviewScreenTitle: NSLocalizedStringPreferredFormat("gini.health.reviewscreen.title",
+                                                                       comment: "navigation bar title for payment review screen")
         )
     }
 

--- a/HealthSDK/GiniHealthSDK/Sources/GiniHealthSDK/Resources/de.lproj/Localizable.strings
+++ b/HealthSDK/GiniHealthSDK/Sources/GiniHealthSDK/Resources/de.lproj/Localizable.strings
@@ -78,6 +78,7 @@
 
 // INFORMAL KEYS - German informal localization strings
 
+"gini.health.reviewscreen.title.informal" = "";
 "gini.health.alert.ok.title.informal" = "OK";
 "gini.health.close.button.accessibility.label.informal" = "Schließen";
 "gini.health.close.button.accessibility.hint.informal" = "Tippen zum Schließen";

--- a/HealthSDK/GiniHealthSDK/Sources/GiniHealthSDK/Resources/de.lproj/Localizable.strings
+++ b/HealthSDK/GiniHealthSDK/Sources/GiniHealthSDK/Resources/de.lproj/Localizable.strings
@@ -5,6 +5,7 @@
  //  Copyright © 2024 Gini GmbH. All rights reserved.
 
 */
+"gini.health.reviewscreen.title" = "";
 "gini.health.alert.ok.title" = "OK";
 "gini.health.close.button.accessibility.label" = "Schließen";
 "gini.health.close.button.accessibility.hint" = "Tippen zum Schließen";

--- a/HealthSDK/GiniHealthSDK/Sources/GiniHealthSDK/Resources/en.lproj/Localizable.strings
+++ b/HealthSDK/GiniHealthSDK/Sources/GiniHealthSDK/Resources/en.lproj/Localizable.strings
@@ -5,6 +5,7 @@
  //  Copyright © 2024 Gini GmbH. All rights reserved.
 
 */
+"gini.health.reviewscreen.title" = "";
 "gini.health.reviewscreen.recipient.placeholder" = "Recipient";
 "gini.health.reviewscreen.iban.placeholder" = "IBAN";
 "gini.health.reviewscreen.amount.placeholder" = "Amount";


### PR DESCRIPTION
## Pull Request Description

<!-- Briefly explain **what** this PR does and **why**. Mention the motivation, feature, or issue it's addressing. -->

[HEAL-514](https://ginis.atlassian.net/browse/HEAL-514)<!-- Closes ticket number PP-####; Replace with JIRA ticket if relevant -->

<!--

Some description of HOW you achieved it. Perhaps give a high level description of the chnages you did. Did you need to refactor something? What tradeoffs did you take?

-->

Adds a localizable navigation bar title to the Payment Review Screen so customers can customize it in their own `Localizable.strings`.

In v6.0.0 the close button moved into the navigation bar, requiring customers like IBM to show the nav bar. Previously there was no way to set a title, leaving it empty. A new string key `gini.health.reviewscreen.title` defaults to empty (preserving existing behavior) and can be overridden by the host app.

Changes span two modules: `GiniInternalPaymentSDK` receives the new `paymentReviewScreenTitle` property on `PaymentReviewStrings` and the updated `setupNavigationBar()` logic; `GiniHealthSDK` owns the localization key and wires it through the strings provider.

## Notes for Reviewers

<!--

Explain how you verified the changes.
A clear testing scenario helps colleagues who may not be familiar with this part of the code quickly understand and verify the changes. Include steps they can follow to see the impact in action.

You can include: 
- Simulators/Devices you used (e.g. iPhone 13, iPad Pro) 
- iOS versions tested (e.g. 16.0, 17.5) 
- Manual checks (e.g. flow tested: onboarding, permissions, error states) 
- Unit tests added or updated 
 
 Include screenshots, screen recordings, or simulator gifs for UI changes. 
 
 - Optional: Anything that needs extra attention in review? Are there TODOs, known limitations, or follow-up work? 
 
 -->

To verify the default (empty title) behavior is unchanged: run the GiniHealthSDK example app in `documentCollection` display mode — the nav bar title should remain blank.

To verify the customization: add `"gini.health.reviewscreen.title" = "Payment Review";` to the host app's `Localizable.strings` and re-run — the nav bar should show the custom title.

The title is set unconditionally for `documentCollection` mode, independently of the `showPaymentReviewCloseButton` flag, so it works whether or not the close button is shown.

No unit tests added — the change is a pass-through from localization to `navigationItem.title` with no logic to test.

[HEAL-514]: https://ginis.atlassian.net/browse/HEAL-514?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ