### PR TITLE
Pp 2521 toggle switch liquid glass

### DIFF
--- a/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/ReturnAssistant/DigitalInvoice/DigitalInvoiceViewController.swift
+++ b/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/ReturnAssistant/DigitalInvoice/DigitalInvoiceViewController.swift
@@ -252,7 +252,15 @@ final class DigitalInvoiceViewController: UIViewController {
                 navigationBarBottomAdapter?.updateSkontoSavingsInfoVisibility(hidden: !isSkontoApplied)
             }
         }
-        tableView.reloadData()
+        // Reconfigure visible cells in place instead of dequeueing new ones so
+        // the iOS 26 Liquid Glass UISwitch isn't animated on unrelated rows
+        // when the table reloads after a tap.
+        if #available(iOS 15.0, *),
+           let visibleIndexPaths = tableView.indexPathsForVisibleRows, !visibleIndexPaths.isEmpty {
+            tableView.reconfigureRows(at: visibleIndexPaths)
+        } else {
+            tableView.reloadData()
+        }
         proceedView.configure(viewModel: viewModel)
     }
 

--- a/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Resources/DigitalLineItemTableViewCell.xib
+++ b/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Resources/DigitalLineItemTableViewCell.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="23504" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="24765" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23506"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="24743"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -22,17 +22,14 @@
                             <rect key="frame" x="0.0" y="0.0" width="414" height="155"/>
                             <subviews>
                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="6LC-kT-CZp" userLabel="Separator View">
-                                    <rect key="frame" x="0.0" y="0.0" width="349" height="1"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="337" height="1"/>
                                     <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                     <constraints>
                                         <constraint firstAttribute="height" constant="1" id="w1f-up-Wj9"/>
                                     </constraints>
                                 </view>
                                 <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="CUJ-3d-daD">
-                                    <rect key="frame" x="349" y="17" width="51" height="31"/>
-                                    <constraints>
-                                        <constraint firstAttribute="width" constant="49" id="6yf-59-2jq"/>
-                                    </constraints>
+                                    <rect key="frame" x="337" y="17" width="63" height="28"/>
                                 </switch>
                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="751" insetsLayoutMarginsFromSafeArea="NO" text="Nike Sportswear Air Max 97 - Sneaker Low…" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" minimumScaleFactor="0.90000000000000002" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="ci3-Xk-SLN">
                                     <rect key="frame" x="16" y="17" width="226" height="42.5"/>
@@ -133,7 +130,7 @@
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>
         <systemColor name="systemOrangeColor">
-            <color red="1" green="0.58431372550000005" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <color red="1" green="0.55294117647058827" blue="0.15686274509803921" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
     </resources>
 </document>

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Review/Views/SaveToGalleryView.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Review/Views/SaveToGalleryView.swift
@@ -29,7 +29,6 @@ final class SaveToGalleryView: UIView {
 
     private lazy var switchUIControl: UISwitch = {
         let switchUIControl = UISwitch()
-
         switchUIControl.onTintColor = GiniColor(light: .GiniCapture.accent1,
                                                 dark: .GiniCapture.accent1).uiColor()
 
@@ -112,9 +111,8 @@ final class SaveToGalleryView: UIView {
         backgroundColor = GiniColor(light: .GiniCapture.light1,
                                     dark: .GiniCapture.dark3).uiColor()
         layer.borderWidth = Constants.borderWidthOnStateApperance
-
-        switchUIControl.onTintColor = GiniColor(light: .GiniCapture.accent1,
-                                                dark: .GiniCapture.accent1).uiColor()
+        // onTintColor is set once in the switch's initializer. Keep it fixed
+        // to avoid iOS 26 Liquid Glass pill animation on tap.
     }
 
     private func applyOffStateAppearance() {
@@ -124,9 +122,9 @@ final class SaveToGalleryView: UIView {
         layer.borderWidth = Constants.borderWidthOffStateApperance
         layer.borderColor = GiniColor(light: .GiniCapture.light3,
                                       dark: .GiniCapture.dark4).uiColor().cgColor
-
-        switchUIControl.onTintColor = GiniColor(light: .GiniCapture.light4,
-                                                dark: .GiniCapture.dark4).uiColor()
+        // onTintColor is only visible while the switch is on. Rewriting it here
+        // makes the iOS 26 Liquid Glass pill animate its color mid-tap; keep it
+        // pinned to the on-state accent instead.
     }
 
     @objc private func didToggleSwitch(_ enabledSwitch: UISwitch) {


### PR DESCRIPTION
## Pull Request Description

<!-- Briefly explain **what** this PR does and **why**. Mention the motivation, feature, or issue it's addressing. -->

[PP-2521](https://ginis.atlassian.net/browse/PP-2521)<!-- Closes ticket number PP-####; Replace with JIRA ticket if relevant -->

This PR adjusts how UISwitch appearance and table updates are applied in CaptureSDK and BankSDK to reduce the “Liquid Glass” style animations triggered by updating switch tint colors and reloading table views after toggles.



<!--

Some description of HOW you achieved it. Perhaps give a high level description of the chnages you did. Did you need to refactor something? What tradeoffs did you take?

-->

## Notes for Reviewers
- CaptureSDK: Stops rewriting UISwitch.onTintColor during on/off appearance updates in SaveToGalleryView.
- BankSDK: Replaces tableView.reloadData() in DigitalInvoiceViewController.updateValues() with a “reconfigure visible rows” approach to avoid switch animations on reload.
- BankSDK: Updates DigitalLineItemTableViewCell.xib (Xcode re-save / layout metadata changes).
<!--

Explain how you verified the changes.
A clear testing scenario helps colleagues who may not be familiar with this part of the code quickly understand and verify the changes. Include steps they can follow to see the impact in action.

You can include: 
- Simulators/Devices you used (e.g. iPhone 13, iPad Pro) 
- iOS versions tested (e.g. 16.0, 17.5) 
- Manual checks (e.g. flow tested: onboarding, permissions, error states) 
- Unit tests added or updated 
 
 Include screenshots, screen recordings, or simulator gifs for UI changes. 
 
 - Optional: Anything that needs extra attention in review? Are there TODOs, known limitations, or follow-up work? 
 
 -->

[PP-2521]: https://ginis.atlassian.net/browse/PP-2521?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ