### PR TITLE
Pp 3258 done button lg skonto

### DIFF
--- a/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/Skonto/Views/SkontoExpiryDateView.swift
+++ b/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/Skonto/Views/SkontoExpiryDateView.swift
@@ -192,6 +192,13 @@ class SkontoExpiryDateView: UIView, GiniInputAccessoryViewPresentable {
         datePicker.minimumDate = currentDate
         datePicker.maximumDate = endDate
         datePicker.addTarget(self, action: #selector(dateChanged(_:)), for: .valueChanged)
+        if #available(iOS 26, *) {
+            // In landscape on iOS 26 the wheel picker's host overlaps the
+            // input accessory band, drawing the Done button behind the wheels.
+            // Flexing the picker's height lets UIKit shrink it to fit above
+            // the toolbar in the compact-height keyboard region.
+            datePicker.autoresizingMask = .flexibleHeight
+        }
         textField.inputView = datePicker
     }
 

--- a/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/Skonto/Views/SkontoExpiryDateView.swift
+++ b/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/Skonto/Views/SkontoExpiryDateView.swift
@@ -96,6 +96,29 @@ class SkontoExpiryDateView: UIView, GiniInputAccessoryViewPresentable {
         textField.resignFirstResponder()
     }
 
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+        updateDatePickerAutoresizingForCurrentTrait()
+    }
+
+    /// On iOS 26 the wheel `UIDatePicker`'s host overlaps the input accessory
+    /// band in landscape (compact height), drawing Done behind the wheels.
+    /// Enabling `.flexibleHeight` lets UIKit shrink the picker to fit. In
+    /// portrait the mask must be cleared and the input views reloaded so
+    /// UIKit re-establishes a single input host — otherwise the accessory
+    /// host stays inflated after returning from landscape, leaving a gap
+    /// between the toolbar and the wheels.
+    private func updateDatePickerAutoresizingForCurrentTrait() {
+        guard #available(iOS 26, *),
+              let picker = textField.inputView as? UIDatePicker else { return }
+        picker.autoresizingMask = traitCollection.verticalSizeClass == .compact
+            ? .flexibleHeight
+            : []
+        if textField.isFirstResponder {
+            textField.reloadInputViews()
+        }
+    }
+
     private func setupView() {
         translatesAutoresizingMaskIntoConstraints = false
         isAccessibilityElement = true
@@ -192,14 +215,8 @@ class SkontoExpiryDateView: UIView, GiniInputAccessoryViewPresentable {
         datePicker.minimumDate = currentDate
         datePicker.maximumDate = endDate
         datePicker.addTarget(self, action: #selector(dateChanged(_:)), for: .valueChanged)
-        if #available(iOS 26, *) {
-            // In landscape on iOS 26 the wheel picker's host overlaps the
-            // input accessory band, drawing the Done button behind the wheels.
-            // Flexing the picker's height lets UIKit shrink it to fit above
-            // the toolbar in the compact-height keyboard region.
-            datePicker.autoresizingMask = .flexibleHeight
-        }
         textField.inputView = datePicker
+        updateDatePickerAutoresizingForCurrentTrait()
     }
 
     @objc private func dateChanged(_ datePicker: UIDatePicker) {

--- a/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/Skonto/Views/SkontoExpiryDateView.swift
+++ b/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/Skonto/Views/SkontoExpiryDateView.swift
@@ -101,10 +101,10 @@ class SkontoExpiryDateView: UIView, GiniInputAccessoryViewPresentable {
         updateDatePickerAutoresizingForCurrentTrait()
     }
 
-/**
- Updates the wheel `UIDatePicker` autoresizing mask on iOS 26 to prevent the input accessory from overlapping it in compact height.
- Reloads the input views while editing to avoid leaving a layout gap after returning to regular height.
- */
+    /**
+     Updates the wheel `UIDatePicker` autoresizing mask on iOS 26 to prevent the input accessory from overlapping it in compact height.
+     Reloads the input views while editing to avoid leaving a layout gap after returning to regular height.
+     */
     private func updateDatePickerAutoresizingForCurrentTrait() {
         guard #available(iOS 26, *),
               let picker = textField.inputView as? UIDatePicker else { return }

--- a/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/Skonto/Views/SkontoExpiryDateView.swift
+++ b/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/Skonto/Views/SkontoExpiryDateView.swift
@@ -101,13 +101,10 @@ class SkontoExpiryDateView: UIView, GiniInputAccessoryViewPresentable {
         updateDatePickerAutoresizingForCurrentTrait()
     }
 
-    /// On iOS 26 the wheel `UIDatePicker`'s host overlaps the input accessory
-    /// band in landscape (compact height), drawing Done behind the wheels.
-    /// Enabling `.flexibleHeight` lets UIKit shrink the picker to fit. In
-    /// portrait the mask must be cleared and the input views reloaded so
-    /// UIKit re-establishes a single input host — otherwise the accessory
-    /// host stays inflated after returning from landscape, leaving a gap
-    /// between the toolbar and the wheels.
+/**
+ Updates the wheel `UIDatePicker` autoresizing mask on iOS 26 to prevent the input accessory from overlapping it in compact height.
+ Reloads the input views while editing to avoid leaving a layout gap after returning to regular height.
+ */
     private func updateDatePickerAutoresizingForCurrentTrait() {
         guard #available(iOS 26, *),
               let picker = textField.inputView as? UIDatePicker else { return }


### PR DESCRIPTION
## Pull Request Description

<!-- Briefly explain **what** this PR does and **why**. Mention the motivation, feature, or issue it's addressing. -->

[PP-3258](https://ginis.atlassian.net/browse/PP-3258)<!-- Closes ticket number PP-####; Replace with JIRA ticket if relevant -->

This PR updates SkontoExpiryDateView in GiniBankSDK to mitigate an iOS 26 landscape layout issue where the wheel-style UIDatePicker overlaps the input accessory toolbar (making “Done” appear behind the wheels).

<!--

Some description of HOW you achieved it. Perhaps give a high level description of the chnages you did. Did you need to refactor something? What tradeoffs did you take?

-->

## Notes for Reviewers

- Adjusts the date picker’s autoresizingMask based on verticalSizeClass (compact vs. regular) for iOS 26.
- Reacts to trait collection changes and reloads input views while editing to avoid leaving a layout gap when switching back to portrait.
- Applies the trait-based configuration right after assigning the UIDatePicker as the inputView.
<!--

Explain how you verified the changes.
A clear testing scenario helps colleagues who may not be familiar with this part of the code quickly understand and verify the changes. Include steps they can follow to see the impact in action.

You can include: 
- Simulators/Devices you used (e.g. iPhone 13, iPad Pro) 
- iOS versions tested (e.g. 16.0, 17.5) 
- Manual checks (e.g. flow tested: onboarding, permissions, error states) 
- Unit tests added or updated 
 
 Include screenshots, screen recordings, or simulator gifs for UI changes. 
 
 - Optional: Anything that needs extra attention in review? Are there TODOs, known limitations, or follow-up work? 
 
 -->

[PP-3258]: https://ginis.atlassian.net/browse/PP-3258?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ