### PR TITLE
Pp 2522 update alert comp liquid glass

### DIFF
--- a/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/Skonto/SkontoAlertFactory.swift
+++ b/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/Skonto/SkontoAlertFactory.swift
@@ -43,6 +43,8 @@ class SkontoAlertFactory {
                                                                                      comment: "Understood"),
                                      style: .default)
         alert.addAction(okAction)
+        // preferredAction must be set after addAction
+        alert.preferredAction = okAction
         return alert
     }
 }

--- a/BankSDK/GiniBankSDKExample/GiniBankSDKExample/AppCoordinator.swift
+++ b/BankSDK/GiniBankSDKExample/GiniBankSDKExample/AppCoordinator.swift
@@ -175,7 +175,7 @@ final class AppCoordinator: Coordinator {
 									  message: "`Open with` feature is currently disabled. \n If you want to test this, please enable it in Gini configuration!",
 									  preferredStyle: .alert)
 		
-		let ok = UIAlertAction(title: NSLocalizedString("gini.bank.example.alert.ok", comment: ""), style: .default) { _ in
+		let ok = UIAlertAction(title: DemoScreenStrings.alertOk.localized, style: .default) { _ in
 			self.rootViewController.dismiss(animated: true)
 		}
 
@@ -313,7 +313,7 @@ final class AppCoordinator: Coordinator {
                                                            comment: "Import error description")
 
         let alertViewController = UIAlertController(title: title, message: description, preferredStyle: .alert)
-        let okAction = UIAlertAction(title: NSLocalizedString("gini.bank.example.alert.ok", comment: ""), style: .default) { _ in
+        let okAction = UIAlertAction(title: DemoScreenStrings.alertOk.localized, style: .default) { _ in
             alertViewController.dismiss(animated: true)
         }
         alertViewController.addAction(okAction)

--- a/BankSDK/GiniBankSDKExample/GiniBankSDKExample/AppCoordinator.swift
+++ b/BankSDK/GiniBankSDKExample/GiniBankSDKExample/AppCoordinator.swift
@@ -180,6 +180,8 @@ final class AppCoordinator: Coordinator {
 		}
 
 		alert.addAction(ok)
+		// preferredAction must be set after addAction
+		alert.preferredAction = ok
 		rootViewController.present(alert, animated: true)
 	}
 	
@@ -292,13 +294,15 @@ final class AppCoordinator: Coordinator {
                                                                  comment: "No")
         let alertViewController = UIAlertController(title: title, message: description, preferredStyle: .alert)
 
-        alertViewController.addAction(UIAlertAction(title: startButtonTitle, style: .default) { [weak self] _ in
+        let startAction = UIAlertAction(title: startButtonTitle, style: .default) { [weak self] _ in
             self?.showScreenAPI(with: pages)
-        })
+        }
+        alertViewController.addAction(startAction)
         alertViewController.addAction(UIAlertAction(title: cancelButtonTitle, style: .default) { _ in
             alertViewController.dismiss(animated: true)
         })
-
+        // preferredAction must be set after addAction
+        alertViewController.preferredAction = startAction
 
         rootViewController.present(alertViewController, animated: true)
     }
@@ -309,10 +313,13 @@ final class AppCoordinator: Coordinator {
                                                            comment: "Import error description")
 
         let alertViewController = UIAlertController(title: title, message: description, preferredStyle: .alert)
-        alertViewController.addAction(UIAlertAction(title: "OK", style: .default) { _ in
+        let okAction = UIAlertAction(title: "OK", style: .default) { _ in
             alertViewController.dismiss(animated: true)
-        })
-        
+        }
+        alertViewController.addAction(okAction)
+        // preferredAction must be set after addAction
+        alertViewController.preferredAction = okAction
+
         rootViewController.present(alertViewController, animated: true)
     }
     

--- a/BankSDK/GiniBankSDKExample/GiniBankSDKExample/AppCoordinator.swift
+++ b/BankSDK/GiniBankSDKExample/GiniBankSDKExample/AppCoordinator.swift
@@ -175,7 +175,7 @@ final class AppCoordinator: Coordinator {
 									  message: "`Open with` feature is currently disabled. \n If you want to test this, please enable it in Gini configuration!",
 									  preferredStyle: .alert)
 		
-		let ok = UIAlertAction(title: "OK", style: .default) { _ in
+		let ok = UIAlertAction(title: NSLocalizedString("gini.bank.example.alert.ok", comment: ""), style: .default) { _ in
 			self.rootViewController.dismiss(animated: true)
 		}
 
@@ -313,7 +313,7 @@ final class AppCoordinator: Coordinator {
                                                            comment: "Import error description")
 
         let alertViewController = UIAlertController(title: title, message: description, preferredStyle: .alert)
-        let okAction = UIAlertAction(title: "OK", style: .default) { _ in
+        let okAction = UIAlertAction(title: NSLocalizedString("gini.bank.example.alert.ok", comment: ""), style: .default) { _ in
             alertViewController.dismiss(animated: true)
         }
         alertViewController.addAction(okAction)

--- a/BankSDK/GiniBankSDKExample/GiniBankSDKExample/Screen API/ScreenAPICoordinator.swift
+++ b/BankSDK/GiniBankSDKExample/GiniBankSDKExample/Screen API/ScreenAPICoordinator.swift
@@ -227,7 +227,7 @@ final class ScreenAPICoordinator: NSObject, Coordinator, UINavigationControllerD
                                       message: nil,
                                       preferredStyle: .alert)
 
-        let ok = UIAlertAction(title: "OK", style: .default) { [weak self] _ in
+        let ok = UIAlertAction(title: NSLocalizedString("gini.bank.example.alert.ok", comment: ""), style: .default) { [weak self] _ in
             self?.rootViewController.dismiss(animated: true)
         }
 

--- a/BankSDK/GiniBankSDKExample/GiniBankSDKExample/Screen API/ScreenAPICoordinator.swift
+++ b/BankSDK/GiniBankSDKExample/GiniBankSDKExample/Screen API/ScreenAPICoordinator.swift
@@ -232,6 +232,8 @@ final class ScreenAPICoordinator: NSObject, Coordinator, UINavigationControllerD
         }
 
         alert.addAction(ok)
+        // preferredAction must be set after addAction
+        alert.preferredAction = ok
         rootViewController.present(alert, animated: true)
     }
 }

--- a/BankSDK/GiniBankSDKExample/GiniBankSDKExample/Screen API/ScreenAPICoordinator.swift
+++ b/BankSDK/GiniBankSDKExample/GiniBankSDKExample/Screen API/ScreenAPICoordinator.swift
@@ -227,7 +227,7 @@ final class ScreenAPICoordinator: NSObject, Coordinator, UINavigationControllerD
                                       message: nil,
                                       preferredStyle: .alert)
 
-        let ok = UIAlertAction(title: NSLocalizedString("gini.bank.example.alert.ok", comment: ""), style: .default) { [weak self] _ in
+        let ok = UIAlertAction(title: DemoScreenStrings.alertOk.localized, style: .default) { [weak self] _ in
             self?.rootViewController.dismiss(animated: true)
         }
 

--- a/BankSDK/GiniBankSDKExample/GiniBankSDKExample/SettingsViewController/SettingsViewController.swift
+++ b/BankSDK/GiniBankSDKExample/GiniBankSDKExample/SettingsViewController/SettingsViewController.swift
@@ -245,7 +245,10 @@ extension SettingsViewController: SegmentedOptionTableViewCellDelegate {
                                       message: message,
                                       preferredStyle: .alert)
 
-        alert.addAction(UIAlertAction(title: "OK", style: .default, handler: nil))
+        let okAction = UIAlertAction(title: "OK", style: .default, handler: nil)
+        alert.addAction(okAction)
+        // preferredAction must be set after addAction
+        alert.preferredAction = okAction
 
         present(alert, animated: true, completion: nil)
     }
@@ -282,7 +285,10 @@ extension SettingsViewController: UpdateUserDefaultsCellDelegate {
                                           message: "The preference was successfully removed.",
                                           preferredStyle: .alert)
 
-            alert.addAction(UIAlertAction(title: "OK", style: .default, handler: nil))
+            let okAction = UIAlertAction(title: "OK", style: .default, handler: nil)
+            alert.addAction(okAction)
+            // preferredAction must be set after addAction
+            alert.preferredAction = okAction
 
             // Present the alert on the provided viewController
             present(alert, animated: true, completion: nil)

--- a/BankSDK/GiniBankSDKExample/GiniBankSDKExample/SettingsViewController/SettingsViewController.swift
+++ b/BankSDK/GiniBankSDKExample/GiniBankSDKExample/SettingsViewController/SettingsViewController.swift
@@ -245,7 +245,7 @@ extension SettingsViewController: SegmentedOptionTableViewCellDelegate {
                                       message: message,
                                       preferredStyle: .alert)
 
-        let okAction = UIAlertAction(title: NSLocalizedString("gini.bank.example.alert.ok", comment: ""), style: .default, handler: nil)
+        let okAction = UIAlertAction(title: DemoScreenStrings.alertOk.localized, style: .default, handler: nil)
         alert.addAction(okAction)
         // preferredAction must be set after addAction
         alert.preferredAction = okAction
@@ -285,7 +285,7 @@ extension SettingsViewController: UpdateUserDefaultsCellDelegate {
                                           message: "The preference was successfully removed.",
                                           preferredStyle: .alert)
 
-            let okAction = UIAlertAction(title: NSLocalizedString("gini.bank.example.alert.ok", comment: ""), style: .default, handler: nil)
+            let okAction = UIAlertAction(title: DemoScreenStrings.alertOk.localized, style: .default, handler: nil)
             alert.addAction(okAction)
             // preferredAction must be set after addAction
             alert.preferredAction = okAction

--- a/BankSDK/GiniBankSDKExample/GiniBankSDKExample/SettingsViewController/SettingsViewController.swift
+++ b/BankSDK/GiniBankSDKExample/GiniBankSDKExample/SettingsViewController/SettingsViewController.swift
@@ -245,7 +245,7 @@ extension SettingsViewController: SegmentedOptionTableViewCellDelegate {
                                       message: message,
                                       preferredStyle: .alert)
 
-        let okAction = UIAlertAction(title: "OK", style: .default, handler: nil)
+        let okAction = UIAlertAction(title: NSLocalizedString("gini.bank.example.alert.ok", comment: ""), style: .default, handler: nil)
         alert.addAction(okAction)
         // preferredAction must be set after addAction
         alert.preferredAction = okAction
@@ -285,7 +285,7 @@ extension SettingsViewController: UpdateUserDefaultsCellDelegate {
                                           message: "The preference was successfully removed.",
                                           preferredStyle: .alert)
 
-            let okAction = UIAlertAction(title: "OK", style: .default, handler: nil)
+            let okAction = UIAlertAction(title: NSLocalizedString("gini.bank.example.alert.ok", comment: ""), style: .default, handler: nil)
             alert.addAction(okAction)
             // preferredAction must be set after addAction
             alert.preferredAction = okAction

--- a/BankSDK/GiniBankSDKExample/GiniBankSDKExample/Utils/Localization/DemoScreenStrings.swift
+++ b/BankSDK/GiniBankSDKExample/GiniBankSDKExample/Utils/Localization/DemoScreenStrings.swift
@@ -14,6 +14,7 @@ enum DemoScreenStrings: Localized {
     case photoPaymentButtonTitle
     case alternativeText
     case transactionListButtonTitle
+    case alertOk
 }
 
 extension DemoScreenStrings {
@@ -33,6 +34,8 @@ extension DemoScreenStrings {
                 return "alternative.text"
             case .transactionListButtonTitle:
                 return "transaction.list.button.title"
+            case .alertOk:
+                return "gini.bank.example.alert.ok"
         }
     }
 }

--- a/BankSDK/GiniBankSDKExample/GiniBankSDKExample/Utils/Localization/Strings/de.lproj/DemoScreen.strings
+++ b/BankSDK/GiniBankSDKExample/GiniBankSDKExample/Utils/Localization/Strings/de.lproj/DemoScreen.strings
@@ -12,3 +12,4 @@
 "photo.payment.button.title" = "Fotoüberweisung";
 "alternative.text" = "oder nutzen Sie die";
 "transaction.list.button.title" = "Umsatzliste";
+"gini.bank.example.alert.ok" = "OK";

--- a/BankSDK/GiniBankSDKExample/GiniBankSDKExample/Utils/Localization/Strings/en.lproj/DemoScreen.strings
+++ b/BankSDK/GiniBankSDKExample/GiniBankSDKExample/Utils/Localization/Strings/en.lproj/DemoScreen.strings
@@ -12,3 +12,4 @@
 "photo.payment.button.title" = "Photopayment";
 "alternative.text" = "or use";
 "transaction.list.button.title" = "Transaction list";
+"gini.bank.example.alert.ok" = "OK";

--- a/BankSDK/GiniBankSDKExample/GiniBankSDKExampleBank/PaymentViewController.swift
+++ b/BankSDK/GiniBankSDKExample/GiniBankSDKExampleBank/PaymentViewController.swift
@@ -447,10 +447,10 @@ extension PaymentViewController {
         let alertController = UIAlertController(title: title,
                                                 message: message,
                                                 preferredStyle: .alert)
-        let OKAction = UIAlertAction(title: "ok", style: .default, handler: nil)
-        alertController.addAction(OKAction)
+        let okAction = UIAlertAction(title: "OK", style: .default, handler: nil)
+        alertController.addAction(okAction)
         // preferredAction must be set after addAction
-        alertController.preferredAction = OKAction
+        alertController.preferredAction = okAction
         present(alertController, animated: true, completion: nil)
     }
 }

--- a/BankSDK/GiniBankSDKExample/GiniBankSDKExampleBank/PaymentViewController.swift
+++ b/BankSDK/GiniBankSDKExample/GiniBankSDKExampleBank/PaymentViewController.swift
@@ -449,6 +449,8 @@ extension PaymentViewController {
                                                 preferredStyle: .alert)
         let OKAction = UIAlertAction(title: "ok", style: .default, handler: nil)
         alertController.addAction(OKAction)
+        // preferredAction must be set after addAction
+        alertController.preferredAction = OKAction
         present(alertController, animated: true, completion: nil)
     }
 }

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Extensions/UIViewController.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Extensions/UIViewController.swift
@@ -46,6 +46,8 @@ extension UIViewController {
                 confirmAction()
             })
             alertViewController.addAction(confirmationAction)
+            // preferredAction must be set after addAction
+            alertViewController.preferredAction = confirmationAction
         }
 
         present(alertViewController, animated: true)


### PR DESCRIPTION
## Pull Request Description

<!-- Briefly explain **what** this PR does and **why**. Mention the motivation, feature, or issue it's addressing. -->

[PP-2522](https://ginis.atlassian.net/browse/PP-2522)<!-- Closes ticket number PP-####; Replace with JIRA ticket if relevant -->
This PR updates several UIAlertController usages across GiniCaptureSDK, GiniBankSDK, and the Bank SDK example apps to explicitly set preferredAction (after adding the action), and it introduces a localized “OK” string for the main BankSDK example.
<!--



Some description of HOW you achieved it. Perhaps give a high level description of the chnages you did. Did you need to refactor something? What tradeoffs did you take?

-->

## Notes for Reviewers

- Set UIAlertController.preferredAction after addAction(_:) in multiple alert presentations/factories.
- Add DemoScreenStrings.alertOk plus en/de string entries and use it in several example alerts.
- Minor refactor of alert action creation in the example app(s) to keep references for preferredAction.

<!--

Explain how you verified the changes.
A clear testing scenario helps colleagues who may not be familiar with this part of the code quickly understand and verify the changes. Include steps they can follow to see the impact in action.

You can include: 
- Simulators/Devices you used (e.g. iPhone 13, iPad Pro) 
- iOS versions tested (e.g. 16.0, 17.5) 
- Manual checks (e.g. flow tested: onboarding, permissions, error states) 
- Unit tests added or updated 
 
 Include screenshots, screen recordings, or simulator gifs for UI changes. 
 
 - Optional: Anything that needs extra attention in review? Are there TODOs, known limitations, or follow-up work? 
 
 -->

[PP-2522]: https://ginis.atlassian.net/browse/PP-2522?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ