### PR TITLE
Heal 526 set current page indicator tint color and page indicator tint color for page control in payment review screen

### DIFF
--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/Views/GiniCarouselView.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/Views/GiniCarouselView.swift
@@ -24,8 +24,9 @@ struct GiniCarouselView: View {
     init(viewModel: GiniCarouselViewModel) {
         self.images = viewModel.images
         self.imageAccessibilityLabel = viewModel.imageAccessibilityLabel
-        UIPageControl.appearance().currentPageIndicatorTintColor = viewModel.currentPageIndicatorTintColor
-        UIPageControl.appearance().pageIndicatorTintColor = viewModel.pageIndicatorTintColor
+        let pageControlAppearance = UIPageControl.appearance(whenContainedInInstancesOf: [PaymentReviewViewController.self])
+        pageControlAppearance.currentPageIndicatorTintColor = viewModel.currentPageIndicatorTintColor
+        pageControlAppearance.pageIndicatorTintColor = viewModel.pageIndicatorTintColor
     }
     
     var body: some View {

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/Views/GiniCarouselView.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/Views/GiniCarouselView.swift
@@ -7,6 +7,13 @@
 
 import SwiftUI
 
+struct GiniCarouselViewModel {
+    let images: [UIImage]
+    let imageAccessibilityLabel: String?
+    let pageIndicatorTintColor: UIColor
+    let currentPageIndicatorTintColor: UIColor
+}
+
 struct GiniCarouselView: View {
     
     private let images: [UIImage]
@@ -14,9 +21,11 @@ struct GiniCarouselView: View {
     
     @State private var currentIndex: Int = 0
     
-    init(images: [UIImage], imageAccessibilityLabel: String? = nil) {
-        self.images = images
-        self.imageAccessibilityLabel = imageAccessibilityLabel
+    init(viewModel: GiniCarouselViewModel) {
+        self.images = viewModel.images
+        self.imageAccessibilityLabel = viewModel.imageAccessibilityLabel
+        UIPageControl.appearance().currentPageIndicatorTintColor = viewModel.currentPageIndicatorTintColor
+        UIPageControl.appearance().pageIndicatorTintColor = viewModel.pageIndicatorTintColor
     }
     
     var body: some View {

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/Views/PaymentReviewContentView.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/Views/PaymentReviewContentView.swift
@@ -205,12 +205,14 @@ public struct PaymentReviewContentView: View {
     @ViewBuilder
     private func showPreviewImageCarousel(carouselHeight: CGFloat) -> some View {
         let images = viewModel.cellViewModels.compactMap { $0.preview }
-        let viewModel = GiniCarouselViewModel(images: images,
-                                              imageAccessibilityLabel: viewModel.invoiceImageAccessibilityLabel,
-                                              pageIndicatorTintColor: viewModel.model.configuration.pageIndicatorTintColor,
-                                              currentPageIndicatorTintColor: viewModel.model.configuration.currentPageIndicatorTintColor)
-        GiniCarouselView(viewModel: viewModel)
-            .frame(height: carouselHeight)
+        let imageAccessibilityLabel = viewModel.invoiceImageAccessibilityLabel
+        let pageIndicatorTintColor = viewModel.model.configuration.pageIndicatorTintColor
+        let currentPageIndicatorTintColor = viewModel.model.configuration.currentPageIndicatorTintColor
+        let carouselViewModel = GiniCarouselViewModel(images: images,
+                                                      imageAccessibilityLabel: imageAccessibilityLabel,
+                                                      pageIndicatorTintColor: pageIndicatorTintColor,
+                                                      currentPageIndicatorTintColor: currentPageIndicatorTintColor)
+        GiniCarouselView(viewModel: carouselViewModel).frame(height: carouselHeight)
     }
     
     // MARK: - Private Methods

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/Views/PaymentReviewContentView.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/Views/PaymentReviewContentView.swift
@@ -205,9 +205,11 @@ public struct PaymentReviewContentView: View {
     @ViewBuilder
     private func showPreviewImageCarousel(carouselHeight: CGFloat) -> some View {
         let images = viewModel.cellViewModels.compactMap { $0.preview }
-        
-        GiniCarouselView(images: images,
-                         imageAccessibilityLabel: viewModel.invoiceImageAccessibilityLabel)
+        let viewModel = GiniCarouselViewModel(images: images,
+                                              imageAccessibilityLabel: viewModel.invoiceImageAccessibilityLabel,
+                                              pageIndicatorTintColor: viewModel.model.configuration.pageIndicatorTintColor,
+                                              currentPageIndicatorTintColor: viewModel.model.configuration.currentPageIndicatorTintColor)
+        GiniCarouselView(viewModel: viewModel)
             .frame(height: carouselHeight)
     }
     

--- a/HealthSDK/GiniHealthSDK/Sources/GiniHealthSDK/Core/GiniHealth+PaymentComponentsConfigurationProvider.swift
+++ b/HealthSDK/GiniHealthSDK/Sources/GiniHealthSDK/Core/GiniHealth+PaymentComponentsConfigurationProvider.swift
@@ -148,10 +148,8 @@ extension GiniHealth: PaymentComponentsConfigurationProvider {
             rectangleColor: GiniColor.standard5.uiColor(),
             infoBarLabelFont: GiniHealthConfiguration.shared.font(for: .captions1),
             statusBarStyle: GiniHealthConfiguration.shared.paymentReviewStatusBarStyle,
-            pageIndicatorTintColor: GiniColor(lightModeColorName: .dark1,
-                                              darkModeColorName: .light1).uiColor().withAlphaComponent(0.3),
-            currentPageIndicatorTintColor: GiniColor(lightModeColorName: .dark1,
-                                                     darkModeColorName: .light1).uiColor(),
+            pageIndicatorTintColor: GiniColor.standard1.uiColor().withAlphaComponent(0.45),
+            currentPageIndicatorTintColor: GiniColor.standard1.uiColor(),
             isInfoBarHidden: GiniHealthConfiguration.shared.useInvoiceWithoutDocument ? true : false,
             popupAnimationDuration: GiniHealthConfiguration.shared.popupDurationPaymentReview
         )

--- a/HealthSDK/GiniHealthSDK/Sources/GiniHealthSDK/Core/GiniHealth+PaymentComponentsConfigurationProvider.swift
+++ b/HealthSDK/GiniHealthSDK/Sources/GiniHealthSDK/Core/GiniHealth+PaymentComponentsConfigurationProvider.swift
@@ -143,12 +143,15 @@ extension GiniHealth: PaymentComponentsConfigurationProvider {
             mainViewBackgroundColor: GiniColor.standard7.uiColor(),
             infoContainerViewBackgroundColor: GiniColor.standard7.uiColor(),
             paymentReviewClose: GiniHealthImage.close.preferredUIImage(),
-            backgroundColor: GiniColor(lightModeColorName: .light7, darkModeColorName: .light7).uiColor(),
+            backgroundColor: GiniColor(lightModeColorName: .light7,
+                                       darkModeColorName: .light7).uiColor(),
             rectangleColor: GiniColor.standard5.uiColor(),
             infoBarLabelFont: GiniHealthConfiguration.shared.font(for: .captions1),
             statusBarStyle: GiniHealthConfiguration.shared.paymentReviewStatusBarStyle,
-            pageIndicatorTintColor: GiniColor.standard4.uiColor(),
-            currentPageIndicatorTintColor: GiniColor(lightModeColorName: .dark2, darkModeColorName: .light5).uiColor(),
+            pageIndicatorTintColor: GiniColor(lightModeColorName: .dark1,
+                                              darkModeColorName: .light1).uiColor().withAlphaComponent(0.3),
+            currentPageIndicatorTintColor: GiniColor(lightModeColorName: .dark1,
+                                                     darkModeColorName: .light1).uiColor(),
             isInfoBarHidden: GiniHealthConfiguration.shared.useInvoiceWithoutDocument ? true : false,
             popupAnimationDuration: GiniHealthConfiguration.shared.popupDurationPaymentReview
         )


### PR DESCRIPTION
## Pull Request Description

<!-- Briefly explain **what** this PR does and **why**. Mention the motivation, feature, or issue it's addressing. -->

[HEAL-526](https://ginis.atlassian.net/browse/HEAL-526) 
This PR addresses HEAL-526 by wiring configurable page-control tint colors through the payment review screen so the preview image carousel uses the desired `pageIndicatorTintColor` and `currentPageIndicatorTintColor`.

**Changes:**
- Updates `GiniHealth` payment components configuration to provide new `pageIndicatorTintColor` and `currentPageIndicatorTintColor` values for the payment review screen.
- Passes the configuration’s page-indicator colors from `PaymentReviewContentView` into the carousel component via a new `GiniCarouselViewModel`.
- Applies page-control tint colors inside `GiniCarouselView` (currently via `UIPageControl` appearance configuration).

[HEAL-526]: https://ginis.atlassian.net/browse/HEAL-526?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ