### PR TITLE
Heal 529 done button issues ios 17.4

### DIFF
--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/Views/TextField/GiniKeyboardAccessoryInstaller.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/Views/TextField/GiniKeyboardAccessoryInstaller.swift
@@ -117,14 +117,21 @@ struct GiniKeyboardAccessoryInstaller: UIViewRepresentable {
         }
 
         func uninstallIfInstalled() {
-            guard let field = attachedField else { return }
-            if let existing = field.inputAccessoryView as? GiniDoneAccessoryView, existing.delegate === self {
+            // Clear from the previously attached field (if it still exists).
+            if let field = attachedField {
                 field.inputAccessoryView = nil
-                // Only reload if the field is still first responder; otherwise it's a no-op
-                // that can cause a keyboard flash on some iOS versions.
                 if field.isFirstResponder {
                     field.reloadInputViews()
                 }
+            }
+            // Also clear from the CURRENT first responder — on iOS 26+ SwiftUI can
+            // switch focus (e.g. amount → IBAN) before our deferred uninstall runs,
+            // leaving the amount's Done toolbar visible above the IBAN keyboard.
+            if let current = currentFirstResponder(),
+               current !== attachedField,
+               current.inputAccessoryView is GiniDoneAccessoryView {
+                current.inputAccessoryView = nil
+                current.reloadInputViews()
             }
             attachedField = nil
             persistentAccessory = nil

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/Views/TextField/GiniKeyboardAccessoryInstaller.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/Views/TextField/GiniKeyboardAccessoryInstaller.swift
@@ -59,8 +59,11 @@ struct GiniKeyboardAccessoryInstaller: UIViewRepresentable {
          */
         private weak var attachedField: UITextField?
 
-        /// Cached accessory — reused on every install so we don't allocate a fresh one
-        /// per SwiftUI update (its Done tap would target a stale delegate on iOS 17.4).
+        /**
+         Cached accessory — reused on every install so we don't allocate a fresh one
+         per SwiftUI update (its Done tap would target a stale delegate on iOS 17.4).
+         */
+         
         private var persistentAccessory: GiniDoneAccessoryView?
 
         /**

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/Views/TextField/GiniKeyboardAccessoryInstaller.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/Views/TextField/GiniKeyboardAccessoryInstaller.swift
@@ -117,20 +117,27 @@ struct GiniKeyboardAccessoryInstaller: UIViewRepresentable {
         }
 
         func uninstallIfInstalled() {
-            // Clear from the previously attached field (if it still exists).
-            if let field = attachedField {
+            let hadInstallation = attachedField != nil || persistentAccessory != nil
+            guard let field = attachedField else {
+                attachedField = nil
+                persistentAccessory = nil
+                return
+            }
+            if let existing = field.inputAccessoryView as? GiniDoneAccessoryView, existing.delegate === self {
                 field.inputAccessoryView = nil
+                // Only reload if the field is still first responder; otherwise it's a no-op
+                // that can cause a keyboard flash on some iOS versions.
                 if field.isFirstResponder {
                     field.reloadInputViews()
                 }
             }
-            // Also clear from the CURRENT first responder — on iOS 26+ SwiftUI can
-            // switch focus (e.g. amount → IBAN) before our deferred uninstall runs,
-            // leaving the amount's Done toolbar visible above the IBAN keyboard.
-            if let current = currentFirstResponder(),
-               current !== attachedField,
-               current.inputAccessoryView is GiniDoneAccessoryView {
-                current.inputAccessoryView = nil
+            // On iOS 26+ SwiftUI can switch focus (amount → IBAN) before our deferred
+            // uninstall runs, leaving the previous field's Done toolbar visible above the
+            // new field's keyboard. Force-reload the current first responder so the
+            // keyboard window re-queries its (nil) accessory and drops the stale one.
+            if hadInstallation,
+               let current = currentFirstResponder(),
+               current !== field {
                 current.reloadInputViews()
             }
             attachedField = nil

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/Views/TextField/GiniKeyboardAccessoryInstaller.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/Views/TextField/GiniKeyboardAccessoryInstaller.swift
@@ -71,6 +71,16 @@ struct GiniKeyboardAccessoryInstaller: UIViewRepresentable {
          */
         private let currentFirstResponder: () -> UITextField?
 
+        /**
+         Debounce for `apply` — cancels any pending install/uninstall from a previous
+         SwiftUI update before scheduling the new one. Without this, a burst of
+         `apply(isActive: true)` calls followed by `apply(isActive: false)` (which
+         happens on every focus change during a SwiftUI update storm) would fire ALL
+         the queued `installIfNeeded` closures AFTER the user has already moved focus
+         to a different field, installing our accessory on the wrong UITextField.
+         */
+        private var pendingWork: DispatchWorkItem?
+
         init(doneTintColor: UIColor,
              onDone: @escaping () -> Void,
              currentFirstResponder: @escaping () -> UITextField? = { Coordinator.currentFirstResponderUITextField() }) {
@@ -86,24 +96,34 @@ struct GiniKeyboardAccessoryInstaller: UIViewRepresentable {
         func apply(isActive: Bool, doneTintColor: UIColor, onDone: @escaping () -> Void) {
             self.onDone = onDone
             self.doneTintColor = doneTintColor
-            let shouldInstall = isActive
-            // `[weak self]` so a `dismantleUIView` between this schedule and the fire lets the
-            // coordinator deallocate — the closure then no-ops instead of re-installing on a
-            // first responder owned by another view.
-            DispatchQueue.main.async { [weak self] in
+            // Cancel any pending work — the LATEST apply's intent wins. Otherwise
+            // stale `installIfNeeded` closures from earlier `apply(isActive: true)`
+            // calls would fire after focus has moved to another field and install
+            // our accessory on the wrong UITextField.
+            pendingWork?.cancel()
+            let work = DispatchWorkItem { [weak self] in
                 guard let self else { return }
-                if shouldInstall {
+                if isActive {
                     self.installIfNeeded()
                 } else {
                     self.uninstallIfInstalled()
                 }
             }
+            pendingWork = work
+            DispatchQueue.main.async(execute: work)
         }
 
         func installIfNeeded() {
             guard let field = currentFirstResponder() else { return }
-            // Idempotent — if we already installed on this same field, keep the accessory and
-            // just refresh the tint.
+            // If we already have an attachedField and the current FR is a different one,
+            // focus has moved between when apply(true) was queued and when it fired. Don't
+            // install on the wrong field — that caused the sticky Done toolbar over the
+            // alphanumeric keyboard when moving amount → IBAN.
+            if let attached = attachedField, attached !== field {
+                return
+            }
+            // Idempotent — if we already installed on this same field, keep the accessory
+            // and just refresh the tint.
             if let existing = field.inputAccessoryView as? GiniDoneAccessoryView, existing.delegate === self {
                 existing.setDoneTintColor(doneTintColor)
                 return
@@ -117,12 +137,7 @@ struct GiniKeyboardAccessoryInstaller: UIViewRepresentable {
         }
 
         func uninstallIfInstalled() {
-            let hadInstallation = attachedField != nil || persistentAccessory != nil
-            guard let field = attachedField else {
-                attachedField = nil
-                persistentAccessory = nil
-                return
-            }
+            guard let field = attachedField else { return }
             if let existing = field.inputAccessoryView as? GiniDoneAccessoryView, existing.delegate === self {
                 field.inputAccessoryView = nil
                 // Only reload if the field is still first responder; otherwise it's a no-op
@@ -130,15 +145,6 @@ struct GiniKeyboardAccessoryInstaller: UIViewRepresentable {
                 if field.isFirstResponder {
                     field.reloadInputViews()
                 }
-            }
-            // On iOS 26+ SwiftUI can switch focus (amount → IBAN) before our deferred
-            // uninstall runs, leaving the previous field's Done toolbar visible above the
-            // new field's keyboard. Force-reload the current first responder so the
-            // keyboard window re-queries its (nil) accessory and drops the stale one.
-            if hadInstallation,
-               let current = currentFirstResponder(),
-               current !== field {
-                current.reloadInputViews()
             }
             attachedField = nil
             persistentAccessory = nil

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/Views/TextField/GiniKeyboardAccessoryInstaller.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Sources/GiniInternalPaymentSDK/PaymentReview/Views/TextField/GiniKeyboardAccessoryInstaller.swift
@@ -59,6 +59,10 @@ struct GiniKeyboardAccessoryInstaller: UIViewRepresentable {
          */
         private weak var attachedField: UITextField?
 
+        /// Cached accessory — reused on every install so we don't allocate a fresh one
+        /// per SwiftUI update (its Done tap would target a stale delegate on iOS 17.4).
+        private var persistentAccessory: GiniDoneAccessoryView?
+
         /**
          Injectable for tests; defaults to walking `UIApplication.shared.connectedScenes`.
          */
@@ -101,7 +105,8 @@ struct GiniKeyboardAccessoryInstaller: UIViewRepresentable {
                 existing.setDoneTintColor(doneTintColor)
                 return
             }
-            let accessory = GiniDoneAccessoryView(tintColor: doneTintColor)
+            let accessory = persistentAccessory ?? GiniDoneAccessoryView(tintColor: doneTintColor)
+            persistentAccessory = accessory
             accessory.delegate = self
             field.inputAccessoryView = accessory
             field.reloadInputViews()
@@ -119,6 +124,7 @@ struct GiniKeyboardAccessoryInstaller: UIViewRepresentable {
                 }
             }
             attachedField = nil
+            persistentAccessory = nil
         }
 
         func giniDoneAccessoryViewDidTapDone(_: GiniDoneAccessoryView) {

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Tests/GiniInternalPaymentSDKTests/GiniKeyboardAccessoryInstallerTests.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Tests/GiniInternalPaymentSDKTests/GiniKeyboardAccessoryInstallerTests.swift
@@ -162,6 +162,59 @@ struct GiniKeyboardAccessoryInstallerCoordinatorTests {
                 "uninstall must leave an accessory owned by other code untouched")
     }
 
+    @Test("installIfNeeded reuses the persistent accessory when the field's inputAccessoryView reads back nil")
+    func installReusesPersistentAccessoryAfterExternalClear() throws {
+        // Simulates the SwiftUI TextField subclass whose `inputAccessoryView` getter returns
+        // nil on a subsequent update even after we set it. The idempotent branch will miss,
+        // and we must fall through to reusing the persistent instance — not allocate fresh.
+        let field = MockTextField()
+        let sut = makeCoordinator(currentFirstResponder: { field })
+        sut.installIfNeeded()
+        let first = try #require(field.inputAccessoryView as? GiniDoneAccessoryView)
+
+        // Simulate the SwiftUI-getter-returns-nil quirk.
+        field.inputAccessoryView = nil
+
+        sut.installIfNeeded()
+        let second = try #require(field.inputAccessoryView as? GiniDoneAccessoryView)
+
+        #expect(first === second, "the coordinator must reuse its cached accessory, not allocate a fresh one")
+    }
+
+    @Test("uninstallIfInstalled reloads the current first responder when focus moved to a different field")
+    func uninstallReloadsCurrentFirstResponderWhenDifferent() {
+        // Amount focused → IBAN focused before uninstall fires: the previous field's Done
+        // toolbar can linger on iOS 26+ unless the current FR is told to reload.
+        let amountField = MockTextField()
+        let ibanField = MockTextField()
+        var currentFR: UITextField? = amountField
+        let sut = makeCoordinator(currentFirstResponder: { currentFR })
+        sut.installIfNeeded()
+        let ibanReloadsBefore = ibanField.reloadInputViewsCount
+
+        currentFR = ibanField
+        sut.uninstallIfInstalled()
+
+        #expect(ibanField.reloadInputViewsCount == ibanReloadsBefore + 1,
+                "current first responder must be reloaded so a stale accessory drops")
+    }
+
+    @Test("uninstallIfInstalled skips the current-FR reload when currentFirstResponder returns nil")
+    func uninstallSkipsReloadWhenNoCurrentFirstResponder() {
+        // Covers the `let current = currentFirstResponder()` branch where the resolver
+        // returns nil (e.g. no responder anywhere in the hierarchy at uninstall time).
+        let field = MockTextField()
+        field.mockIsFirstResponder = false
+        var currentFR: UITextField? = field
+        let sut = makeCoordinator(currentFirstResponder: { currentFR })
+        sut.installIfNeeded()
+
+        currentFR = nil
+        sut.uninstallIfInstalled()
+
+        #expect(field.inputAccessoryView == nil, "the attached field must still have its accessory cleared")
+    }
+
     @Test("uninstallIfInstalled clears attachedField so subsequent uninstall is a no-op")
     func uninstallClearsAttachedField() {
         let field = MockTextField()

--- a/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Tests/GiniInternalPaymentSDKTests/GiniKeyboardAccessoryInstallerTests.swift
+++ b/GiniComponents/InternalPaymentSDK/GiniInternalPaymentSDK/Tests/GiniInternalPaymentSDKTests/GiniKeyboardAccessoryInstallerTests.swift
@@ -181,40 +181,6 @@ struct GiniKeyboardAccessoryInstallerCoordinatorTests {
         #expect(first === second, "the coordinator must reuse its cached accessory, not allocate a fresh one")
     }
 
-    @Test("uninstallIfInstalled reloads the current first responder when focus moved to a different field")
-    func uninstallReloadsCurrentFirstResponderWhenDifferent() {
-        // Amount focused → IBAN focused before uninstall fires: the previous field's Done
-        // toolbar can linger on iOS 26+ unless the current FR is told to reload.
-        let amountField = MockTextField()
-        let ibanField = MockTextField()
-        var currentFR: UITextField? = amountField
-        let sut = makeCoordinator(currentFirstResponder: { currentFR })
-        sut.installIfNeeded()
-        let ibanReloadsBefore = ibanField.reloadInputViewsCount
-
-        currentFR = ibanField
-        sut.uninstallIfInstalled()
-
-        #expect(ibanField.reloadInputViewsCount == ibanReloadsBefore + 1,
-                "current first responder must be reloaded so a stale accessory drops")
-    }
-
-    @Test("uninstallIfInstalled skips the current-FR reload when currentFirstResponder returns nil")
-    func uninstallSkipsReloadWhenNoCurrentFirstResponder() {
-        // Covers the `let current = currentFirstResponder()` branch where the resolver
-        // returns nil (e.g. no responder anywhere in the hierarchy at uninstall time).
-        let field = MockTextField()
-        field.mockIsFirstResponder = false
-        var currentFR: UITextField? = field
-        let sut = makeCoordinator(currentFirstResponder: { currentFR })
-        sut.installIfNeeded()
-
-        currentFR = nil
-        sut.uninstallIfInstalled()
-
-        #expect(field.inputAccessoryView == nil, "the attached field must still have its accessory cleared")
-    }
-
     @Test("uninstallIfInstalled clears attachedField so subsequent uninstall is a no-op")
     func uninstallClearsAttachedField() {
         let field = MockTextField()
@@ -316,6 +282,27 @@ struct GiniKeyboardAccessoryInstallerCoordinatorTests {
         try? await Task.sleep(for: .milliseconds(20))
 
         #expect(field.inputAccessoryView == nil, "uninstall must run after the async dispatch")
+    }
+
+    @Test("apply cancels the previous pending work — the latest intent wins")
+    func applyCancelsPreviousPendingWork() async {
+        // Simulates the SwiftUI update storm: many rapid `apply` calls before the first
+        // work item has a chance to fire. Only the LATEST intent must run — the previous
+        // pending install must be cancelled, otherwise a stale install would run and
+        // then be undone by the queued uninstall, wasting a reloadInputViews call.
+        let field = MockTextField()
+        field.mockIsFirstResponder = false
+        let sut = makeCoordinator(currentFirstResponder: { field })
+
+        sut.apply(isActive: true, doneTintColor: .systemBlue, onDone: {})
+        sut.apply(isActive: false, doneTintColor: .systemBlue, onDone: {})
+
+        try? await Task.sleep(for: .milliseconds(20))
+
+        #expect(field.inputAccessoryView == nil,
+                "the cancelled install must not have run")
+        #expect(field.reloadInputViewsCount == 0,
+                "the cancelled install's reloadInputViews must NOT fire")
     }
 
     @Test("apply captures self weakly — a coordinator released before the async fires is deallocated cleanly")

--- a/GiniComponents/Utilities/GiniUtilites/Sources/GiniUtilites/GiniDoneAccessoryView.swift
+++ b/GiniComponents/Utilities/GiniUtilites/Sources/GiniUtilites/GiniDoneAccessoryView.swift
@@ -41,7 +41,10 @@ public final class GiniDoneAccessoryView: UIView {
        iOS 26 Liquid Glass this renders as a checkmark glyph inside the accessory pill.
      */
     public init(tintColor: UIColor? = nil) {
-        let toolbar = UIToolbar()
+        // Non-zero initial width avoids the iOS < 26 `_UIToolbarContentView.width == 0` conflict loop.
+        let toolbar = UIToolbar(frame: CGRect(x: 0, y: 0,
+                                              width: UIScreen.main.bounds.width,
+                                              height: Constants.innerToolbarHeight))
         toolbar.translatesAutoresizingMaskIntoConstraints = false
         toolbar.barStyle = .default
 


### PR DESCRIPTION
## Pull Request Description

<!-- Briefly explain **what** this PR does and **why**. Mention the motivation, feature, or issue it's addressing. -->

[HEAL-529](https://ginis.atlassian.net/browse/HEAL-529)<!-- Closes ticket number PP-####; Replace with JIRA ticket if relevant -->

This PR resolves the issue when Done button not working for iOS < 17.5 and IBAN field showing done button toolbar

<!--

Some description of HOW you achieved it. Perhaps give a high level description of the chnages you did. Did you need to refactor something? What tradeoffs did you take?

-->

## Notes for Reviewers
- Initialize the underlying UIToolbar with a non-zero frame size to avoid a zero-width constraint conflict loop on iOS < 26.
- Cache and reuse a GiniDoneAccessoryView instance in the SwiftUI installer coordinator to avoid repeated accessory allocations and stale delegate behavior.
<!--

Explain how you verified the changes.
A clear testing scenario helps colleagues who may not be familiar with this part of the code quickly understand and verify the changes. Include steps they can follow to see the impact in action.

You can include: 
- Simulators/Devices you used (e.g. iPhone 13, iPad Pro) 
- iOS versions tested (e.g. 16.0, 17.5) 
- Manual checks (e.g. flow tested: onboarding, permissions, error states) 
- Unit tests added or updated 
 
 Include screenshots, screen recordings, or simulator gifs for UI changes. 
 
 - Optional: Anything that needs extra attention in review? Are there TODOs, known limitations, or follow-up work? 
 
 -->

[HEAL-529]: https://ginis.atlassian.net/browse/HEAL-529?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ