### PR TITLE
fix(GiniCaptureSDK): fixing of clipping frame on Camera Screen

### DIFF
--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Camera/CameraPreviewViewController.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Camera/CameraPreviewViewController.swift
@@ -217,7 +217,10 @@ final class CameraPreviewViewController: UIViewController {
                 cameraFrameViewHeightAnchorPortrait])
         } else {
             NSLayoutConstraint.activate([
-                cameraFrameView.topAnchor.constraint(equalTo: view.topAnchor,
+                // Anchor to safe area top so the frame is not clipped by a host nav bar
+                // when the SDK is presented in a non-full-screen style (e.g. .pageSheet).
+                // In .fullScreen this resolves to the same y as view.topAnchor.
+                cameraFrameView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor,
                                                      constant: Constants.padding),
                 cameraFrameView.leadingAnchor.constraint(greaterThanOrEqualTo: view.leadingAnchor,
                                                          constant: Constants.padding),


### PR DESCRIPTION
## Pull Request Description

<!-- Briefly explain **what** this PR does and **why**. Mention the motivation, feature, or issue it's addressing. -->

[PP-2646](https://ginis.atlassian.net/browse/PP-2646)<!-- Closes ticket number PP-####; Replace with JIRA ticket if relevant -->

This PR updates the CaptureSDK camera screen layout to prevent the camera frame overlay from being clipped when the SDK is embedded in host containers (e.g., navigation controller / non-full-screen presentations).



<!--

Some description of HOW you achieved it. Perhaps give a high level description of the chnages you did. Did you need to refactor something? What tradeoffs did you take?

-->

## Notes for Reviewers

- Anchors cameraFrameView to view.safeAreaLayoutGuide.topAnchor (instead of view.topAnchor) for non-iPad layouts to avoid clipping under system UI.
- Adds an inline comment explaining the rationale for the safe-area anchoring.
<!--

Explain how you verified the changes.
A clear testing scenario helps colleagues who may not be familiar with this part of the code quickly understand and verify the changes. Include steps they can follow to see the impact in action.

You can include: 
- Simulators/Devices you used (e.g. iPhone 13, iPad Pro) 
- iOS versions tested (e.g. 16.0, 17.5) 
- Manual checks (e.g. flow tested: onboarding, permissions, error states) 
- Unit tests added or updated 
 
 Include screenshots, screen recordings, or simulator gifs for UI changes. 
 
 - Optional: Anything that needs extra attention in review? Are there TODOs, known limitations, or follow-up work? 
 
 -->

[PP-2646]: https://ginis.atlassian.net/browse/PP-2646?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ