### PR TITLE
Pp 2605 payment due hint displays loading spinner overlapping the UI for due date hint

### DIFF
--- a/.github/workflows/shared-config.yml
+++ b/.github/workflows/shared-config.yml
@@ -43,4 +43,4 @@ jobs:
         run: |
           echo "xcode-version=26.2" >> $GITHUB_OUTPUT
           echo "ruby-version=3.2.0" >> $GITHUB_OUTPUT
-          echo "ios-simulator-destination=platform=iOS Simulator,name=iPhone 16,OS=26.2" >> $GITHUB_OUTPUT
+          echo "ios-simulator-destination=platform=iOS Simulator,name=iPhone 17,OS=26.2" >> $GITHUB_OUTPUT

--- a/BankAPILibrary/GiniBankAPILibrary/.jazzy.yaml
+++ b/BankAPILibrary/GiniBankAPILibrary/.jazzy.yaml
@@ -5,7 +5,7 @@ xcodebuild_arguments:
 - "-scheme"
 - GiniBankAPILibrary
 - "-destination"
-- platform=iOS Simulator,OS=18.5,name=iPhone 16
+- platform=iOS Simulator,OS=26.2,name=iPhone 17
 author: Gini GmbH
 author_url: https://gini.net
 module: GiniBankAPILibrary

--- a/BankSDK/GiniBankSDK/.jazzy.yaml
+++ b/BankSDK/GiniBankSDK/.jazzy.yaml
@@ -5,7 +5,7 @@ xcodebuild_arguments:
 - "-scheme"
 - GiniBankSDK
 - "-destination"
-- platform=iOS Simulator,OS=18.5,name=iPhone 16
+- platform=iOS Simulator,OS=26.2,name=iPhone 17
 author: Gini GmbH
 author_url: https://gini.net
 module: GiniBankSDK

--- a/CaptureSDK/GiniCaptureSDK/.jazzy.yaml
+++ b/CaptureSDK/GiniCaptureSDK/.jazzy.yaml
@@ -5,7 +5,7 @@ xcodebuild_arguments:
 - "-scheme"
 - GiniCaptureSDK
 - "-destination"
-- platform=iOS Simulator,OS=18.5,name=iPhone 16
+- platform=iOS Simulator,OS=26.2,name=iPhone 17
 author: Gini GmbH
 author_url: https://gini.net
 module: GiniCaptureSDK

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Analysis/AnalysisViewController.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Analysis/AnalysisViewController.swift
@@ -460,11 +460,29 @@ import Photos
     }
 
     // MARK: - Handling UI - Payment DueHint
-    private func setupScrollableStackView(dueDate: String) {
 
-        /// hide views before showing hint
+    private func tearDownLoadingUI() {
         loadingIndicatorText.isHidden = true
         loadingIndicatorView.stopAnimating()
+        loadingIndicatorContainer.removeFromSuperview()
+
+        if let customIndicator = giniConfiguration.customLoadingIndicator {
+            customIndicator.stopAnimation()
+            customIndicator.injectedView().removeFromSuperview()
+        }
+
+        // Drain pending continuations so any Task waiting on animation completion is not stranded.
+        animationCompletionContinuations.forEach { $0.resume() }
+        animationCompletionContinuations.removeAll()
+        loadingViewModel = nil
+
+        view.subviews
+            .compactMap { $0 as? QRCodeEducationLoadingView }
+            .forEach { $0.removeFromSuperview() }
+    }
+
+    private func setupScrollableStackView(dueDate: String) {
+        tearDownLoadingUI()
 
         view.addSubview(scrollView)
 

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Analysis/AnalysisViewController.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Analysis/AnalysisViewController.swift
@@ -472,7 +472,7 @@ import Photos
             customIndicator.injectedView().removeFromSuperview()
         }
 
-        // Drain pending continuations so any Task waiting on animation completion is not stranded.
+        /// Drain pending continuations so any `Task` waiting on animation completion is not stranded.
         animationCompletionContinuations.forEach { $0.resume() }
         animationCompletionContinuations.removeAll()
         loadingViewModel = nil

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Analysis/AnalysisViewController.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Analysis/AnalysisViewController.swift
@@ -482,6 +482,7 @@ import Photos
             .forEach { $0.removeFromSuperview() }
     }
 
+    @MainActor
     private func setupScrollableStackView(dueDate: String) {
         tearDownLoadingUI()
 
@@ -568,6 +569,12 @@ import Photos
             self.updateContentStackConstraints()
         })
     }
+    
+    func someCallerThatUsedToCallSetupScrollableStackView(dueDate: String) {
+        Task { @MainActor [weak self] in
+            self?.setupScrollableStackView(dueDate: dueDate)
+        }
+    }
 }
 
 extension AnalysisViewController: PaymentDueDateProtocol {
@@ -576,7 +583,9 @@ extension AnalysisViewController: PaymentDueDateProtocol {
         removeCaptureSuggestions()
 
         /// show due hint view
-        setupScrollableStackView(dueDate: dueDate)
+        Task { @MainActor [weak self] in
+            self?.setupScrollableStackView(dueDate: dueDate)
+        }
     }
 
     @MainActor
@@ -636,3 +645,4 @@ private extension AnalysisViewController {
         )
     }
 }
+

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Analysis/AnalysisViewController.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Analysis/AnalysisViewController.swift
@@ -569,12 +569,6 @@ import Photos
             self.updateContentStackConstraints()
         })
     }
-    
-    func someCallerThatUsedToCallSetupScrollableStackView(dueDate: String) {
-        Task { @MainActor [weak self] in
-            self?.setupScrollableStackView(dueDate: dueDate)
-        }
-    }
 }
 
 extension AnalysisViewController: PaymentDueDateProtocol {
@@ -583,12 +577,9 @@ extension AnalysisViewController: PaymentDueDateProtocol {
         removeCaptureSuggestions()
 
         /// show due hint view
-        Task { @MainActor [weak self] in
-            self?.setupScrollableStackView(dueDate: dueDate)
-        }
+        setupScrollableStackView(dueDate: dueDate)
     }
 
-    @MainActor
     public func clearPaymentDueDate(after timeout: TimeInterval) async {
         await withCheckedContinuation { continuation in
             var didClear = false

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Analysis/AnalysisViewController.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Analysis/AnalysisViewController.swift
@@ -117,7 +117,8 @@ import Photos
         let scrollView = UIScrollView()
         scrollView.alwaysBounceVertical = true
         scrollView.showsVerticalScrollIndicator = false
-        scrollView.backgroundColor = .clear
+        scrollView.backgroundColor = GiniColor(light: .GiniCapture.light2,
+                                               dark: .GiniCapture.dark2).uiColor()
         scrollView.translatesAutoresizingMaskIntoConstraints = false
         return scrollView
     }()

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Screen API Coordinator/GiniScreenAPICoordinator.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Screen API Coordinator/GiniScreenAPICoordinator.swift
@@ -13,6 +13,7 @@ protocol Coordinator: AnyObject {
 }
 
 /// Defines how a view can show and hide a payment due date message.
+@MainActor
 public protocol PaymentDueDateProtocol: AnyObject {
 
     /// Show the payment due date text

--- a/CaptureSDK/GiniCaptureSDK/Tests/GiniCaptureSDKTests/AnalysisViewControllerPaymentDueHintTests.swift
+++ b/CaptureSDK/GiniCaptureSDK/Tests/GiniCaptureSDKTests/AnalysisViewControllerPaymentDueHintTests.swift
@@ -33,7 +33,11 @@ struct AnalysisViewControllerPaymentDueHintTests {
 
     private func makeImportedImageVC(config: GiniConfiguration) -> AnalysisViewController {
         let image = GiniCaptureTestsHelper.loadImage(named: "invoice")
-        let data = image.jpegData(compressionQuality: 0.2) ?? Data()
+        guard let data = image.jpegData(compressionQuality: 0.2) else {
+            #expect(Bool(false), "Failed to create JPEG data from invoice image")
+            let document = GiniImageDocument(data: Data(), imageSource: .external)
+            return AnalysisViewController(document: document, giniConfiguration: config)
+        }
         let document = GiniImageDocument(data: data, imageSource: .external)
         return AnalysisViewController(document: document, giniConfiguration: config)
     }

--- a/CaptureSDK/GiniCaptureSDK/Tests/GiniCaptureSDKTests/AnalysisViewControllerPaymentDueHintTests.swift
+++ b/CaptureSDK/GiniCaptureSDK/Tests/GiniCaptureSDKTests/AnalysisViewControllerPaymentDueHintTests.swift
@@ -1,0 +1,94 @@
+//
+//  AnalysisViewControllerPaymentDueHintTests.swift
+//  GiniCaptureSDK
+//
+//  Copyright © 2026 Gini GmbH. All rights reserved.
+//
+
+import Testing
+import UIKit
+@testable import GiniCaptureSDK
+
+// MARK: - Mock
+
+private final class MockCustomLoadingIndicator: CustomLoadingIndicatorAdapter {
+    func onDeinit() {
+        // Intentionally left empty
+    }
+    
+    private let _view = UIView()
+    private(set) var stopAnimationCalled = false
+
+    func injectedView() -> UIView { _view }
+    func startAnimation() {
+        // Intentionally left empty
+    }
+    func stopAnimation() { stopAnimationCalled = true }
+}
+
+// MARK: - Suite
+
+@Suite("AnalysisViewController Payment Due Hint")
+struct AnalysisViewControllerPaymentDueHintTests {
+
+    private func makeImportedImageVC(config: GiniConfiguration) -> AnalysisViewController {
+        let image = GiniCaptureTestsHelper.loadImage(named: "invoice")
+        let data = image.jpegData(compressionQuality: 0.2) ?? Data()
+        let document = GiniImageDocument(data: data, imageSource: .external)
+        return AnalysisViewController(document: document, giniConfiguration: config)
+    }
+
+    @Test("Custom indicator is stopped and its view removed when hint is shown")
+    @MainActor func customLoadingIndicatorStoppedWhenHintShown() {
+        let mockIndicator = MockCustomLoadingIndicator()
+        let config = GiniConfiguration()
+        config.fileImportSupportedTypes = .pdf
+        config.customLoadingIndicator = mockIndicator
+        let sut = makeImportedImageVC(config: config)
+        _ = sut.view
+
+        sut.handlePaymentDueDate("13.06.2026")
+
+        #expect(mockIndicator.stopAnimationCalled, "Custom indicator should be stopped")
+        #expect(mockIndicator.injectedView().superview == nil, "Custom indicator view should be removed from hierarchy")
+    }
+
+    @Test("Default activity indicator is not animating when hint is shown")
+    @MainActor func defaultActivityIndicatorStoppedWhenHintShown() {
+        let config = GiniConfiguration()
+        config.fileImportSupportedTypes = .pdf
+        let sut = makeImportedImageVC(config: config)
+        _ = sut.view
+
+        sut.handlePaymentDueDate("13.06.2026")
+
+        let animating = allActivityIndicators(in: sut.view).filter { $0.isAnimating }
+        #expect(animating.isEmpty, "No activity indicator should be animating after hint is shown")
+    }
+
+    @Test("PaymentDueHintView and DismissMessageView are present after hint is shown")
+    @MainActor func hintAndDismissViewsPresentAfterHandlePaymentDueDate() {
+        let config = GiniConfiguration()
+        config.fileImportSupportedTypes = .pdf
+        let sut = makeImportedImageVC(config: config)
+        _ = sut.view
+
+        sut.handlePaymentDueDate("13.06.2026")
+
+        #expect(contains(type: PaymentDueHintView.self, in: sut.view), "PaymentDueHintView should be in the view hierarchy")
+        #expect(contains(type: DismissMessageView.self, in: sut.view), "DismissMessageView should be in the view hierarchy")
+    }
+
+    // MARK: - Helpers
+
+    private func allActivityIndicators(in view: UIView) -> [UIActivityIndicatorView] {
+        var result = view.subviews.compactMap { $0 as? UIActivityIndicatorView }
+        result += view.subviews.flatMap { allActivityIndicators(in: $0) }
+        return result
+    }
+
+    private func contains<T: UIView>(type: T.Type, in view: UIView) -> Bool {
+        if view is T { return true }
+        return view.subviews.contains { contains(type: type, in: $0) }
+    }
+}


### PR DESCRIPTION
## Pull Request Description

<!-- Briefly explain **what** this PR does and **why**. Mention the motivation, feature, or issue it's addressing. -->

[PP-2605](https://ginis.atlassian.net/browse/PP-2605)

This PR addresses the issue where the Payment Due Hint UI can be shown while the analysis/loading UI (default spinner, custom indicator, and/or education loading view) is still present, causing visual overlap.

**Changes:**
- Adds `tearDownLoadingUI()` and calls it before building the scrollable Payment Due Hint stack, stopping animations and removing loading-related views.
- Updates the analysis scroll view background color to use the SDK theme colors.
- Adds Swift Testing-based regression tests to verify loading indicators stop and hint/dismiss views are present after `handlePaymentDueDate()`.


[PP-2605]: https://ginis.atlassian.net/browse/PP-2605?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ