### PR TITLE
fix: Apply accent1 tint to keyboard Done buttons

### DIFF
--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/PaymentReviewObservableModel.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/PaymentReviewObservableModel.swift
@@ -54,6 +54,15 @@ final class PaymentReviewObservableModel: ObservableObject {
     }
 
     /**
+     Tint for the keyboard Done button. Supplied by the host SDK via
+     PaymentReviewContainerConfiguration so it stays decoupled from the
+     primary/Pay button styling.
+     */
+    var keyboardDoneButtonTintColor: Color {
+        Color(uiColor: containerViewModel.configuration.keyboardDoneButtonTintColor)
+    }
+
+    /**
      Tracks the keyboard-dismissed analytics event and clears the stored active field so that
      a subsequent device rotation does not restore focus (and reopen the keyboard).
      Call this when the user explicitly taps the Done button.

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/Views/PaymentInformation/PaymentReviewContainerConfiguration.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/Views/PaymentInformation/PaymentReviewContainerConfiguration.swift
@@ -72,15 +72,18 @@ public struct PaymentReviewContainerConfiguration {
     let banksPicker: PaymentReviewBanksPickerConfiguration
     let infoBar: PaymentReviewInfoBarConfiguration
     let popupAnimationDuration: TimeInterval
-    
+    let keyboardDoneButtonTintColor: UIColor
+
     public init(errorLabel: PaymentReviewErrorLabelConfiguration,
                 banksPicker: PaymentReviewBanksPickerConfiguration,
                 infoBar: PaymentReviewInfoBarConfiguration,
-                popupAnimationDuration: TimeInterval) {
+                popupAnimationDuration: TimeInterval,
+                keyboardDoneButtonTintColor: UIColor = .tintColor) {
         self.errorLabel = errorLabel
         self.banksPicker = banksPicker
         self.infoBar = infoBar
         self.popupAnimationDuration = popupAnimationDuration
+        self.keyboardDoneButtonTintColor = keyboardDoneButtonTintColor
     }
 }
 

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/Views/PaymentInformation/PaymentReviewPaymentInformationObservableModel.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/Views/PaymentInformation/PaymentReviewPaymentInformationObservableModel.swift
@@ -75,7 +75,16 @@ final class PaymentReviewPaymentInformationObservableModel: ObservableObject {
     var poweredByGiniViewModel: PoweredByGiniViewModel {
         model.poweredByGiniViewModel
     }
-    
+
+    /**
+     Tint for the keyboard Done button. Supplied by the host SDK via
+     PaymentReviewContainerConfiguration so it stays decoupled from the
+     primary/Pay button styling.
+     */
+    var keyboardDoneButtonTintColor: Color {
+        Color(uiColor: model.configuration.keyboardDoneButtonTintColor)
+    }
+
     let model: PaymentReviewContainerViewModel
     
     init(model: PaymentReviewContainerViewModel) {

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/Views/PaymentInformation/PaymentReviewPaymentInformationView.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/Views/PaymentInformation/PaymentReviewPaymentInformationView.swift
@@ -139,6 +139,7 @@ struct PaymentReviewPaymentInformationView: View {
                         Button(viewModelStrings.keyboardDoneButtonTitle) {
                             dismissAmountKeyboard()
                         }
+                        .tint(viewModel.keyboardDoneButtonTintColor)
                     }
                 }
             }
@@ -199,6 +200,7 @@ struct PaymentReviewPaymentInformationView: View {
             Button(viewModelStrings.keyboardDoneButtonTitle) {
                 dismissAmountKeyboard()
             }
+            .tint(viewModel.keyboardDoneButtonTintColor)
             .padding(.horizontal, Constants.doneButtonHorizontalPadding)
         }
         .frame(height: Constants.doneButtonBarHeight)

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/Views/PaymentReviewContentView.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/Views/PaymentReviewContentView.swift
@@ -73,6 +73,7 @@ public struct PaymentReviewContentView: View {
                                                             from: nil,
                                                             for: nil)
                         }
+                        .tint(viewModel.keyboardDoneButtonTintColor)
                         .padding(.trailing, Constants.doneButtonHorizontalPadding)
                     }
                 }

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Tests/GiniInternalPaymentSDKTests/PaymentReviewKeyboardDoneButtonTintTests.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Tests/GiniInternalPaymentSDKTests/PaymentReviewKeyboardDoneButtonTintTests.swift
@@ -1,0 +1,43 @@
+//
+//  PaymentReviewKeyboardDoneButtonTintTests.swift
+//  GiniInternalPaymentSDKTests
+//
+//  Copyright © 2026 Gini GmbH. All rights reserved.
+//
+
+import Testing
+import UIKit
+import SwiftUI
+@testable import GiniInternalPaymentSDK
+
+@Suite("Keyboard Done button tint color")
+@MainActor
+struct PaymentReviewKeyboardDoneButtonTintTests {
+
+    @Test("PaymentReviewContainerConfiguration carries the tint color to the container view model")
+    func containerConfigurationCarriesTintColor() {
+        let vm = PaymentReviewContainerViewModel.test()
+
+        #expect(vm.configuration.keyboardDoneButtonTintColor == .systemBlue,
+                "configuration.keyboardDoneButtonTintColor must match the value passed at init")
+    }
+
+    @Test("PaymentReviewObservableModel exposes the tint color as a SwiftUI Color")
+    func observableModelExposesTintColor() {
+        let delegate = MockPaymentReviewDelegate()
+        let provider = MockBottomSheetsProvider()
+        let model = makePaymentReviewModel(delegate: delegate, bottomSheetsProvider: provider)
+        let sut = PaymentReviewObservableModel(model: model)
+
+        #expect(sut.keyboardDoneButtonTintColor == Color(uiColor: .systemBlue),
+                "keyboardDoneButtonTintColor must expose the container configuration's UIColor as a SwiftUI Color")
+    }
+
+    @Test("PaymentReviewPaymentInformationObservableModel exposes the tint color as a SwiftUI Color")
+    func paymentInformationObservableModelExposesTintColor() {
+        let sut = PaymentReviewPaymentInformationObservableModel(model: .test())
+
+        #expect(sut.keyboardDoneButtonTintColor == Color(uiColor: .systemBlue),
+                "keyboardDoneButtonTintColor must expose the container configuration's UIColor as a SwiftUI Color")
+    }
+}

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Tests/GiniInternalPaymentSDKTests/PaymentReviewTestHelpers.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Tests/GiniInternalPaymentSDKTests/PaymentReviewTestHelpers.swift
@@ -135,7 +135,8 @@ extension PaymentReviewContainerConfiguration {
         return PaymentReviewContainerConfiguration(errorLabel: errorLabel,
                                                    banksPicker: banksPicker,
                                                    infoBar: infoBar,
-                                                   popupAnimationDuration: 3.0)
+                                                   popupAnimationDuration: 3.0,
+                                                   keyboardDoneButtonTintColor: .systemBlue)
     }
 }
 

--- a/HealthSDK/GiniHealthSDK/Sources/GiniHealthSDK/Core/GiniHealth+PaymentComponentsConfigurationProvider.swift
+++ b/HealthSDK/GiniHealthSDK/Sources/GiniHealthSDK/Core/GiniHealth+PaymentComponentsConfigurationProvider.swift
@@ -44,7 +44,8 @@ extension GiniHealth: PaymentComponentsConfigurationProvider {
                            labelFont: GiniHealthConfiguration.shared.font(for: .captions1),
                            backgroundColor: GiniColor.success1.uiColor(),
                            containerBackgroundColor: GiniColor.standard7.uiColor()),
-            popupAnimationDuration: GiniHealthConfiguration.shared.popupDurationPaymentReview
+            popupAnimationDuration: GiniHealthConfiguration.shared.popupDurationPaymentReview,
+            keyboardDoneButtonTintColor: GiniColor.accent1.uiColor()
         )
     }
 


### PR DESCRIPTION
- Plumb keyboardDoneButtonTintColor: UIColor through PaymentReviewContainerConfiguration; HealthSDK sets it to GiniColor.accent1.uiColor().
- Apply .tint to the three Done buttons: iOS <26 landscape toolbar, iOS 26+ Liquid Glass keyboard toolbar, and iOS <26 doneButtonBar above the .decimalPad.

HEAL-508