### PR TITLE
docs(GiniHealthSDK): Document iOS 26 Liquid Glass customization hooks

### DIFF
--- a/HealthSDK/GiniHealthSDK/Documentation/source/Customization guide.md
+++ b/HealthSDK/GiniHealthSDK/Documentation/source/Customization guide.md
@@ -129,7 +129,7 @@ To copy text from Figma you need to have a Figma account. If you don't have one,
 
 ### iOS 26 Liquid Glass adaptations
 
-On iOS 26+ the Payment Review screen adopts system Liquid Glass automatically — no host-app configuration is required. Three customization hooks were introduced alongside the adaptation and apply to all iOS versions:
+On iOS 26+ the Payment Review screen adopts system Liquid Glass automatically — no host-app configuration is required. The three customization hooks below were introduced alongside the adaptation and are available on all supported iOS versions:
 
 #### Navigation bar title
 
@@ -159,8 +159,8 @@ The amount field's numeric keyboard shows a Done accessory that dismisses the ke
 
   A `.informal` variant is also supported for the German informal tone.
 
-- **Tint color** — follows the `Accent01` color asset used across the SDK. Override `Accent01.colorset` in your main bundle to change it. See [Colors](#colors).
+- **Tint color** — follows the accent color used across the SDK, which resolves through the `Accent01Dark` (light mode) and `Accent01Light` (dark mode) color assets. To override, add `Accent01Dark.colorset` and `Accent01Light.colorset` to your main bundle. See [Colors](#colors).
 
 #### Page indicator colors
 
-The document carousel's page indicators use colors driven by the `Standard01` color asset — the current-page dot renders at full opacity, other dots at 45% alpha. Override `Standard01.colorset` in your main bundle to change both.
+The document carousel's page indicators use the standard foreground color, which resolves through the `Dark01` (light mode) and `Light01` (dark mode) color assets. The current-page dot renders at full opacity; other dots at 45% alpha. To override, add `Dark01.colorset` and `Light01.colorset` to your main bundle.

--- a/HealthSDK/GiniHealthSDK/Documentation/source/Customization guide.md
+++ b/HealthSDK/GiniHealthSDK/Documentation/source/Customization guide.md
@@ -18,7 +18,7 @@ We provide a global color palette `GiniColors.xcassets` which you are free to ov
 For example, if you want to override Accent01 color you need to create an Accent01.colorset with your wished value in your main bundle.
 The custom colors are then applied to all screens.
 
-Find the names of the color resources in the color palette (you can also view it in Figma [here](https://www.figma.com/design/pImKS4S03V7d8NQhzbnDKa/iOS-Gini-Health-SDK-6.0.0?node-id=17116-10662&t=frkU7wM8jb9IqqA4-4)).
+Find the names of the color resources in the color palette (you can also view it in Figma [here](https://www.figma.com/design/LQIQPGarYngG9QQUbgr5j9/iOS-Gini-Health-SDK-6.1.0?node-id=17116-10662&t=QIIdMD5XVFcf24hv-1)).
 
 ### Images
 
@@ -30,7 +30,7 @@ If you want to override specific SDK images:
 ### Typography
 
 We provide global typography based on text appearance styles from UIFont.TextStyle.
-Preview our typography and find the names of the style resources (you can also view it in Figma [here](https://www.figma.com/design/pImKS4S03V7d8NQhzbnDKa/iOS-Gini-Health-SDK-6.0.0?node-id=17116-10470&t=frkU7wM8jb9IqqA4-4)).
+Preview our typography and find the names of the style resources (you can also view it in Figma [here](https://www.figma.com/design/LQIQPGarYngG9QQUbgr5j9/iOS-Gini-Health-SDK-6.1.0?node-id=17116-10470&t=QIIdMD5XVFcf24hv-1)).
 
 In the example below you can see to override a font for `.body1`
 
@@ -69,16 +69,17 @@ Text customization is done via overriding of string resources.
 For example you would like to customize pay invoice button label in the Payment Review screen:
 
 1. Find a string key for a text that you would like to customize.
-   For the [To the banking app button label](https://www.figma.com/design/pImKS4S03V7d8NQhzbnDKa/iOS-Gini-Health-SDK-6.0.0?node-id=16914-14742&t=frkU7wM8jb9IqqA4-4) in the Payment Review screen we use `gini.health.paymentcomponent.to.banking.app.label`. 
+   For the [To the banking app button label](https://www.figma.com/design/LQIQPGarYngG9QQUbgr5j9/iOS-Gini-Health-SDK-6.1.0?node-id=21903-27247&t=QIIdMD5XVFcf24hv-1) in the Payment Review screen we use `gini.health.paymentcomponent.to.banking.app.label`. 
 2. Add the string key with a desired value to `Localizable.strings` in your app.
     2.1 For German informal tone, you must add a key with `.informal` suffix to `Localizable.strings` in your app. For example, `gini.health.paymentcomponent.to.banking.app.label.informal`.
+
 ### Supporting dark mode
 
 We support dark mode in our SDK. If you decide to customize the color palette, please ensure that the text colors are also set in contrast to the background colors.
 
 ## Payment Component
  
-You can also view the UI customisation guide in Figma [here](https://www.figma.com/design/pImKS4S03V7d8NQhzbnDKa/iOS-Gini-Health-SDK-6.0.0?node-id=12906-23094&t=frkU7wM8jb9IqqA4-4).
+You can also view the UI customisation guide in Figma [here](https://www.figma.com/design/LQIQPGarYngG9QQUbgr5j9/iOS-Gini-Health-SDK-6.1.0?node-id=12906-11434&t=QIIdMD5XVFcf24hv-1).
 
 For configuring the the payment component height use `paymentComponentButtonsHeight` configuration option:
 
@@ -93,34 +94,34 @@ healthSDK.setConfiguration(config)
 **Note:**
 To copy text from Figma you need to have a Figma account. If you don't have one, you can create one for free.
 
-<iframe style="border: 1px solid rgba(0, 0, 0, 0.1);" width="800" height="450" src="https://embed.figma.com/design/pImKS4S03V7d8NQhzbnDKa/iOS-Gini-Health-SDK-6.0.0?node-id=12906-23094&embed-host=share" allowfullscreen></iframe>
+<iframe style="border: 1px solid rgba(0, 0, 0, 0.1);" width="800" height="450" src="https://embed.figma.com/design/LQIQPGarYngG9QQUbgr5j9/iOS-Gini-Health-SDK-6.1.0?node-id=12906-11434&embed-host=share" allowfullscreen></iframe>
 
 ## Bank Selection Bottom Sheet
 
-You can also view the UI customisation guide in Figma [here](https://www.figma.com/design/pImKS4S03V7d8NQhzbnDKa/iOS-Gini-Health-SDK-6.0.0?node-id=12907-10274&t=frkU7wM8jb9IqqA4-4).
+You can also view the UI customisation guide in Figma [here](https://www.figma.com/design/LQIQPGarYngG9QQUbgr5j9/iOS-Gini-Health-SDK-6.1.0?node-id=12906-11434&t=QIIdMD5XVFcf24hv-1).
 
 **Note:**
 To copy text from Figma you need to have a Figma account. If you don't have one, you can create one for free.
 
-<iframe style="border: 1px solid rgba(0, 0, 0, 0.1);" width="800" height="450" src="https://embed.figma.com/design/pImKS4S03V7d8NQhzbnDKa/iOS-Gini-Health-SDK-6.0.0?node-id=12907-10274&embed-host=share" allowfullscreen></iframe>
+<iframe style="border: 1px solid rgba(0, 0, 0, 0.1);" width="800" height="450" src="https://embed.figma.com/design/LQIQPGarYngG9QQUbgr5j9/iOS-Gini-Health-SDK-6.1.0?node-id=12906-11434&embed-host=share" allowfullscreen></iframe>
 
 ## Payment Feature Info Screen
 
-You can also view the UI customisation guide in Figma [here](https://www.figma.com/design/pImKS4S03V7d8NQhzbnDKa/iOS-Gini-Health-SDK-6.0.0?node-id=12907-11429&t=frkU7wM8jb9IqqA4-4).
+You can also view the UI customisation guide in Figma [here](https://www.figma.com/design/LQIQPGarYngG9QQUbgr5j9/iOS-Gini-Health-SDK-6.1.0?node-id=12906-11434&t=QIIdMD5XVFcf24hv-1).
 
 **Note:**
 To copy text from Figma you need to have a Figma account. If you don't have one, you can create one for free.
 
-<iframe style="border: 1px solid rgba(0, 0, 0, 0.1);" width="800" height="450" src="https://embed.figma.com/design/pImKS4S03V7d8NQhzbnDKa/iOS-Gini-Health-SDK-6.0.0?node-id=12907-11429&embed-host=share" allowfullscreen></iframe>
+<iframe style="border: 1px solid rgba(0, 0, 0, 0.1);" width="800" height="450" src="https://embed.figma.com/design/LQIQPGarYngG9QQUbgr5j9/iOS-Gini-Health-SDK-6.1.0?node-id=12906-11434&embed-host=share" allowfullscreen></iframe>
 
 ## Payment Review screen
  
-You can also view the UI customisation guide in Figma [here](https://www.figma.com/design/pImKS4S03V7d8NQhzbnDKa/iOS-Gini-Health-SDK-6.0.0?node-id=12907-12507&t=frkU7wM8jb9IqqA4-4).
+You can also view the UI customisation guide in Figma [here](https://www.figma.com/design/LQIQPGarYngG9QQUbgr5j9/iOS-Gini-Health-SDK-6.1.0?node-id=12906-11434&t=QIIdMD5XVFcf24hv-1).
 
 **Note:**
 To copy text from Figma you need to have a Figma account. If you don't have one, you can create one for free.
 
-<iframe style="border: 1px solid rgba(0, 0, 0, 0.1);" width="800" height="450" src="https://embed.figma.com/design/pImKS4S03V7d8NQhzbnDKa/iOS-Gini-Health-SDK-6.0.0?node-id=12907-12507&embed-host=share" allowfullscreen></iframe>
+<iframe style="border: 1px solid rgba(0, 0, 0, 0.1);" width="800" height="450" src="https://embed.figma.com/design/LQIQPGarYngG9QQUbgr5j9/iOS-Gini-Health-SDK-6.1.0?node-id=12906-11434&embed-host=share" allowfullscreen></iframe>
 
 
 > **Note:** 
@@ -129,22 +130,24 @@ To copy text from Figma you need to have a Figma account. If you don't have one,
 
 ### iOS 26 Liquid Glass adaptations
 
-On iOS 26+ the Payment Review screen adopts system Liquid Glass automatically — no host-app configuration is required. The three customization hooks below were introduced alongside the adaptation and are available on all supported iOS versions:
+All screens with Liquid Glass adaptation can be found [here](https://www.figma.com/design/LQIQPGarYngG9QQUbgr5j9/iOS-Gini-Health-SDK-6.1.0?node-id=21903-16041&t=QIIdMD5XVFcf24hv-1)
+On iOS 26+ the Payment Review screen adopts system Liquid Glass automatically — no host-app configuration is required. 
+The three customization hooks below were introduced alongside the adaptation and are available on all supported iOS versions:
 
 #### Navigation bar title
 
-The screen supports a navigation bar title, set via a localized string. The default is empty (no title shown), preserving existing behavior.
+The [screen](https://www.figma.com/design/LQIQPGarYngG9QQUbgr5j9/iOS-Gini-Health-SDK-6.1.0?node-id=21903-16255&t=QIIdMD5XVFcf24hv-1) supports a navigation bar title, set via a localized string. The default is empty (no title shown), preserving existing behavior.
 
 To display a title, add the key to your `Localizable.strings`:
 
 ```swift
-"gini.health.reviewscreen.title" = "Payment Review";
+"gini.health.reviewscreen.title" = "Your Invoice";
 ```
 
 For German informal tone, add the `.informal` variant:
 
 ```swift
-"gini.health.reviewscreen.title.informal" = "Zahlungsübersicht";
+"gini.health.reviewscreen.title.informal" = "Ihre Rechnung";
 ```
 
 #### Keyboard "Done" button
@@ -163,4 +166,4 @@ The amount field's numeric keyboard shows a Done accessory that dismisses the ke
 
 #### Page indicator colors
 
-The document carousel's page indicators use the standard foreground color, which resolves through the `Dark01` (light mode) and `Light01` (dark mode) color assets. The current-page dot renders at full opacity; other dots at 45% alpha. To override, add `Dark01.colorset` and `Light01.colorset` to your main bundle.
+The [document carousel's page indicators])https://www.figma.com/design/LQIQPGarYngG9QQUbgr5j9/iOS-Gini-Health-SDK-6.1.0?node-id=21909-17450&t=QIIdMD5XVFcf24hv-1) use the standard foreground color, which resolves through the `Dark01` (light mode) and `Light01` (dark mode) color assets. The current-page dot renders at full opacity; other dots at 45% alpha. To override, add `Dark01.colorset` and `Light01.colorset` to your main bundle.

--- a/HealthSDK/GiniHealthSDK/Documentation/source/Customization guide.md
+++ b/HealthSDK/GiniHealthSDK/Documentation/source/Customization guide.md
@@ -126,3 +126,41 @@ To copy text from Figma you need to have a Figma account. If you don't have one,
 > **Note:** 
 > - PaymentReviewViewController contains the following configuration options:
 > - paymentReviewStatusBarStyle: Sets the status bar style on the payment review screen. Only if `View controller-based status bar appearance` = `YES` in `Info.plist`.
+
+### iOS 26 Liquid Glass adaptations
+
+On iOS 26+ the Payment Review screen adopts system Liquid Glass automatically — no host-app configuration is required. Three customization hooks were introduced alongside the adaptation and apply to all iOS versions:
+
+#### Navigation bar title
+
+The screen supports a navigation bar title, set via a localized string. The default is empty (no title shown), preserving existing behavior.
+
+To display a title, add the key to your `Localizable.strings`:
+
+```swift
+"gini.health.reviewscreen.title" = "Payment Review";
+```
+
+For German informal tone, add the `.informal` variant:
+
+```swift
+"gini.health.reviewscreen.title.informal" = "Zahlungsübersicht";
+```
+
+#### Keyboard "Done" button
+
+The amount field's numeric keyboard shows a Done accessory that dismisses the keyboard. On iOS 26+ the system renders it as a Liquid Glass pill; on earlier iOS versions it renders as a labeled bar button.
+
+- **Label** — override via `Localizable.strings`:
+
+  ```swift
+  "gini.health.reviewscreen.keyboard.done.button.title" = "Done";
+  ```
+
+  A `.informal` variant is also supported for the German informal tone.
+
+- **Tint color** — follows the `Accent01` color asset used across the SDK. Override `Accent01.colorset` in your main bundle to change it. See [Colors](#colors).
+
+#### Page indicator colors
+
+The document carousel's page indicators use colors driven by the `Standard01` color asset — the current-page dot renders at full opacity, other dots at 45% alpha. Override `Standard01.colorset` in your main bundle to change both.

--- a/HealthSDK/GiniHealthSDK/Documentation/source/Customization guide.md
+++ b/HealthSDK/GiniHealthSDK/Documentation/source/Customization guide.md
@@ -79,7 +79,7 @@ We support dark mode in our SDK. If you decide to customize the color palette, p
 
 ## Payment Component
  
-You can also view the UI customisation guide in Figma [here](https://www.figma.com/design/LQIQPGarYngG9QQUbgr5j9/iOS-Gini-Health-SDK-6.1.0?node-id=12906-11434&t=QIIdMD5XVFcf24hv-1).
+You can also view the UI customisation guide in Figma [here](https://www.figma.com/design/LQIQPGarYngG9QQUbgr5j9/iOS-Gini-Health-SDK-6.1.0?node-id=22147-7576&t=Q07UvHyFl3LftADO-4).
 
 For configuring the the payment component height use `paymentComponentButtonsHeight` configuration option:
 
@@ -94,34 +94,34 @@ healthSDK.setConfiguration(config)
 **Note:**
 To copy text from Figma you need to have a Figma account. If you don't have one, you can create one for free.
 
-<iframe style="border: 1px solid rgba(0, 0, 0, 0.1);" width="800" height="450" src="https://embed.figma.com/design/LQIQPGarYngG9QQUbgr5j9/iOS-Gini-Health-SDK-6.1.0?node-id=12906-11434&embed-host=share" allowfullscreen></iframe>
+<iframe style="border: 1px solid rgba(0, 0, 0, 0.1);" width="800" height="450" src="https://embed.figma.com/design/LQIQPGarYngG9QQUbgr5j9/iOS-Gini-Health-SDK-6.1.0?node-id=22147-7576&embed-host=share" allowfullscreen></iframe>
 
 ## Bank Selection Bottom Sheet
 
-You can also view the UI customisation guide in Figma [here](https://www.figma.com/design/LQIQPGarYngG9QQUbgr5j9/iOS-Gini-Health-SDK-6.1.0?node-id=12906-11434&t=QIIdMD5XVFcf24hv-1).
+You can also view the UI customisation guide in Figma [here](https://www.figma.com/design/LQIQPGarYngG9QQUbgr5j9/iOS-Gini-Health-SDK-6.1.0?node-id=22147-7577&t=Q07UvHyFl3LftADO-4).
 
 **Note:**
 To copy text from Figma you need to have a Figma account. If you don't have one, you can create one for free.
 
-<iframe style="border: 1px solid rgba(0, 0, 0, 0.1);" width="800" height="450" src="https://embed.figma.com/design/LQIQPGarYngG9QQUbgr5j9/iOS-Gini-Health-SDK-6.1.0?node-id=12906-11434&embed-host=share" allowfullscreen></iframe>
+<iframe style="border: 1px solid rgba(0, 0, 0, 0.1);" width="800" height="450" src="https://embed.figma.com/design/LQIQPGarYngG9QQUbgr5j9/iOS-Gini-Health-SDK-6.1.0?node-id=22147-7577&embed-host=share" allowfullscreen></iframe>
 
 ## Payment Feature Info Screen
 
-You can also view the UI customisation guide in Figma [here](https://www.figma.com/design/LQIQPGarYngG9QQUbgr5j9/iOS-Gini-Health-SDK-6.1.0?node-id=12906-11434&t=QIIdMD5XVFcf24hv-1).
+You can also view the UI customisation guide in Figma [here](https://www.figma.com/design/LQIQPGarYngG9QQUbgr5j9/iOS-Gini-Health-SDK-6.1.0?node-id=22147-7578&t=Q07UvHyFl3LftADO-4).
 
 **Note:**
 To copy text from Figma you need to have a Figma account. If you don't have one, you can create one for free.
 
-<iframe style="border: 1px solid rgba(0, 0, 0, 0.1);" width="800" height="450" src="https://embed.figma.com/design/LQIQPGarYngG9QQUbgr5j9/iOS-Gini-Health-SDK-6.1.0?node-id=12906-11434&embed-host=share" allowfullscreen></iframe>
+<iframe style="border: 1px solid rgba(0, 0, 0, 0.1);" width="800" height="450" src="https://embed.figma.com/design/LQIQPGarYngG9QQUbgr5j9/iOS-Gini-Health-SDK-6.1.0?node-id=22147-7578&embed-host=share" allowfullscreen></iframe>
 
 ## Payment Review screen
  
-You can also view the UI customisation guide in Figma [here](https://www.figma.com/design/LQIQPGarYngG9QQUbgr5j9/iOS-Gini-Health-SDK-6.1.0?node-id=12906-11434&t=QIIdMD5XVFcf24hv-1).
+You can also view the UI customisation guide in Figma [here](https://www.figma.com/design/LQIQPGarYngG9QQUbgr5j9/iOS-Gini-Health-SDK-6.1.0?node-id=22147-7579&t=Q07UvHyFl3LftADO-4).
 
 **Note:**
 To copy text from Figma you need to have a Figma account. If you don't have one, you can create one for free.
 
-<iframe style="border: 1px solid rgba(0, 0, 0, 0.1);" width="800" height="450" src="https://embed.figma.com/design/LQIQPGarYngG9QQUbgr5j9/iOS-Gini-Health-SDK-6.1.0?node-id=12906-11434&embed-host=share" allowfullscreen></iframe>
+<iframe style="border: 1px solid rgba(0, 0, 0, 0.1);" width="800" height="450" src="https://embed.figma.com/design/LQIQPGarYngG9QQUbgr5j9/iOS-Gini-Health-SDK-6.1.0?node-id=22147-7579&embed-host=share" allowfullscreen></iframe>
 
 
 > **Note:** 
@@ -166,4 +166,4 @@ The amount field's numeric keyboard shows a Done accessory that dismisses the ke
 
 #### Page indicator colors
 
-The [document carousel's page indicators])https://www.figma.com/design/LQIQPGarYngG9QQUbgr5j9/iOS-Gini-Health-SDK-6.1.0?node-id=21909-17450&t=QIIdMD5XVFcf24hv-1) use the standard foreground color, which resolves through the `Dark01` (light mode) and `Light01` (dark mode) color assets. The current-page dot renders at full opacity; other dots at 45% alpha. To override, add `Dark01.colorset` and `Light01.colorset` to your main bundle.
+The [document carousel's page indicators](https://www.figma.com/design/LQIQPGarYngG9QQUbgr5j9/iOS-Gini-Health-SDK-6.1.0?node-id=21909-17450&t=QIIdMD5XVFcf24hv-1) use the standard foreground color, which resolves through the `Dark01` (light mode) and `Light01` (dark mode) color assets. The current-page dot renders at full opacity; other dots at 45% alpha. To override, add `Dark01.colorset` and `Light01.colorset` to your main bundle.


### PR DESCRIPTION
## Pull Request Description

<!-- Briefly explain **what** this PR does and **why**. Mention the motivation, feature, or issue it's addressing. -->

[HEAL-528]<!-- Closes ticket number PP-####; Replace with JIRA ticket if relevant -->

<!--

Some description of HOW you achieved it. Perhaps give a high level description of the chnages you did. Did you need to refactor something? What tradeoffs did you take?

-->

Adds a new "iOS 26 Liquid Glass adaptations" subsection under "Payment Review screen" in the GiniHealthSDK customization guide, documenting the customer-facing hooks introduced alongside the iOS 26 uplift:

- **Navigation bar title** — `gini.health.reviewscreen.title` (+ `.informal` variant for German informal tone)
- **Keyboard "Done" button** — `gini.health.reviewscreen.keyboard.done.button.title` label (+ `.informal` variant), with tint driven by the `Accent01` color asset
- **Page indicator colors** — driven by the `Standard01` color asset (current page at full opacity, other pages at 45% alpha)

Docs-only change — no source or behavior is modified. The subsection notes that Liquid Glass adoption on iOS 26+ is automatic and requires no host-app configuration, and that the three hooks above apply to all iOS versions.

## Notes for Reviewers

<!--

Explain how you verified the changes.
A clear testing scenario helps colleagues who may not be familiar with this part of the code quickly understand and verify the changes. Include steps they can follow to see the impact in action.

You can include: 
- Simulators/Devices you used (e.g. iPhone 13, iPad Pro) 
- iOS versions tested (e.g. 16.0, 17.5) 
- Manual checks (e.g. flow tested: onboarding, permissions, error states) 
- Unit tests added or updated 
 
 Include screenshots, screen recordings, or simulator gifs for UI changes. 
 
 - Optional: Anything that needs extra attention in review? Are there TODOs, known limitations, or follow-up work? 
 
 -->

- Single file touched: `HealthSDK/GiniHealthSDK/Documentation/source/Customization guide.md` (+38 / -0).
- Please render the markdown (GitHub preview or Jazzy) to confirm the new subsection appears under "Payment Review screen" and code fences / headings render correctly.
- Verify that the localization keys and color asset names match the ones actually shipped in the iOS 26 uplift PR they accompany.

[HEAL-528]: https://ginis.atlassian.net/browse/HEAL-528?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ