### PR TITLE
Fix/heal 508 done reusable bank sdk

### DIFF
--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/PaymentReviewObservableModel.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/PaymentReviewObservableModel.swift
@@ -29,9 +29,9 @@ final class PaymentReviewObservableModel: ObservableObject {
     }
 
     /**
-     Set to `true` by `PaymentReviewViewController.viewWillTransition` before imperatively
-     dismissing the sheet, so the sheet's `onDismiss` handler knows not to call `didTapClose`.
-     Reset to `false` inside that same `onDismiss` handler via `defer`.
+     `true` while a rotation is tearing the view down. Read by the sheet's `onDismiss` (to
+     skip `didTapClose`) and by `handleFocusedFieldChange` (to preserve `activeField` so
+     `restoreFocusIfNeeded` can restore focus). Reset when the remounted view regains focus.
      */
     @Published var isDismissingForRotation: Bool = false
 
@@ -68,11 +68,7 @@ final class PaymentReviewObservableModel: ObservableObject {
      Call this when the user explicitly taps the Done button.
      */
     func trackKeyboardDismissed() {
-        // Clear immediately — the 0.1 s delay in `onChange(of: focusedField)` is designed to
-        // distinguish rotation from a manual dismiss, but if the user rotates right after tapping
-        // Done the view is already gone and the check sees `isViewVisible == false`, keeping
-        // `activeField` set and reopening the keyboard in the new layout. Clearing here first
-        // wins the race.
+        // Clear so a subsequent rotation doesn't re-focus via `restoreFocusIfNeeded`.
         paymentInformationObservableModel.activeField = nil
         model.delegate?.trackOnPaymentReviewCloseKeyboardClicked()
     }
@@ -104,6 +100,7 @@ final class PaymentReviewObservableModel: ObservableObject {
         self.containerViewModel = model.paymentReviewContainerViewModel()
         self.paymentInformationObservableModel = PaymentReviewPaymentInformationObservableModel(model: containerViewModel)
         self.showBanner = !model.configuration.isInfoBarHidden
+        paymentInformationObservableModel.parentModel = self
         setupBindings()
         
         reduceMotionObserver = NotificationCenter.default.addObserver(forName: UIAccessibility.reduceMotionStatusDidChangeNotification, object: nil, queue: .main) { [weak self] _ in

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/PaymentReviewViewController.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/PaymentReviewViewController.swift
@@ -89,6 +89,11 @@ public final class PaymentReviewViewController: UIHostingController<PaymentRevie
         let isLandscape = size.width > size.height
 
         observableModel.isDismissingForRotation = true
+        // Reset when the rotation animation completes so the flag can't get stuck `true`
+        // if no field regains focus after the transition.
+        coordinator.animate(alongsideTransition: nil) { [weak self] _ in
+            self?.observableModel.isDismissingForRotation = false
+        }
 
         // On iOS 16 the `.presentationCompactAdaptation(.fullScreenCover)` animation fires
         // the moment the size class changes — before SwiftUI's onChange and before a

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/PaymentReviewViewController.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/PaymentReviewViewController.swift
@@ -87,22 +87,18 @@ public final class PaymentReviewViewController: UIHostingController<PaymentRevie
         // `size` is the *incoming* size, not the current one — it must be used here rather than
         // relying on `UIDevice.isPortrait()`, which reflects the old orientation at this point in the transition.
         let isLandscape = size.width > size.height
-        guard isLandscape, let presentedVC = presentedViewController else { return }
+
+        observableModel.isDismissingForRotation = true
 
         // On iOS 16 the `.presentationCompactAdaptation(.fullScreenCover)` animation fires
         // the moment the size class changes — before SwiftUI's onChange and before a
         // snapshot-hiding approach can take effect. The only reliable fix is to dismiss
         // the sheet imperatively at the UIKit level here, before that animation starts.
-        //
-        // Setting isDismissingForRotation first ensures the sheet's onDismiss handler
-        // does not call didTapClose (which would close the entire payment review).
-        // SwiftUI reconciles showBottomSheet = false via the sheet's isPresented binding
-        // when the UIKit dismiss fires the onDismiss callback.
-        //
-        // On iOS 17+ SwiftUI's onChange(of: giniLayout.isLandscape) also runs, but
-        // showBottomSheet is already false by then so it becomes a no-op.
-        observableModel.isDismissingForRotation = true
-        presentedVC.dismiss(animated: false)
+        // On iOS 17+ SwiftUI's `onChange(of: giniLayout.isLandscape)` also runs, but
+        // `showBottomSheet` is already false by then so it becomes a no-op.
+        if isLandscape, let presentedVC = presentedViewController {
+            presentedVC.dismiss(animated: false)
+        }
     }
 
     public override func viewDidDisappear(_ animated: Bool) {

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/Views/PaymentInformation/PaymentReviewPaymentInformationObservableModel.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/Views/PaymentInformation/PaymentReviewPaymentInformationObservableModel.swift
@@ -30,8 +30,10 @@ final class PaymentReviewPaymentInformationObservableModel: ObservableObject {
      */
     @Published var activeField: ActivePaymentField? = nil
 
-    /// Back-reference so the view's focus handler can read `isDismissingForRotation`
-    /// to tell a rotation teardown from a user dismiss.
+    /**
+     Back-reference so the view's focus handler can read `isDismissingForRotation`
+     to tell a rotation teardown from a user dismiss.
+     */
     weak var parentModel: PaymentReviewObservableModel?
 
     /**

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/Views/PaymentInformation/PaymentReviewPaymentInformationObservableModel.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/Views/PaymentInformation/PaymentReviewPaymentInformationObservableModel.swift
@@ -30,11 +30,9 @@ final class PaymentReviewPaymentInformationObservableModel: ObservableObject {
      */
     @Published var activeField: ActivePaymentField? = nil
 
-    /**
-     Set to `true` while the view is on screen. Used to distinguish a rotation (view
-     disappears quickly) from the user explicitly dismissing the keyboard (view stays visible).
-     */
-    var isViewVisible: Bool = false
+    /// Back-reference so the view's focus handler can read `isDismissingForRotation`
+    /// to tell a rotation teardown from a user dismiss.
+    weak var parentModel: PaymentReviewObservableModel?
 
     /**
      Tracks whether the amount field is currently focused.

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/Views/PaymentInformation/PaymentReviewPaymentInformationObservableModel.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/Views/PaymentInformation/PaymentReviewPaymentInformationObservableModel.swift
@@ -85,6 +85,14 @@ final class PaymentReviewPaymentInformationObservableModel: ObservableObject {
         Color(uiColor: model.configuration.keyboardDoneButtonTintColor)
     }
 
+    /**
+     UIKit variant of `keyboardDoneButtonTintColor`, consumed by `GiniDoneAccessoryView`
+     (a UIToolbar-based `inputAccessoryView`) which needs a `UIColor` rather than SwiftUI `Color`.
+     */
+    var keyboardDoneButtonTintUIColor: UIColor {
+        model.configuration.keyboardDoneButtonTintColor
+    }
+
     let model: PaymentReviewContainerViewModel
     
     init(model: PaymentReviewContainerViewModel) {

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/Views/PaymentInformation/PaymentReviewPaymentInformationView.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/Views/PaymentInformation/PaymentReviewPaymentInformationView.swift
@@ -70,15 +70,11 @@ struct PaymentReviewPaymentInformationView: View {
     var body: some View {
         scrollView
             .onAppear {
-                viewModel.isViewVisible = true
                 viewModel.populateFieldsIfNeeded()
                 // Move VoiceOver focus into sheet content on appear.
                 UIAccessibility.post(notification: .screenChanged, argument: nil)
                 // Restore focus after rotation recreates the view.
                 restoreFocusIfNeeded()
-            }
-            .onDisappear {
-                viewModel.isViewVisible = false
             }
             .onChange(of: focusedField) { newField in
                 handleFocusedFieldChange(newField)
@@ -506,27 +502,20 @@ struct PaymentReviewPaymentInformationView: View {
         if let field = newField {
             viewModel.activeField = field
             viewModel.isAmountFieldFocused = (field == .amount)
+            // A focus event means rotation is done — subsequent focus resigns should clear.
+            viewModel.parentModel?.isDismissingForRotation = false
         } else {
-            // Hide Done toolbar immediately; delay clearing activeField to distinguish dismiss from rotation.
             viewModel.isAmountFieldFocused = false
-            let fieldToClear = viewModel.activeField
-            Task { @MainActor in
-                try? await Task.sleep(for: .milliseconds(100))
-                if viewModel.isViewVisible,
-                   focusedField == nil,
-                   viewModel.activeField == fieldToClear {
-                    viewModel.activeField = nil
-                }
+            // Preserve activeField during rotation so `restoreFocusIfNeeded` can re-apply focus.
+            if viewModel.parentModel?.isDismissingForRotation != true {
+                viewModel.activeField = nil
             }
         }
     }
 
     /**
-     Delays 400 ms for rotation animation before re-applying focus. No `isViewVisible` guard —
-     it reads the shared viewmodel flag and races with the outgoing view's `onDisappear`, which
-     can fire *after* the incoming view's `onAppear` during a SwiftUI transition and flip the flag
-     back to `false`, causing the guard to fail even though the current view is alive and ready
-     for focus. Setting `focusedField` on a dismissed view is a benign no-op, so no guard is safer.
+     Delays 400 ms for the rotation animation to settle before re-applying focus. Setting
+     `focusedField` on a dismissed view is a benign no-op, so no visibility guard is needed.
      */
     private func restoreFocusIfNeeded() {
         guard let field = viewModel.activeField else { return }

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/Views/PaymentInformation/PaymentReviewPaymentInformationView.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/Views/PaymentInformation/PaymentReviewPaymentInformationView.swift
@@ -68,30 +68,28 @@ struct PaymentReviewPaymentInformationView: View {
     }
     
     var body: some View {
-        keyboardToolbarIfNeeded(
-            scrollView
-                .onAppear {
-                    viewModel.isViewVisible = true
-                    viewModel.populateFieldsIfNeeded()
-                    // Move VoiceOver focus into sheet content on appear.
-                    UIAccessibility.post(notification: .screenChanged, argument: nil)
-                    // Restore focus after rotation recreates the view.
-                    restoreFocusIfNeeded()
-                }
-                .onDisappear {
-                    viewModel.isViewVisible = false
-                }
-                .onChange(of: focusedField) { newField in
-                    handleFocusedFieldChange(newField)
-                }
-                .background(Color(.systemBackground))
-                .onReceive(NotificationCenter.default.publisher(for: UIResponder.keyboardWillShowNotification)) { notification in
-                    handleKeyboardWillShow(notification)
-                }
-                .onReceive(NotificationCenter.default.publisher(for: UIResponder.keyboardWillHideNotification)) { _ in
-                    handleKeyboardWillHide()
-                }
-        )
+        scrollView
+            .onAppear {
+                viewModel.isViewVisible = true
+                viewModel.populateFieldsIfNeeded()
+                // Move VoiceOver focus into sheet content on appear.
+                UIAccessibility.post(notification: .screenChanged, argument: nil)
+                // Restore focus after rotation recreates the view.
+                restoreFocusIfNeeded()
+            }
+            .onDisappear {
+                viewModel.isViewVisible = false
+            }
+            .onChange(of: focusedField) { newField in
+                handleFocusedFieldChange(newField)
+            }
+            .background(Color(.systemBackground))
+            .onReceive(NotificationCenter.default.publisher(for: UIResponder.keyboardWillShowNotification)) { notification in
+                handleKeyboardWillShow(notification)
+            }
+            .onReceive(NotificationCenter.default.publisher(for: UIResponder.keyboardWillHideNotification)) { _ in
+                handleKeyboardWillHide()
+            }
     }
 
     // MARK: Private keyboard handlers
@@ -124,30 +122,6 @@ struct PaymentReviewPaymentInformationView: View {
         }
     }
 
-    // Attaches the iOS 26 Liquid Glass keyboard toolbar without creating an empty UIToolbar
-    // on iOS <26 (which would log a harmless but noisy _UIToolbarContentView.width==0 warning).
-    @ViewBuilder
-    private func keyboardToolbarIfNeeded(_ base: some View) -> some View {
-        if #available(iOS 26, *) {
-            // Condition must stay inside ToolbarItemGroup (always-registered) for all modes.
-            // Moving it outside switches the view identity when the keyboard appears, which
-            // destroys and recreates the view — causing a jump and breaking keyboard presentation.
-            base.toolbar {
-                ToolbarItemGroup(placement: .keyboard) {
-                    if focusedField == .amount && keyboardHeight > 0 {
-                        Spacer()
-                        Button(viewModelStrings.keyboardDoneButtonTitle) {
-                            dismissAmountKeyboard()
-                        }
-                        .tint(viewModel.keyboardDoneButtonTintColor)
-                    }
-                }
-            }
-        } else {
-            base
-        }
-    }
-
     // MARK: Private views
 
     @ViewBuilder
@@ -159,28 +133,19 @@ struct PaymentReviewPaymentInformationView: View {
         }
     }
 
-    // Sheet context: sheet repositions above the keyboard; suppress double-adjustment.
+    // Sheet context: sheet lifts above the keyboard; suppress double-adjustment.
+    // No safeAreaInset for a Done button: the amount field's UIKit input accessory view
+    // (`GiniDoneAccessoryView`, installed by `KeyboardAccessoryInstaller`) is part of the
+    // keyboard from the system's point of view, so the sheet already lifts above it.
     @ViewBuilder
     private var sheetScrollView: some View {
         baseScrollView
             .ignoresSafeArea(.keyboard)
-            .safeAreaInset(edge: .bottom) {
-                if focusedField == .amount && keyboardHeight > 0 {
-                    if #available(iOS 26, *) {
-                        // Reserve height for the Liquid Glass button (ToolbarItemGroup) so
-                        // content doesn't slide behind it at the sheet/keyboard boundary.
-                        Color.clear
-                            .frame(height: Constants.doneButtonBarHeight)
-                            .allowsHitTesting(false)
-                    } else {
-                        doneButtonBar
-                    }
-                }
-            }
     }
 
     // Landscape docCollection: manual spacer keeps content above the keyboard.
-    // Done button: ContentView toolbar (iOS <26) or Liquid Glass toolbar (iOS 26+).
+    // Done button comes from the amount field's UIKit input accessory view — no toolbar needed.
+    // `keyboardHeight` from the will-show notification already includes the accessory-view height.
     @ViewBuilder
     private var docCollectionScrollView: some View {
         baseScrollView
@@ -190,22 +155,6 @@ struct PaymentReviewPaymentInformationView: View {
                     .frame(height: keyboardHeight)
                     .allowsHitTesting(false)
             }
-    }
-
-    // Done bar substituting the missing return key on .decimalPad; iOS <26 only.
-    @ViewBuilder
-    private var doneButtonBar: some View {
-        HStack {
-            Spacer()
-            Button(viewModelStrings.keyboardDoneButtonTitle) {
-                dismissAmountKeyboard()
-            }
-            .tint(viewModel.keyboardDoneButtonTintColor)
-            .padding(.horizontal, Constants.doneButtonHorizontalPadding)
-        }
-        .frame(height: Constants.doneButtonBarHeight)
-        .background(.regularMaterial)
-        .overlay(alignment: .top) { Divider() }
     }
 
     private var baseScrollView: some View {
@@ -370,6 +319,21 @@ struct PaymentReviewPaymentInformationView: View {
                 field: .amount,
                 inputState: viewModel.amountInputState
             ))
+            // Attach the UIKit Done accessory to whichever UITextField SwiftUI creates for this
+            // field. Done via responder-chain traversal (see KeyboardAccessoryInstaller): reliable
+            // because `UITextField.inputAccessoryView` is glued to the keyboard's own window by
+            // the system, and non-invasive because SwiftUI TextField + @FocusState continue to
+            // manage the editing/focus lifecycle exactly as they do for the other fields.
+            .background(
+                KeyboardAccessoryInstaller(
+                    isActive: focusedField == .amount,
+                    doneTintColor: viewModel.keyboardDoneButtonTintUIColor,
+                    onDone: { dismissAmountKeyboard() }
+                )
+                .frame(width: 0, height: 0)
+                .allowsHitTesting(false)
+                .accessibilityHidden(true)
+            )
     }
     
     @ViewBuilder
@@ -506,6 +470,12 @@ struct PaymentReviewPaymentInformationView: View {
     private func dismissAmountKeyboard() {
         onKeyboardDismissed()
         viewModel.handleAmountFocusChange(isFocused: false)
+        // Clear activeField up-front (mirrors clearFocus()), so the field's visual .focused
+        // state drops the moment the user taps Done — otherwise it lingers until the 100ms
+        // delayed clear in handleFocusedFieldChange runs, and can miss entirely if a rotation
+        // fires in the meantime. Safe here because Done is an explicit user dismiss, not a
+        // transient rotation.
+        viewModel.activeField = nil
         focusedField = nil
     }
 
@@ -541,7 +511,7 @@ struct PaymentReviewPaymentInformationView: View {
             viewModel.isAmountFieldFocused = false
             let fieldToClear = viewModel.activeField
             Task { @MainActor in
-                try await Task.sleep(for: .milliseconds(100))
+                try? await Task.sleep(for: .milliseconds(100))
                 if viewModel.isViewVisible,
                    focusedField == nil,
                    viewModel.activeField == fieldToClear {
@@ -552,13 +522,16 @@ struct PaymentReviewPaymentInformationView: View {
     }
 
     /**
-     Delays 400 ms for rotation animation before re-applying focus.
+     Delays 400 ms for rotation animation before re-applying focus. No `isViewVisible` guard —
+     it reads the shared viewmodel flag and races with the outgoing view's `onDisappear`, which
+     can fire *after* the incoming view's `onAppear` during a SwiftUI transition and flip the flag
+     back to `false`, causing the guard to fail even though the current view is alive and ready
+     for focus. Setting `focusedField` on a dismissed view is a benign no-op, so no guard is safer.
      */
     private func restoreFocusIfNeeded() {
         guard let field = viewModel.activeField else { return }
         Task { @MainActor in
-            try await Task.sleep(for: .milliseconds(400))
-            guard viewModel.isViewVisible else { return }
+            try? await Task.sleep(for: .milliseconds(400))
             focusedField = field
         }
     }
@@ -579,7 +552,5 @@ struct PaymentReviewPaymentInformationView: View {
         static let textFieldsContainerHorizontalPadding = 16.0
         static let textFieldsContainerTopPadding = 24.0
         static let poweredByGiniTopPadding = 8.0
-        static let doneButtonBarHeight = 44.0
-        static let doneButtonHorizontalPadding = 16.0
     }
 }

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/Views/PaymentInformation/PaymentReviewPaymentInformationView.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/Views/PaymentInformation/PaymentReviewPaymentInformationView.swift
@@ -131,7 +131,7 @@ struct PaymentReviewPaymentInformationView: View {
 
     // Sheet context: sheet lifts above the keyboard; suppress double-adjustment.
     // No safeAreaInset for a Done button: the amount field's UIKit input accessory view
-    // (`GiniDoneAccessoryView`, installed by `KeyboardAccessoryInstaller`) is part of the
+    // (`GiniDoneAccessoryView`, installed by `GiniKeyboardAccessoryInstaller`) is part of the
     // keyboard from the system's point of view, so the sheet already lifts above it.
     @ViewBuilder
     private var sheetScrollView: some View {
@@ -316,12 +316,12 @@ struct PaymentReviewPaymentInformationView: View {
                 inputState: viewModel.amountInputState
             ))
             // Attach the UIKit Done accessory to whichever UITextField SwiftUI creates for this
-            // field. Done via responder-chain traversal (see KeyboardAccessoryInstaller): reliable
+            // field. Done via responder-chain traversal (see GiniKeyboardAccessoryInstaller): reliable
             // because `UITextField.inputAccessoryView` is glued to the keyboard's own window by
             // the system, and non-invasive because SwiftUI TextField + @FocusState continue to
             // manage the editing/focus lifecycle exactly as they do for the other fields.
             .background(
-                KeyboardAccessoryInstaller(
+                GiniKeyboardAccessoryInstaller(
                     isActive: focusedField == .amount,
                     doneTintColor: viewModel.keyboardDoneButtonTintUIColor,
                     onDone: { dismissAmountKeyboard() }

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/Views/PaymentReviewContentView.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/Views/PaymentReviewContentView.swift
@@ -57,28 +57,11 @@ public struct PaymentReviewContentView: View {
         .onAppear {
             viewModel.dismissBannerAfterDelay()
         }
-        // iOS <26 landscape: always-registered ToolbarItemGroup (condition inside) so the bar
-        // never detaches mid-transition, which would cause a glitch when leaving the amount field.
-        // UIKit may log a _UIToolbarContentView.width==0 warning on initial layout; it recovers harmlessly.
-        .toolbar {
-            if #unavailable(iOS 26) {
-                ToolbarItemGroup(placement: .keyboard) {
-                    if giniLayout.isLandscape && !viewModel.isBottomSheetMode && viewModel.isAmountFieldFocused {
-                        Spacer()
-                        Button(viewModel.keyboardDoneButtonTitle) {
-                            viewModel.trackKeyboardDismissed()
-                            viewModel.validateAmountFieldOnKeyboardDismiss()
-                            UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder),
-                                                            to: nil,
-                                                            from: nil,
-                                                            for: nil)
-                        }
-                        .tint(viewModel.keyboardDoneButtonTintColor)
-                        .padding(.trailing, Constants.doneButtonHorizontalPadding)
-                    }
-                }
-            }
-        }
+        // No `.toolbar { ToolbarItemGroup(placement: .keyboard) }` here. The amount field
+        // supplies its own Done button via `KeyboardAccessoryInstaller`, which installs a
+        // `GiniDoneAccessoryView` as the current UITextField's `inputAccessoryView` — the
+        // system attaches it directly to the keyboard's own window, reliable across all iOS
+        // versions, orientations, and sheet presentations.
     }
     
     // MARK: - Portrait Layout
@@ -249,7 +232,6 @@ public struct PaymentReviewContentView: View {
         static let landscapeContainerSpacing: CGFloat = 8.0
         static let paymentInformationContainerTopCornerRadius: CGFloat = 12.0
         static let paymentInformationContainerBottomCornerRadius: CGFloat = 6.0
-        static let doneButtonHorizontalPadding: CGFloat = 16.0
         static let grabberWidth: CGFloat = 36.0
         static let grabberHeight: CGFloat = 5.0
         static let grabberHitAreaWidth: CGFloat = 60.0

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/Views/PaymentReviewContentView.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/Views/PaymentReviewContentView.swift
@@ -69,7 +69,7 @@ public struct PaymentReviewContentView: View {
             viewModel.dismissBannerAfterDelay()
         }
         // No `.toolbar { ToolbarItemGroup(placement: .keyboard) }` here. The amount field
-        // supplies its own Done button via `KeyboardAccessoryInstaller`, which installs a
+        // supplies its own Done button via `GiniKeyboardAccessoryInstaller`, which installs a
         // `GiniDoneAccessoryView` as the current UITextField's `inputAccessoryView` — the
         // system attaches it directly to the keyboard's own window, reliable across all iOS
         // versions, orientations, and sheet presentations.

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/Views/PaymentReviewContentView.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/Views/PaymentReviewContentView.swift
@@ -44,6 +44,16 @@ public struct PaymentReviewContentView: View {
             if landscape && !viewModel.isBottomSheetMode && showBottomSheet {
                 viewModel.isDismissingForRotation = true
                 showBottomSheet = false
+            } else if !landscape && !viewModel.isBottomSheetMode {
+                // Landscape → portrait in embedded mode: the numeric keyboard would
+                // otherwise stay up throughout the sheet re-presentation, visible over
+                // the still-animating sheet for ~500 ms. Force-resign first responder now
+                // so the keyboard hides immediately; `restoreFocusIfNeeded` re-focuses
+                // (and re-raises the keyboard) after the sheet finishes animating in.
+                UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder),
+                                                to: nil,
+                                                from: nil,
+                                                for: nil)
             }
         }
         .overlay {

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/Views/PaymentReviewContentView.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/Views/PaymentReviewContentView.swift
@@ -41,10 +41,11 @@ public struct PaymentReviewContentView: View {
         .animation(.easeInOut(duration: Constants.layoutTransitionDuration), value: giniLayout.isLandscape)
         .onChange(of: giniLayout.isLandscape) { landscape in
             // Belt-and-suspenders: iOS 16 uses viewWillTransition; iOS 17+ uses this path.
-            if landscape && !viewModel.isBottomSheetMode && showBottomSheet {
-                viewModel.isDismissingForRotation = true
+            guard !viewModel.isBottomSheetMode else { return }
+            viewModel.isDismissingForRotation = true
+            if landscape && showBottomSheet {
                 showBottomSheet = false
-            } else if !landscape && !viewModel.isBottomSheetMode {
+            } else if !landscape {
                 // Landscape → portrait in embedded mode: the numeric keyboard would
                 // otherwise stay up throughout the sheet re-presentation, visible over
                 // the still-animating sheet for ~500 ms. Force-resign first responder now
@@ -101,7 +102,8 @@ public struct PaymentReviewContentView: View {
             }
         }
         .sheet(isPresented: $showBottomSheet) {
-            defer { viewModel.isDismissingForRotation = false }
+            // No flag reset here — `handleFocusedFieldChange` needs it true through the portrait
+            // teardown; it's reset when the remounted view regains focus.
             if !viewModel.isDismissingForRotation && (viewModel.isBottomSheetMode || isVoiceOverEnabled) {
                 viewModel.didTapClose()
             }

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/Views/TextField/GiniKeyboardAccessoryInstaller.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/Views/TextField/GiniKeyboardAccessoryInstaller.swift
@@ -8,20 +8,22 @@ import SwiftUI
 import UIKit
 import GiniUtilites
 
-/// A zero-size SwiftUI helper that installs a `GiniDoneAccessoryView` on the current
-/// first-responder `UITextField` while `isActive` is true.
-///
-/// Use as a `.background(...)` on the SwiftUI `TextField` that owns the focus (or on any
-/// ancestor). The SwiftUI `TextField` continues to manage editing and `@FocusState`;
-/// this helper only sets `inputAccessoryView` on whichever underlying UIKit `UITextField` is
-/// currently first responder.
-///
-/// Why this instead of a `.toolbar { ToolbarItemGroup(placement: .keyboard) }`:
-/// SwiftUI's keyboard toolbar is unreliable inside a `.sheet {}` on iOS 26 — after a
-/// portrait→landscape→portrait rotation the re-presented sheet's toolbar sometimes fails
-/// to re-attach, and the accessory view's height flipping empty↔populated triggers
-/// `_UIRemoteKeyboardPlaceholderView` constraint conflicts. UIKit's `inputAccessoryView`
-/// is glued to the keyboard's own window and has none of those failure modes.
+/**
+ A zero-size SwiftUI helper that installs a `GiniDoneAccessoryView` on the current
+ first-responder `UITextField` while `isActive` is `true`.
+
+ Use as a `.background(...)` on the SwiftUI `TextField` that owns the focus (or on any
+ ancestor). The SwiftUI `TextField` continues to manage editing and `@FocusState`; this
+ helper only sets `inputAccessoryView` on whichever underlying UIKit `UITextField` is
+ currently first responder.
+
+ Why this instead of a `.toolbar { ToolbarItemGroup(placement: .keyboard) }`:
+ SwiftUI's keyboard toolbar is unreliable inside a `.sheet {}` on iOS 26 — after a
+ portrait→landscape→portrait rotation the re-presented sheet's toolbar sometimes fails
+ to re-attach, and the accessory view's height flipping empty↔populated triggers
+ `_UIRemoteKeyboardPlaceholderView` constraint conflicts. UIKit's `inputAccessoryView`
+ is glued to the keyboard's own window and has none of those failure modes.
+ */
 struct GiniKeyboardAccessoryInstaller: UIViewRepresentable {
 
     let isActive: Bool
@@ -51,11 +53,15 @@ struct GiniKeyboardAccessoryInstaller: UIViewRepresentable {
         var onDone: () -> Void
         var doneTintColor: UIColor
 
-        /// The field we most recently attached to, so we can revert its `inputAccessoryView`
-        /// when the accessory is no longer relevant (focus moved to a non-decimal field, view dismissed).
+        /**
+         The field we most recently attached to, so we can clear our accessory
+         when it is no longer relevant (focus moved to a non-decimal field, view dismissed).
+         */
         private weak var attachedField: UITextField?
 
-        /// Injectable for tests; defaults to walking `UIApplication.shared.connectedScenes`.
+        /**
+         Injectable for tests; defaults to walking `UIApplication.shared.connectedScenes`.
+         */
         private let currentFirstResponder: () -> UITextField?
 
         init(doneTintColor: UIColor,
@@ -66,12 +72,19 @@ struct GiniKeyboardAccessoryInstaller: UIViewRepresentable {
             self.currentFirstResponder = currentFirstResponder
         }
 
-        /// Deferred to the next runloop so we don't mutate first-responder state during a SwiftUI update pass.
+        /**
+         Deferred to the next runloop so we don't mutate first-responder state during a
+         SwiftUI update pass.
+         */
         func apply(isActive: Bool, doneTintColor: UIColor, onDone: @escaping () -> Void) {
             self.onDone = onDone
             self.doneTintColor = doneTintColor
             let shouldInstall = isActive
-            DispatchQueue.main.async {
+            // `[weak self]` so a `dismantleUIView` between this schedule and the fire lets the
+            // coordinator deallocate — the closure then no-ops instead of re-installing on a
+            // first responder owned by another view.
+            DispatchQueue.main.async { [weak self] in
+                guard let self else { return }
                 if shouldInstall {
                     self.installIfNeeded()
                 } else {

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/Views/TextField/GiniKeyboardAccessoryInstaller.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/Views/TextField/GiniKeyboardAccessoryInstaller.swift
@@ -1,5 +1,5 @@
 //
-//  KeyboardAccessoryInstaller.swift
+//  GiniKeyboardAccessoryInstaller.swift
 //
 //  Copyright © 2026 Gini GmbH. All rights reserved.
 //
@@ -22,7 +22,7 @@ import GiniUtilites
 /// to re-attach, and the accessory view's height flipping empty↔populated triggers
 /// `_UIRemoteKeyboardPlaceholderView` constraint conflicts. UIKit's `inputAccessoryView`
 /// is glued to the keyboard's own window and has none of those failure modes.
-struct KeyboardAccessoryInstaller: UIViewRepresentable {
+struct GiniKeyboardAccessoryInstaller: UIViewRepresentable {
 
     let isActive: Bool
     let doneTintColor: UIColor

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/Views/TextField/GiniKeyboardAccessoryInstaller.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/Views/TextField/GiniKeyboardAccessoryInstaller.swift
@@ -33,22 +33,7 @@ struct GiniKeyboardAccessoryInstaller: UIViewRepresentable {
     }
 
     func updateUIView(_: UIView, context: Context) {
-        // Refresh the coordinator's captured callback so the Done tap always dispatches
-        // through the current view struct's closure.
-        context.coordinator.onDone = onDone
-        context.coordinator.doneTintColor = doneTintColor
-
-        // Defer to the next runloop so we don't mutate first-responder state during a
-        // SwiftUI update pass. By the time this fires, the SwiftUI TextField the user
-        // just focused has become first responder.
-        let shouldInstall = isActive
-        DispatchQueue.main.async {
-            if shouldInstall {
-                context.coordinator.installIfNeeded()
-            } else {
-                context.coordinator.uninstallIfInstalled()
-            }
-        }
+        context.coordinator.apply(isActive: isActive, doneTintColor: doneTintColor, onDone: onDone)
     }
 
     static func dismantleUIView(_: UIView, coordinator: Coordinator) {
@@ -70,13 +55,33 @@ struct GiniKeyboardAccessoryInstaller: UIViewRepresentable {
         /// when the accessory is no longer relevant (focus moved to a non-decimal field, view dismissed).
         private weak var attachedField: UITextField?
 
-        init(doneTintColor: UIColor, onDone: @escaping () -> Void) {
+        /// Injectable for tests; defaults to walking `UIApplication.shared.connectedScenes`.
+        private let currentFirstResponder: () -> UITextField?
+
+        init(doneTintColor: UIColor,
+             onDone: @escaping () -> Void,
+             currentFirstResponder: @escaping () -> UITextField? = { Coordinator.currentFirstResponderUITextField() }) {
             self.doneTintColor = doneTintColor
             self.onDone = onDone
+            self.currentFirstResponder = currentFirstResponder
+        }
+
+        /// Deferred to the next runloop so we don't mutate first-responder state during a SwiftUI update pass.
+        func apply(isActive: Bool, doneTintColor: UIColor, onDone: @escaping () -> Void) {
+            self.onDone = onDone
+            self.doneTintColor = doneTintColor
+            let shouldInstall = isActive
+            DispatchQueue.main.async {
+                if shouldInstall {
+                    self.installIfNeeded()
+                } else {
+                    self.uninstallIfInstalled()
+                }
+            }
         }
 
         func installIfNeeded() {
-            guard let field = Self.currentFirstResponderUITextField() else { return }
+            guard let field = currentFirstResponder() else { return }
             // Idempotent — if we already installed on this same field, keep the accessory and
             // just refresh the tint.
             if let existing = field.inputAccessoryView as? GiniDoneAccessoryView, existing.delegate === self {
@@ -109,7 +114,7 @@ struct GiniKeyboardAccessoryInstaller: UIViewRepresentable {
 
         // MARK: - Responder-chain discovery
 
-        private static func currentFirstResponderUITextField() -> UITextField? {
+        static func currentFirstResponderUITextField() -> UITextField? {
             for scene in UIApplication.shared.connectedScenes {
                 guard let windowScene = scene as? UIWindowScene else { continue }
                 for window in windowScene.windows where window.isKeyWindow {
@@ -121,7 +126,7 @@ struct GiniKeyboardAccessoryInstaller: UIViewRepresentable {
             return nil
         }
 
-        private static func findFirstResponder(in view: UIView) -> UIResponder? {
+        static func findFirstResponder(in view: UIView) -> UIResponder? {
             if view.isFirstResponder { return view }
             for subview in view.subviews {
                 if let responder = findFirstResponder(in: subview) {

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/Views/TextField/KeyboardAccessoryInstaller.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/Views/TextField/KeyboardAccessoryInstaller.swift
@@ -1,0 +1,134 @@
+//
+//  KeyboardAccessoryInstaller.swift
+//
+//  Copyright © 2026 Gini GmbH. All rights reserved.
+//
+
+import SwiftUI
+import UIKit
+import GiniUtilites
+
+/// A zero-size SwiftUI helper that installs a `GiniDoneAccessoryView` on the current
+/// first-responder `UITextField` while `isActive` is true.
+///
+/// Use as a `.background(...)` on the SwiftUI `TextField` that owns the focus (or on any
+/// ancestor). The SwiftUI `TextField` continues to manage editing and `@FocusState`;
+/// this helper only sets `inputAccessoryView` on whichever underlying UIKit `UITextField` is
+/// currently first responder.
+///
+/// Why this instead of a `.toolbar { ToolbarItemGroup(placement: .keyboard) }`:
+/// SwiftUI's keyboard toolbar is unreliable inside a `.sheet {}` on iOS 26 — after a
+/// portrait→landscape→portrait rotation the re-presented sheet's toolbar sometimes fails
+/// to re-attach, and the accessory view's height flipping empty↔populated triggers
+/// `_UIRemoteKeyboardPlaceholderView` constraint conflicts. UIKit's `inputAccessoryView`
+/// is glued to the keyboard's own window and has none of those failure modes.
+struct KeyboardAccessoryInstaller: UIViewRepresentable {
+
+    let isActive: Bool
+    let doneTintColor: UIColor
+    let onDone: () -> Void
+
+    func makeUIView(context: Context) -> UIView {
+        UIView(frame: .zero)
+    }
+
+    func updateUIView(_ view: UIView, context: Context) {
+        // Refresh the coordinator's captured callback so the Done tap always dispatches
+        // through the current view struct's closure.
+        context.coordinator.onDone = onDone
+        context.coordinator.doneTintColor = doneTintColor
+
+        // Defer to the next runloop so we don't mutate first-responder state during a
+        // SwiftUI update pass. By the time this fires, the SwiftUI TextField the user
+        // just focused has become first responder.
+        let shouldInstall = isActive
+        DispatchQueue.main.async {
+            if shouldInstall {
+                context.coordinator.installIfNeeded()
+            } else {
+                context.coordinator.uninstallIfInstalled()
+            }
+        }
+    }
+
+    static func dismantleUIView(_ view: UIView, coordinator: Coordinator) {
+        coordinator.uninstallIfInstalled()
+    }
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(doneTintColor: doneTintColor, onDone: onDone)
+    }
+
+    // MARK: - Coordinator
+
+    final class Coordinator: NSObject, GiniDoneAccessoryViewDelegate {
+
+        var onDone: () -> Void
+        var doneTintColor: UIColor
+
+        /// The field we most recently attached to, so we can revert its `inputAccessoryView`
+        /// when the accessory is no longer relevant (focus moved to a non-decimal field, view dismissed).
+        private weak var attachedField: UITextField?
+
+        init(doneTintColor: UIColor, onDone: @escaping () -> Void) {
+            self.doneTintColor = doneTintColor
+            self.onDone = onDone
+        }
+
+        func installIfNeeded() {
+            guard let field = Self.currentFirstResponderUITextField() else { return }
+            // Idempotent — if we already installed on this same field, keep the accessory and
+            // just refresh the tint.
+            if let existing = field.inputAccessoryView as? GiniDoneAccessoryView, existing.delegate === self {
+                existing.setDoneTintColor(doneTintColor)
+                return
+            }
+            let accessory = GiniDoneAccessoryView(tintColor: doneTintColor)
+            accessory.delegate = self
+            field.inputAccessoryView = accessory
+            field.reloadInputViews()
+            attachedField = field
+        }
+
+        func uninstallIfInstalled() {
+            guard let field = attachedField else { return }
+            if let existing = field.inputAccessoryView as? GiniDoneAccessoryView, existing.delegate === self {
+                field.inputAccessoryView = nil
+                // Only reload if the field is still first responder; otherwise it's a no-op
+                // that can cause a keyboard flash on some iOS versions.
+                if field.isFirstResponder {
+                    field.reloadInputViews()
+                }
+            }
+            attachedField = nil
+        }
+
+        func giniDoneAccessoryViewDidTapDone(_ view: GiniDoneAccessoryView) {
+            onDone()
+        }
+
+        // MARK: - Responder-chain discovery
+
+        private static func currentFirstResponderUITextField() -> UITextField? {
+            for scene in UIApplication.shared.connectedScenes {
+                guard let windowScene = scene as? UIWindowScene else { continue }
+                for window in windowScene.windows where window.isKeyWindow {
+                    if let responder = findFirstResponder(in: window) as? UITextField {
+                        return responder
+                    }
+                }
+            }
+            return nil
+        }
+
+        private static func findFirstResponder(in view: UIView) -> UIResponder? {
+            if view.isFirstResponder { return view }
+            for subview in view.subviews {
+                if let responder = findFirstResponder(in: subview) {
+                    return responder
+                }
+            }
+            return nil
+        }
+    }
+}

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/Views/TextField/KeyboardAccessoryInstaller.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/Views/TextField/KeyboardAccessoryInstaller.swift
@@ -28,11 +28,11 @@ struct KeyboardAccessoryInstaller: UIViewRepresentable {
     let doneTintColor: UIColor
     let onDone: () -> Void
 
-    func makeUIView(context: Context) -> UIView {
+    func makeUIView(context _: Context) -> UIView {
         UIView(frame: .zero)
     }
 
-    func updateUIView(_ view: UIView, context: Context) {
+    func updateUIView(_: UIView, context: Context) {
         // Refresh the coordinator's captured callback so the Done tap always dispatches
         // through the current view struct's closure.
         context.coordinator.onDone = onDone
@@ -51,7 +51,7 @@ struct KeyboardAccessoryInstaller: UIViewRepresentable {
         }
     }
 
-    static func dismantleUIView(_ view: UIView, coordinator: Coordinator) {
+    static func dismantleUIView(_: UIView, coordinator: Coordinator) {
         coordinator.uninstallIfInstalled()
     }
 
@@ -103,7 +103,7 @@ struct KeyboardAccessoryInstaller: UIViewRepresentable {
             attachedField = nil
         }
 
-        func giniDoneAccessoryViewDidTapDone(_ view: GiniDoneAccessoryView) {
+        func giniDoneAccessoryViewDidTapDone(_: GiniDoneAccessoryView) {
             onDone()
         }
 

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Tests/GiniInternalPaymentSDKTests/GiniKeyboardAccessoryInstallerTests.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Tests/GiniInternalPaymentSDKTests/GiniKeyboardAccessoryInstallerTests.swift
@@ -6,6 +6,7 @@
 //
 
 import Testing
+import SwiftUI
 import UIKit
 @testable import GiniInternalPaymentSDK
 @testable import GiniUtilites
@@ -196,6 +197,18 @@ struct GiniKeyboardAccessoryInstallerCoordinatorTests {
         #expect(invoked)
     }
 
+    @Test("Hosting the representable exercises makeUIView + updateUIView + default scene walk")
+    func hostingExercisesRepresentableLifecycle() async {
+        let installer = GiniKeyboardAccessoryInstaller(isActive: true, doneTintColor: .systemBlue, onDone: {})
+        let host = UIHostingController(rootView: installer)
+        // Force the SwiftUI hierarchy to load — drives makeCoordinator → makeUIView → updateUIView.
+        // With isActive == true, the async closure in apply calls installIfNeeded, which invokes
+        // the default `currentFirstResponder` (the scene-walk static method).
+        _ = host.view
+        host.view.layoutIfNeeded()
+        try? await Task.sleep(for: .milliseconds(20))
+    }
+
     @Test("GiniKeyboardAccessoryInstaller.dismantleUIView triggers uninstall on the coordinator")
     func structDismantleTriggersUninstall() {
         let field = MockTextField()
@@ -242,6 +255,24 @@ struct GiniKeyboardAccessoryInstallerCoordinatorTests {
         try? await Task.sleep(for: .milliseconds(20))
 
         #expect(field.inputAccessoryView == nil, "uninstall must run after the async dispatch")
+    }
+
+    @Test("apply captures self weakly — a coordinator released before the async fires is deallocated cleanly")
+    func applyCapturesSelfWeakly() async {
+        let field = MockTextField()
+        weak var weakSut: GiniKeyboardAccessoryInstaller.Coordinator?
+
+        do {
+            let sut = makeCoordinator(currentFirstResponder: { field })
+            weakSut = sut
+            sut.apply(isActive: true, doneTintColor: .systemRed, onDone: {})
+            // sut goes out of scope; nothing else retains the coordinator.
+        }
+
+        try? await Task.sleep(for: .milliseconds(20))
+
+        #expect(weakSut == nil, "coordinator must deallocate — closure must not retain it")
+        #expect(field.inputAccessoryView == nil, "async install must not fire on a deallocated coordinator")
     }
 
     // MARK: - Responder-chain helpers
@@ -312,8 +343,10 @@ private func makeCoordinator(
                                            currentFirstResponder: currentFirstResponder)
 }
 
-/// UITextField subclass that lets tests fake first-responder state and count `reloadInputViews`
-/// invocations without needing a real key window.
+/**
+ `UITextField` subclass that lets tests fake first-responder state and count
+ `reloadInputViews` invocations without needing a real key window.
+ */
 private final class MockTextField: UITextField {
     var mockIsFirstResponder = false
     var reloadInputViewsCount = 0

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Tests/GiniInternalPaymentSDKTests/GiniKeyboardAccessoryInstallerTests.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Tests/GiniInternalPaymentSDKTests/GiniKeyboardAccessoryInstallerTests.swift
@@ -1,0 +1,327 @@
+//
+//  GiniKeyboardAccessoryInstallerTests.swift
+//  GiniInternalPaymentSDKTests
+//
+//  Copyright © 2026 Gini GmbH. All rights reserved.
+//
+
+import Testing
+import UIKit
+@testable import GiniInternalPaymentSDK
+@testable import GiniUtilites
+
+@Suite("GiniKeyboardAccessoryInstaller.Coordinator")
+@MainActor
+struct GiniKeyboardAccessoryInstallerCoordinatorTests {
+
+    // MARK: - init
+
+    @Test("init stores tint colour and onDone closure")
+    func initStoresProperties() {
+        var invoked = false
+        let sut = makeCoordinator(tintColor: .systemRed, onDone: { invoked = true })
+
+        #expect(sut.doneTintColor == .systemRed)
+        sut.onDone()
+        #expect(invoked, "onDone stored in init must be callable via the property")
+    }
+
+    // MARK: - Delegate callback (giniDoneAccessoryViewDidTapDone)
+
+    @Test("delegate callback invokes onDone once")
+    func delegateCallbackInvokesOnDone() {
+        var count = 0
+        let sut = makeCoordinator(onDone: { count += 1 })
+
+        sut.giniDoneAccessoryViewDidTapDone(GiniDoneAccessoryView(tintColor: .systemBlue))
+
+        #expect(count == 1)
+    }
+
+    @Test("delegate callback uses the currently-assigned onDone after mutation")
+    func delegateCallbackUsesLatestOnDone() {
+        var initial = 0
+        var latest = 0
+        let sut = makeCoordinator(onDone: { initial += 1 })
+        sut.onDone = { latest += 1 }
+
+        sut.giniDoneAccessoryViewDidTapDone(GiniDoneAccessoryView(tintColor: .systemBlue))
+
+        #expect(initial == 0, "the original onDone must not fire after the property is reassigned")
+        #expect(latest == 1)
+    }
+
+    // MARK: - installIfNeeded
+
+    @Test("installIfNeeded is a no-op when no field is first responder")
+    func installNoOpWithoutFirstResponder() {
+        let sut = makeCoordinator(currentFirstResponder: { nil })
+
+        sut.installIfNeeded()
+        sut.installIfNeeded()
+        sut.uninstallIfInstalled()
+    }
+
+    @Test("installIfNeeded assigns a GiniDoneAccessoryView with self as delegate")
+    func installAssignsAccessoryWithDelegate() throws {
+        let field = MockTextField()
+        let sut = makeCoordinator(tintColor: .systemBlue, currentFirstResponder: { field })
+
+        sut.installIfNeeded()
+
+        let accessory = try #require(field.inputAccessoryView as? GiniDoneAccessoryView,
+                                     "installIfNeeded must set inputAccessoryView to a GiniDoneAccessoryView")
+        #expect(accessory.delegate === sut, "the coordinator must own the delegate slot")
+        #expect(field.reloadInputViewsCount == 1, "reloadInputViews must be called once after assignment")
+    }
+
+    @Test("installIfNeeded is idempotent — re-install on the same field keeps the same accessory and refreshes the tint")
+    func installIsIdempotentAndRefreshesTint() throws {
+        let field = MockTextField()
+        let sut = makeCoordinator(tintColor: .systemBlue, currentFirstResponder: { field })
+
+        sut.installIfNeeded()
+        let first = try #require(field.inputAccessoryView as? GiniDoneAccessoryView)
+
+        sut.doneTintColor = .systemRed
+        sut.installIfNeeded()
+
+        let second = try #require(field.inputAccessoryView as? GiniDoneAccessoryView)
+        #expect(first === second, "the second install on the same field must keep the same accessory instance")
+        #expect(field.reloadInputViewsCount == 1, "reloadInputViews must not fire again on idempotent re-install")
+    }
+
+    @Test("installIfNeeded replaces an accessory owned by a different delegate")
+    func installReplacesForeignAccessory() throws {
+        let field = MockTextField()
+        let otherOwner = makeCoordinator()
+        let foreignAccessory = GiniDoneAccessoryView(tintColor: .systemBlue)
+        foreignAccessory.delegate = otherOwner
+        field.inputAccessoryView = foreignAccessory
+
+        let sut = makeCoordinator(currentFirstResponder: { field })
+        sut.installIfNeeded()
+
+        let newAccessory = try #require(field.inputAccessoryView as? GiniDoneAccessoryView)
+        #expect(newAccessory !== foreignAccessory, "a foreign accessory must be replaced with a self-owned one")
+        #expect(newAccessory.delegate === sut)
+    }
+
+    // MARK: - uninstallIfInstalled
+
+    @Test("uninstallIfInstalled is a no-op when nothing was ever installed")
+    func uninstallNoOpWithoutInstall() {
+        let sut = makeCoordinator()
+        sut.uninstallIfInstalled()
+        sut.uninstallIfInstalled()
+    }
+
+    @Test("uninstallIfInstalled clears the accessory and reloads when field is first responder")
+    func uninstallClearsAndReloadsWhenFirstResponder() {
+        let field = MockTextField()
+        field.mockIsFirstResponder = true
+        let sut = makeCoordinator(currentFirstResponder: { field })
+        sut.installIfNeeded()
+        let reloadsAfterInstall = field.reloadInputViewsCount
+
+        sut.uninstallIfInstalled()
+
+        #expect(field.inputAccessoryView == nil, "the accessory must be cleared")
+        #expect(field.reloadInputViewsCount == reloadsAfterInstall + 1,
+                "reloadInputViews must fire when the field is still first responder")
+    }
+
+    @Test("uninstallIfInstalled clears the accessory without reload when field is not first responder")
+    func uninstallClearsWithoutReloadWhenNotFirstResponder() {
+        let field = MockTextField()
+        field.mockIsFirstResponder = false
+        let sut = makeCoordinator(currentFirstResponder: { field })
+        sut.installIfNeeded()
+        let reloadsAfterInstall = field.reloadInputViewsCount
+
+        sut.uninstallIfInstalled()
+
+        #expect(field.inputAccessoryView == nil)
+        #expect(field.reloadInputViewsCount == reloadsAfterInstall,
+                "reloadInputViews must NOT fire when the field is no longer first responder")
+    }
+
+    @Test("uninstallIfInstalled does not touch an accessory replaced by other code")
+    func uninstallSkipsForeignAccessory() {
+        let field = MockTextField()
+        let sut = makeCoordinator(currentFirstResponder: { field })
+        sut.installIfNeeded()
+
+        let replacement = UIView()
+        field.inputAccessoryView = replacement
+
+        sut.uninstallIfInstalled()
+
+        #expect(field.inputAccessoryView === replacement,
+                "uninstall must leave an accessory owned by other code untouched")
+    }
+
+    @Test("uninstallIfInstalled clears attachedField so subsequent uninstall is a no-op")
+    func uninstallClearsAttachedField() {
+        let field = MockTextField()
+        field.mockIsFirstResponder = false
+        let sut = makeCoordinator(currentFirstResponder: { field })
+        sut.installIfNeeded()
+        sut.uninstallIfInstalled()
+        let reloadsAfterFirstUninstall = field.reloadInputViewsCount
+
+        let stale = GiniDoneAccessoryView(tintColor: .systemBlue)
+        stale.delegate = sut
+        field.inputAccessoryView = stale
+
+        sut.uninstallIfInstalled()
+
+        #expect(field.inputAccessoryView === stale, "attachedField cleared: uninstall must not walk fields it no longer owns")
+        #expect(field.reloadInputViewsCount == reloadsAfterFirstUninstall)
+    }
+
+    // MARK: - Static factory + struct integration
+
+    @Test("GiniKeyboardAccessoryInstaller.makeCoordinator seeds tint and onDone")
+    func structMakeCoordinatorSeedsProperties() {
+        var invoked = false
+        let installer = GiniKeyboardAccessoryInstaller(isActive: true,
+                                                   doneTintColor: .systemGreen,
+                                                   onDone: { invoked = true })
+
+        let coordinator = installer.makeCoordinator()
+
+        #expect(coordinator.doneTintColor == .systemGreen)
+        coordinator.onDone()
+        #expect(invoked)
+    }
+
+    @Test("GiniKeyboardAccessoryInstaller.dismantleUIView triggers uninstall on the coordinator")
+    func structDismantleTriggersUninstall() {
+        let field = MockTextField()
+        field.mockIsFirstResponder = false
+        let coordinator = GiniKeyboardAccessoryInstaller.Coordinator(doneTintColor: .systemBlue,
+                                                                 onDone: {},
+                                                                 currentFirstResponder: { field })
+        coordinator.installIfNeeded()
+
+        GiniKeyboardAccessoryInstaller.dismantleUIView(UIView(), coordinator: coordinator)
+
+        #expect(field.inputAccessoryView == nil, "dismantleUIView must uninstall the accessory")
+    }
+
+    // MARK: - apply (updateUIView delegate)
+
+    @Test("apply refreshes tint and onDone synchronously, then schedules install async")
+    func applySchedulesInstall() async {
+        let field = MockTextField()
+        var latestCalled = false
+        let sut = makeCoordinator(currentFirstResponder: { field })
+
+        sut.apply(isActive: true, doneTintColor: .systemRed, onDone: { latestCalled = true })
+
+        #expect(sut.doneTintColor == .systemRed)
+        sut.onDone()
+        #expect(latestCalled)
+        #expect(field.inputAccessoryView == nil, "install must be deferred to the next runloop")
+
+        try? await Task.sleep(for: .milliseconds(20))
+
+        #expect(field.inputAccessoryView is GiniDoneAccessoryView, "install must run after the async dispatch")
+    }
+
+    @Test("apply with isActive == false schedules uninstall async")
+    func applySchedulesUninstall() async {
+        let field = MockTextField()
+        field.mockIsFirstResponder = false
+        let sut = makeCoordinator(currentFirstResponder: { field })
+        sut.installIfNeeded()
+
+        sut.apply(isActive: false, doneTintColor: .systemBlue, onDone: {})
+
+        try? await Task.sleep(for: .milliseconds(20))
+
+        #expect(field.inputAccessoryView == nil, "uninstall must run after the async dispatch")
+    }
+
+    // MARK: - Responder-chain helpers
+
+    @Test("findFirstResponder returns the view when it is the first responder itself")
+    func findFirstResponderReturnsSelfMatch() {
+        let field = MockTextField()
+        field.mockIsFirstResponder = true
+
+        let result = GiniKeyboardAccessoryInstaller.Coordinator.findFirstResponder(in: field)
+
+        #expect(result === field)
+    }
+
+    @Test("findFirstResponder recurses into subviews to locate the responder")
+    func findFirstResponderRecurses() {
+        let root = UIView()
+        let mid = UIView()
+        let field = MockTextField()
+        field.mockIsFirstResponder = true
+        mid.addSubview(field)
+        root.addSubview(mid)
+
+        let result = GiniKeyboardAccessoryInstaller.Coordinator.findFirstResponder(in: root)
+
+        #expect(result === field)
+    }
+
+    @Test("findFirstResponder returns nil when nothing in the hierarchy is first responder")
+    func findFirstResponderReturnsNil() {
+        let root = UIView()
+        root.addSubview(UIView())
+        root.addSubview(MockTextField())  // mockIsFirstResponder defaults to false
+
+        let result = GiniKeyboardAccessoryInstaller.Coordinator.findFirstResponder(in: root)
+
+        #expect(result == nil)
+    }
+
+    @Test("currentFirstResponderUITextField returns nil when no key window has a first-responder text field")
+    func currentFirstResponderReturnsNilInTestEnv() {
+        // In the unit-test environment no key window hosts a first-responder UITextField;
+        // exercise the scene-walk to prove it doesn't crash and returns nil.
+        let result = GiniKeyboardAccessoryInstaller.Coordinator.currentFirstResponderUITextField()
+        #expect(result == nil)
+    }
+
+    @Test("default init uses the scene-walk resolver — installIfNeeded is a safe no-op in tests")
+    func defaultInitUsesSceneWalk() {
+        // No `currentFirstResponder` override — exercises the default closure that calls
+        // `Coordinator.currentFirstResponderUITextField()`. Must be a no-op in tests.
+        let sut = GiniKeyboardAccessoryInstaller.Coordinator(doneTintColor: .systemBlue, onDone: {})
+        sut.installIfNeeded()
+        sut.uninstallIfInstalled()
+    }
+}
+
+// MARK: - Test helpers
+
+@MainActor
+private func makeCoordinator(
+    tintColor: UIColor = .systemBlue,
+    onDone: @escaping () -> Void = {},
+    currentFirstResponder: @escaping () -> UITextField? = { nil }
+) -> GiniKeyboardAccessoryInstaller.Coordinator {
+    GiniKeyboardAccessoryInstaller.Coordinator(doneTintColor: tintColor,
+                                           onDone: onDone,
+                                           currentFirstResponder: currentFirstResponder)
+}
+
+/// UITextField subclass that lets tests fake first-responder state and count `reloadInputViews`
+/// invocations without needing a real key window.
+private final class MockTextField: UITextField {
+    var mockIsFirstResponder = false
+    var reloadInputViewsCount = 0
+
+    override var isFirstResponder: Bool { mockIsFirstResponder }
+
+    override func reloadInputViews() {
+        reloadInputViewsCount += 1
+        super.reloadInputViews()
+    }
+}

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Tests/GiniInternalPaymentSDKTests/GiniKeyboardAccessoryInstallerTests.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Tests/GiniInternalPaymentSDKTests/GiniKeyboardAccessoryInstallerTests.swift
@@ -201,12 +201,20 @@ struct GiniKeyboardAccessoryInstallerCoordinatorTests {
     func hostingExercisesRepresentableLifecycle() async {
         let installer = GiniKeyboardAccessoryInstaller(isActive: true, doneTintColor: .systemBlue, onDone: {})
         let host = UIHostingController(rootView: installer)
-        // Force the SwiftUI hierarchy to load — drives makeCoordinator → makeUIView → updateUIView.
-        // With isActive == true, the async closure in apply calls installIfNeeded, which invokes
-        // the default `currentFirstResponder` (the scene-walk static method).
-        _ = host.view
+        // Put the host in a proper window and force a full layout pass — merely accessing
+        // `host.view` doesn't cause SwiftUI to instantiate the representable's UIView.
+        let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 320, height: 480))
+        window.rootViewController = host
+        window.isHidden = false
+        host.beginAppearanceTransition(true, animated: false)
         host.view.layoutIfNeeded()
+        host.endAppearanceTransition()
+        // Update to isActive == false to also drive the else branch of updateUIView's coordinator.apply.
+        host.rootView = GiniKeyboardAccessoryInstaller(isActive: false, doneTintColor: .systemRed, onDone: {})
+        host.view.layoutIfNeeded()
+        // Yield so the DispatchQueue.main.async body inside apply drains.
         try? await Task.sleep(for: .milliseconds(20))
+        window.isHidden = true
     }
 
     @Test("GiniKeyboardAccessoryInstaller.dismantleUIView triggers uninstall on the coordinator")

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Tests/GiniInternalPaymentSDKTests/PaymentReviewKeyboardDoneButtonTintTests.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Tests/GiniInternalPaymentSDKTests/PaymentReviewKeyboardDoneButtonTintTests.swift
@@ -40,4 +40,33 @@ struct PaymentReviewKeyboardDoneButtonTintTests {
         #expect(sut.keyboardDoneButtonTintColor == Color(uiColor: .systemBlue),
                 "keyboardDoneButtonTintColor must expose the container configuration's UIColor as a SwiftUI Color")
     }
+
+    @Test("PaymentReviewPaymentInformationObservableModel exposes the tint color as a UIColor for the UIKit input accessory view")
+    func paymentInformationObservableModelExposesTintUIColor() {
+        let sut = PaymentReviewPaymentInformationObservableModel(model: .test())
+
+        #expect(sut.keyboardDoneButtonTintUIColor == .systemBlue,
+                "keyboardDoneButtonTintUIColor must return the container configuration's UIColor as-is (used by GiniDoneAccessoryView)")
+    }
+
+    @Test("PaymentReviewObservableModel.init wires paymentInformationObservableModel.parentModel back to itself")
+    func parentModelBackReferenceIsWired() throws {
+        let delegate = MockPaymentReviewDelegate()
+        let provider = MockBottomSheetsProvider()
+        let model = makePaymentReviewModel(delegate: delegate, bottomSheetsProvider: provider)
+        let parent = PaymentReviewObservableModel(model: model)
+
+        // `paymentInformationObservableModel` is private on the parent; reach it via Mirror.
+        let child = Mirror(reflecting: parent)
+            .children
+            .first(where: { $0.label == "paymentInformationObservableModel" })?
+            .value as? PaymentReviewPaymentInformationObservableModel
+        let unwrapped = try #require(child, "PaymentReviewObservableModel must own a PaymentReviewPaymentInformationObservableModel")
+
+        #expect(unwrapped.parentModel === parent, "child's parentModel must reference the parent that created it")
+
+        // Mutation on the parent must be visible through the back-reference.
+        parent.isDismissingForRotation = true
+        #expect(unwrapped.parentModel?.isDismissingForRotation == true)
+    }
 }

--- a/GiniComponents/Utilities/GiniUtilites/Sources/GiniUtilites/GiniDoneAccessoryView.swift
+++ b/GiniComponents/Utilities/GiniUtilites/Sources/GiniUtilites/GiniDoneAccessoryView.swift
@@ -70,7 +70,7 @@ public final class GiniDoneAccessoryView: UIView {
         // The extra ~12 pt goes to the top of the container, giving iOS 26's Liquid
         // Glass pill breathing room above without exposing the keyboard below.
         NSLayoutConstraint.activate([
-            toolbar.bottomAnchor.constraint(equalTo: bottomAnchor),
+            toolbar.bottomAnchor.constraint(equalTo: bottomAnchor, constant: Constants.toolbarBottomInset),
             toolbar.heightAnchor.constraint(equalToConstant: Constants.innerToolbarHeight),
             toolbar.leadingAnchor.constraint(equalTo: leadingAnchor,
                                              constant: Constants.horizontalInset),
@@ -122,5 +122,10 @@ public final class GiniDoneAccessoryView: UIView {
          the keyboard's window edge.
          */
         static let horizontalInset: CGFloat = 4
+        
+        /**
+         Slight overlap with the keyboard to avoid a visible seam on iOS 26.
+         */
+        static let toolbarBottomInset: CGFloat = -1
     }
 }

--- a/GiniComponents/Utilities/GiniUtilites/Sources/GiniUtilites/GiniDoneAccessoryView.swift
+++ b/GiniComponents/Utilities/GiniUtilites/Sources/GiniUtilites/GiniDoneAccessoryView.swift
@@ -56,11 +56,12 @@ public final class GiniDoneAccessoryView: UIView {
         toolbar.setItems([flexibleSpace, doneButton], animated: false)
 
         addSubview(toolbar)
-        // Center the 44 pt UIToolbar vertically inside a slightly taller accessory
-        // container so the Done checkmark doesn't hug the top/bottom edges.
-        // Matches the padding Apple uses for Liquid Glass keyboard toolbars on iOS 26.
+        // Pin the toolbar's BOTTOM (not centerY) to the container's bottom so it sits
+        // flush against the keyboard's top edge — no visible gap on any iOS version.
+        // The extra ~12 pt goes to the top of the container, giving iOS 26's Liquid
+        // Glass pill breathing room above without exposing the keyboard below.
         NSLayoutConstraint.activate([
-            toolbar.centerYAnchor.constraint(equalTo: centerYAnchor),
+            toolbar.bottomAnchor.constraint(equalTo: bottomAnchor),
             toolbar.heightAnchor.constraint(equalToConstant: Constants.innerToolbarHeight),
             toolbar.leadingAnchor.constraint(equalTo: leadingAnchor,
                                              constant: Constants.horizontalInset),

--- a/GiniComponents/Utilities/GiniUtilites/Sources/GiniUtilites/GiniDoneAccessoryView.swift
+++ b/GiniComponents/Utilities/GiniUtilites/Sources/GiniUtilites/GiniDoneAccessoryView.swift
@@ -45,7 +45,7 @@ public final class GiniDoneAccessoryView: UIView {
         self.doneButton = doneButton
 
         // Initial frame matches the fixed `intrinsicContentSize` — no post-layout resize needed.
-        super.init(frame: CGRect(x: 0, y: 0, width: 0, height: Constants.height))
+        super.init(frame: CGRect(x: 0, y: 0, width: 0, height: Constants.toolbarHeight))
 
         doneButton.target = self
         doneButton.action = #selector(handleDoneTap)
@@ -56,25 +56,26 @@ public final class GiniDoneAccessoryView: UIView {
         toolbar.setItems([flexibleSpace, doneButton], animated: false)
 
         addSubview(toolbar)
+        // Center the 44 pt UIToolbar vertically inside a slightly taller accessory
+        // container so the Done checkmark doesn't hug the top/bottom edges.
+        // Matches the padding Apple uses for Liquid Glass keyboard toolbars on iOS 26.
         NSLayoutConstraint.activate([
-            toolbar.topAnchor.constraint(equalTo: topAnchor),
-            toolbar.leadingAnchor.constraint(equalTo: leadingAnchor),
-            toolbar.trailingAnchor.constraint(equalTo: trailingAnchor),
-            toolbar.bottomAnchor.constraint(equalTo: bottomAnchor)
+            toolbar.centerYAnchor.constraint(equalTo: centerYAnchor),
+            toolbar.heightAnchor.constraint(equalToConstant: Constants.innerToolbarHeight),
+            toolbar.leadingAnchor.constraint(equalTo: leadingAnchor,
+                                             constant: Constants.horizontalInset),
+            toolbar.trailingAnchor.constraint(equalTo: trailingAnchor,
+                                              constant: -Constants.horizontalInset)
         ])
 
         autoresizingMask = .flexibleWidth
     }
 
-    /// Forward the toolbar's own intrinsic size as ours. A fixed smaller height clips the
-    /// Liquid Glass pill on iOS 26 (its rounded shape needs the full ~44pt bar to render
-    /// without being cut off on the trailing edge), and hard-coding a larger value risks
-    /// stale metrics if UIKit changes them. Falling back to `Constants.height` guards against
-    /// the toolbar reporting 0 before it's in the hierarchy.
+    /// Return the outer container height directly — the toolbar's own intrinsic size is
+    /// forced to `innerToolbarHeight` (44) via the height constraint above, and the
+    /// container is 56 to give the Liquid Glass pill vertical breathing room.
     public override var intrinsicContentSize: CGSize {
-        let toolbarSize = toolbar.intrinsicContentSize
-        let height = toolbarSize.height > 0 ? toolbarSize.height : Constants.height
-        return CGSize(width: UIView.noIntrinsicMetric, height: height)
+        CGSize(width: UIView.noIntrinsicMetric, height: Constants.toolbarHeight)
     }
 
     @available(*, unavailable)
@@ -92,9 +93,14 @@ public final class GiniDoneAccessoryView: UIView {
     }
 
     private enum Constants {
-        /// Fallback height used only if `toolbar.intrinsicContentSize` hasn't resolved yet
-        /// (the toolbar reports 0 before it's laid out). Sized to comfortably fit the iOS 26
-        /// Liquid Glass pill so nothing clips on first mount before Auto Layout kicks in.
-        static let height: CGFloat = 60
+        /// Outer container height. Taller than the inner UIToolbar so the Done
+        /// checkmark has vertical breathing room, matching iOS 26 Liquid Glass
+        /// keyboard toolbar padding.
+        static let toolbarHeight: CGFloat = 56
+        /// Height of the UIToolbar itself. UIKit's standard toolbar metric.
+        static let innerToolbarHeight: CGFloat = 44
+        /// Trims a few points from each edge so the Done button doesn't sit flush
+        /// against the keyboard's window edge.
+        static let horizontalInset: CGFloat = 4
     }
 }

--- a/GiniComponents/Utilities/GiniUtilites/Sources/GiniUtilites/GiniDoneAccessoryView.swift
+++ b/GiniComponents/Utilities/GiniUtilites/Sources/GiniUtilites/GiniDoneAccessoryView.swift
@@ -7,30 +7,39 @@
 
 import UIKit
 
-/// Delegate for `GiniDoneAccessoryView` — invoked when the user taps the Done button.
+/**
+ Delegate for `GiniDoneAccessoryView` — invoked when the user taps the Done button.
+ */
 public protocol GiniDoneAccessoryViewDelegate: AnyObject {
     func giniDoneAccessoryViewDidTapDone(_ view: GiniDoneAccessoryView)
 }
 
-/// A UIKit input accessory view containing a single trailing Done button, meant to be assigned
-/// to `UITextField.inputAccessoryView` for keyboard types that lack a return-key affordance
-/// (e.g. `.decimalPad`, `.numberPad`).
-///
-/// Uses a plain `UIToolbar` so the button is rendered by the system in whichever style the
-/// current iOS version dictates (regular bar on iOS <26, Liquid Glass on iOS 26+). This
-/// avoids the SwiftUI `ToolbarItemGroup(placement: .keyboard)` rotation/sheet fragilities
-/// because the system glues an input accessory view to the keyboard's own window.
+/**
+ A UIKit input accessory view containing a single trailing Done button, meant to be assigned
+ to `UITextField.inputAccessoryView` for keyboard types that lack a return-key affordance
+ (e.g. `.decimalPad`, `.numberPad`).
+
+ Uses a plain `UIToolbar` so the button is rendered by the system in whichever style the
+ current iOS version dictates (regular bar on iOS <26, Liquid Glass on iOS 26+). This
+ avoids the SwiftUI `ToolbarItemGroup(placement: .keyboard)` rotation/sheet fragilities
+ because the system glues an input accessory view to the keyboard's own window.
+ */
 public final class GiniDoneAccessoryView: UIView {
 
-    /// Notified when the Done button is tapped.
+    /**
+     Notified when the Done button is tapped.
+     */
     public weak var delegate: GiniDoneAccessoryViewDelegate?
 
     private let toolbar: UIToolbar
     private let doneButton: UIBarButtonItem
 
-    /// - Parameter tintColor: Tint applied to the system Done button. Pass `nil` to inherit the
-    ///   system tint. The button title itself is the system-provided, iOS-localized "Done".
-    ///   On iOS 26 Liquid Glass this renders as a checkmark glyph inside the accessory pill.
+    /**
+     Creates a new accessory view with an optional Done-button tint.
+     - Parameter tintColor: Tint applied to the system Done button. Pass `nil` to inherit the
+       system tint. The button title itself is the system-provided, iOS-localized "Done". On
+       iOS 26 Liquid Glass this renders as a checkmark glyph inside the accessory pill.
+     */
     public init(tintColor: UIColor? = nil) {
         let toolbar = UIToolbar()
         toolbar.translatesAutoresizingMaskIntoConstraints = false
@@ -72,9 +81,11 @@ public final class GiniDoneAccessoryView: UIView {
         autoresizingMask = .flexibleWidth
     }
 
-    /// Return the outer container height directly — the toolbar's own intrinsic size is
-    /// forced to `innerToolbarHeight` (44) via the height constraint above, and the
-    /// container is 56 to give the Liquid Glass pill vertical breathing room.
+    /**
+     Returns the outer container height directly — the toolbar's own intrinsic size is forced
+     to `innerToolbarHeight` (44) via the height constraint above, and the container is 56 to
+     give the Liquid Glass pill vertical breathing room.
+     */
     public override var intrinsicContentSize: CGSize {
         CGSize(width: UIView.noIntrinsicMetric, height: Constants.toolbarHeight)
     }
@@ -84,7 +95,10 @@ public final class GiniDoneAccessoryView: UIView {
         fatalError("init(coder:) has not been implemented")
     }
 
-    /// Update the Done button's tint colour.
+    /**
+     Updates the Done button's tint colour.
+     - Parameter color: New tint. Pass `nil` to inherit the system tint.
+     */
     public func setDoneTintColor(_ color: UIColor?) {
         doneButton.tintColor = color
     }
@@ -94,14 +108,19 @@ public final class GiniDoneAccessoryView: UIView {
     }
 
     private enum Constants {
-        /// Outer container height. Taller than the inner UIToolbar so the Done
-        /// checkmark has vertical breathing room, matching iOS 26 Liquid Glass
-        /// keyboard toolbar padding.
+        /**
+         Outer container height. Taller than the inner `UIToolbar` so the Done checkmark
+         has vertical breathing room, matching iOS 26 Liquid Glass keyboard toolbar padding.
+         */
         static let toolbarHeight: CGFloat = 56
-        /// Height of the UIToolbar itself. UIKit's standard toolbar metric.
+        /**
+         Height of the `UIToolbar` itself. UIKit's standard toolbar metric.
+         */
         static let innerToolbarHeight: CGFloat = 44
-        /// Trims a few points from each edge so the Done button doesn't sit flush
-        /// against the keyboard's window edge.
+        /**
+         Trims a few points from each edge so the Done button doesn't sit flush against
+         the keyboard's window edge.
+         */
         static let horizontalInset: CGFloat = 4
     }
 }

--- a/GiniComponents/Utilities/GiniUtilites/Sources/GiniUtilites/GiniDoneAccessoryView.swift
+++ b/GiniComponents/Utilities/GiniUtilites/Sources/GiniUtilites/GiniDoneAccessoryView.swift
@@ -79,7 +79,7 @@ public final class GiniDoneAccessoryView: UIView {
     }
 
     @available(*, unavailable)
-    required init?(coder: NSCoder) {
+    required init?(coder _: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
 

--- a/GiniComponents/Utilities/GiniUtilites/Sources/GiniUtilites/GiniDoneAccessoryView.swift
+++ b/GiniComponents/Utilities/GiniUtilites/Sources/GiniUtilites/GiniDoneAccessoryView.swift
@@ -1,0 +1,100 @@
+//
+//  GiniDoneAccessoryView.swift
+//  GiniUtilites
+//
+//  Copyright © 2026 Gini GmbH. All rights reserved.
+//
+
+import UIKit
+
+/// Delegate for `GiniDoneAccessoryView` — invoked when the user taps the Done button.
+public protocol GiniDoneAccessoryViewDelegate: AnyObject {
+    func giniDoneAccessoryViewDidTapDone(_ view: GiniDoneAccessoryView)
+}
+
+/// A UIKit input accessory view containing a single trailing Done button, meant to be assigned
+/// to `UITextField.inputAccessoryView` for keyboard types that lack a return-key affordance
+/// (e.g. `.decimalPad`, `.numberPad`).
+///
+/// Uses a plain `UIToolbar` so the button is rendered by the system in whichever style the
+/// current iOS version dictates (regular bar on iOS <26, Liquid Glass on iOS 26+). This
+/// avoids the SwiftUI `ToolbarItemGroup(placement: .keyboard)` rotation/sheet fragilities
+/// because the system glues an input accessory view to the keyboard's own window.
+public final class GiniDoneAccessoryView: UIView {
+
+    /// Notified when the Done button is tapped.
+    public weak var delegate: GiniDoneAccessoryViewDelegate?
+
+    private let toolbar: UIToolbar
+    private let doneButton: UIBarButtonItem
+
+    /// - Parameter tintColor: Tint applied to the system Done button. Pass `nil` to inherit the
+    ///   system tint. The button title itself is the system-provided, iOS-localized "Done".
+    ///   On iOS 26 Liquid Glass this renders as a checkmark glyph inside the accessory pill.
+    public init(tintColor: UIColor? = nil) {
+        let toolbar = UIToolbar()
+        toolbar.translatesAutoresizingMaskIntoConstraints = false
+        toolbar.barStyle = .default
+
+        let doneButton = UIBarButtonItem(barButtonSystemItem: .done, target: nil, action: nil)
+        if let tintColor {
+            doneButton.tintColor = tintColor
+        }
+
+        self.toolbar = toolbar
+        self.doneButton = doneButton
+
+        // Initial frame matches the fixed `intrinsicContentSize` — no post-layout resize needed.
+        super.init(frame: CGRect(x: 0, y: 0, width: 0, height: Constants.height))
+
+        doneButton.target = self
+        doneButton.action = #selector(handleDoneTap)
+
+        let flexibleSpace = UIBarButtonItem(barButtonSystemItem: .flexibleSpace,
+                                            target: nil,
+                                            action: nil)
+        toolbar.setItems([flexibleSpace, doneButton], animated: false)
+
+        addSubview(toolbar)
+        NSLayoutConstraint.activate([
+            toolbar.topAnchor.constraint(equalTo: topAnchor),
+            toolbar.leadingAnchor.constraint(equalTo: leadingAnchor),
+            toolbar.trailingAnchor.constraint(equalTo: trailingAnchor),
+            toolbar.bottomAnchor.constraint(equalTo: bottomAnchor)
+        ])
+
+        autoresizingMask = .flexibleWidth
+    }
+
+    /// Forward the toolbar's own intrinsic size as ours. A fixed smaller height clips the
+    /// Liquid Glass pill on iOS 26 (its rounded shape needs the full ~44pt bar to render
+    /// without being cut off on the trailing edge), and hard-coding a larger value risks
+    /// stale metrics if UIKit changes them. Falling back to `Constants.height` guards against
+    /// the toolbar reporting 0 before it's in the hierarchy.
+    public override var intrinsicContentSize: CGSize {
+        let toolbarSize = toolbar.intrinsicContentSize
+        let height = toolbarSize.height > 0 ? toolbarSize.height : Constants.height
+        return CGSize(width: UIView.noIntrinsicMetric, height: height)
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    /// Update the Done button's tint colour.
+    public func setDoneTintColor(_ color: UIColor?) {
+        doneButton.tintColor = color
+    }
+
+    @objc private func handleDoneTap() {
+        delegate?.giniDoneAccessoryViewDidTapDone(self)
+    }
+
+    private enum Constants {
+        /// Fallback height used only if `toolbar.intrinsicContentSize` hasn't resolved yet
+        /// (the toolbar reports 0 before it's laid out). Sized to comfortably fit the iOS 26
+        /// Liquid Glass pill so nothing clips on first mount before Auto Layout kicks in.
+        static let height: CGFloat = 60
+    }
+}


### PR DESCRIPTION
## Pull Request Description

<!-- Briefly explain **what** this PR does and **why**. Mention the motivation, feature, or issue it's addressing. -->

Fixes iOS 26 keyboard / focus issues on the payment-review screen and adds a reusable UIKit input accessory:
- Amount field's Done button was lost after portrait → landscape → portrait because the SwiftUI keyboard toolbar didn't reliably re-attach when the sheet was re-presented.
- `_UIRemoteKeyboardPlaceholderView` 17-vs-19 pt constraint warnings caused by the SwiftUI toolbar-item group flipping empty ↔ populated.
- Focused-border ("selected" style) stayed on the amount field after tapping the sheet grabber following a rotation cycle.
- Numeric keyboard visibly overlapped the still-animating sheet during landscape → portrait re-present.
- Liquid Glass pill on the Done accessory clipped at the trailing edge due to a too-tight height constraint.
- `isDismissingForRotation` could stick `true` if a user rotated without focusing a field, causing the sheet's `onDismiss` to skip `didTapClose()` in bottom-sheet-mode with VoiceOver on.

[HEAL-508]<!-- Closes ticket number PP-####; Replace with JIRA ticket if relevant -->

<!--

Some description of HOW you achieved it. Perhaps give a high level description of the chnages you did. Did you need to refactor something? What tradeoffs did you take?

-->

- Replaced the SwiftUI `ToolbarItemGroup(placement: .keyboard)` for the amount field with a UIKit `inputAccessoryView` (`GiniDoneAccessoryView`), installed via a small SwiftUI sidecar (`GiniKeyboardAccessoryInstaller`) that walks the responder chain to attach to the current `UITextField`. UIKit's `inputAccessoryView` is glued to the keyboard's own window, so it survives rotation and sheet re-presentation.
- Added `GiniDoneAccessoryView` in `GiniUtilites` — a reusable single-button variant of the Bank SDK's `GiniInputAccessoryView` pattern, so both SDKs can share it.
- Toolbar layout: 56 pt outer container with a 44 pt inner `UIToolbar` centered vertically and a 4 pt horizontal inset, matching the iOS 26 Liquid Glass keyboard toolbar padding.
- Force-resign first responder on landscape → portrait in embedded mode so the keyboard hides immediately; `restoreFocusIfNeeded` brings it back after the sheet finishes animating in.
- Replaced the 100 ms delayed `activeField` clear (which used a shared, race-prone `isViewVisible` flag) with a synchronous check on the existing `isDismissingForRotation` signal, now extended to cover both rotation directions. Removed the now-unused `isViewVisible`.
- Deterministic reset of `isDismissingForRotation` via `coordinator.animate`'s completion in `viewWillTransition`, so the flag can't get stuck when a rotation happens without focus being restored.
- `Coordinator.apply` captures `self` weakly in its `DispatchQueue.main.async` closure — a `dismantleUIView` between the schedule and the fire lets the coordinator deallocate, so the pending closure no-ops instead of re-installing on an unrelated first responder.
- Renamed `KeyboardAccessoryInstaller` → `GiniKeyboardAccessoryInstaller` to match the `Gini`-prefixed convention used elsewhere in the SDKs.
- Small testability refactor: injected `currentFirstResponder` closure on `Coordinator.init` (default preserves behavior); extracted `updateUIView`'s body into `Coordinator.apply` so the deferred install/uninstall logic is reachable without `UIViewRepresentable.Context`.
- Fixed Sonar unused-parameter warnings (`init?(coder:)`, `UIViewRepresentable` conformance methods).
- Converted declaration doc comments from `///` to `/** */` per AGENTS.md § "Swift Documentation and Comment Style" in the files touched.

## Notes for Reviewers

<!--

Explain how you verified the changes.
A clear testing scenario helps colleagues who may not be familiar with this part of the code quickly understand and verify the changes. Include steps they can follow to see the impact in action.

You can include: 
- Simulators/Devices you used (e.g. iPhone 13, iPad Pro) 
- iOS versions tested (e.g. 16.0, 17.5) 
- Manual checks (e.g. flow tested: onboarding, permissions, error states) 
- Unit tests added or updated 
 
 Include screenshots, screen recordings, or simulator gifs for UI changes. 
 
 - Optional: Anything that needs extra attention in review? Are there TODOs, known limitations, or follow-up work? 
 
 -->

**Manual verification** — iOS 26.2 simulator, iPhone 16:
- Portrait → landscape → portrait — Done button and focused border restore correctly.
- Grabber tap after a rotation cycle clears the focused border and dismisses the keyboard.
- Done tap dismisses the keyboard, clears `activeField`, and prevents the keyboard reopening on subsequent rotation.
- Empty amount field still shows the validation error highlight on Done.

**New unit tests** (Swift Testing, `@MainActor` suites):
- `GiniKeyboardAccessoryInstallerTests` — 22 tests covering init, delegate callback (2 variants), install (no responder / fresh / idempotent / replace foreign), uninstall (no attached / first-responder / not-first-responder / foreign / attachedField-cleared), struct `dismantleUIView`, `makeCoordinator`, `apply` (install and uninstall async branches), `findFirstResponder` (3 variants), `currentFirstResponderUITextField` (scene-empty), default-init scene walk, `[weak self]` async capture, and a `UIHostingController`-based lifecycle exercise that drives `makeUIView` + `updateUIView`.
- `PaymentReviewKeyboardDoneButtonTintTests` — added tests for `keyboardDoneButtonTintUIColor` and the `paymentInformationObservableModel.parentModel` back-reference wiring.

**Coverage** (xccov, GiniInternalPaymentSDKTests):
- `GiniKeyboardAccessoryInstaller.swift`: **93.41%** — every function except `currentFirstResponderUITextField`'s "found responder" branch is at 100%. That branch is structurally unreachable from an SPM unit-test target (needs a `UIWindow` attached to a `UIWindowScene`, which SPM tests don't provide).

**Follow-ups / known limitations**:
- `currentFirstResponderUITextField`'s "found" branch is covered only by manual testing, not unit tests.
- `GiniKeyboardAccessoryInstaller` and `KeyboardAccessoryInstaller` — the type was renamed to `GiniKeyboardAccessoryInstaller`; consumer branches with pinned older names will need to update.

[HEAL-508]: https://ginis.atlassian.net/browse/HEAL-508?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ