### PR TITLE
fix(GiniCaptureSDK): clear Help menu row selection to silence "select…

### DIFF
--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Help/DataSources/HelpMenu/HelpMenuDataSource.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Help/DataSources/HelpMenu/HelpMenuDataSource.swift
@@ -67,6 +67,9 @@ final class HelpMenuDataSource: HelpRoundedCornersDataSource<HelpMenuItem, HelpM
 
     // MARK: - UITableViewDelegate
     override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        // Clear the row's selection state so VoiceOver doesn't announce
+        // "selected" when the user navigates back to the Help menu.
+        tableView.deselectRow(at: indexPath, animated: false)
         self.delegate?.didSelectHelpItem(at: indexPath.row)
     }
 


### PR DESCRIPTION

PP-3216

## Pull Request Description

<!-- Briefly explain **what** this PR does and **why**. Mention the motivation, feature, or issue it's addressing. -->

[PP-3216](https://ginis.atlassian.net/browse/PP-3216)<!-- Closes ticket number PP-####; Replace with JIRA ticket if relevant -->

This PR addresses an accessibility issue in GiniCaptureSDK where VoiceOver announces a Help menu item as “selected” when navigating back to the Help menu by explicitly clearing the table row selection on tap.

<!--

Some description of HOW you achieved it. Perhaps give a high level description of the chnages you did. Did you need to refactor something? What tradeoffs did you take?

-->

## Notes for Reviewers

- Deselect the tapped Help menu row in tableView(_:didSelectRowAt:) before delegating the selection handling.
- Add an inline comment explaining the VoiceOver motivation for the deselection.
<!--

Explain how you verified the changes.
A clear testing scenario helps colleagues who may not be familiar with this part of the code quickly understand and verify the changes. Include steps they can follow to see the impact in action.

You can include: 
- Simulators/Devices you used (e.g. iPhone 13, iPad Pro) 
- iOS versions tested (e.g. 16.0, 17.5) 
- Manual checks (e.g. flow tested: onboarding, permissions, error states) 
- Unit tests added or updated 
 
 Include screenshots, screen recordings, or simulator gifs for UI changes. 
 
 - Optional: Anything that needs extra attention in review? Are there TODOs, known limitations, or follow-up work? 
 
 -->

[PP-3216]: https://ginis.atlassian.net/browse/PP-3216?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ