### PR TITLE
fix(GiniCaptureSDK): Tighten tipLabel top padding on review screen

### DIFF
--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Review/ReviewViewController.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Review/ReviewViewController.swift
@@ -273,7 +273,8 @@ public final class ReviewViewController: UIViewController {
 
     private lazy var tipLabelConstraints: [NSLayoutConstraint] = {
         return [
-            tipLabel.topAnchor.constraint(equalTo: contentView.topAnchor, constant: Constants.padding),
+            tipLabel.topAnchor.constraint(equalTo: contentView.topAnchor,
+                                          constant: Constants.tipLabelTopPadding),
             tipLabel.leadingAnchor.constraint(equalTo: contentView.leadingAnchor,
                                               constant: Constants.tipLabelPadding),
             tipLabel.trailingAnchor.constraint(equalTo: collectionView.trailingAnchor)
@@ -1240,6 +1241,7 @@ extension ReviewViewController {
 
         static let padding: CGFloat = 16
         static let tipLabelPadding: CGFloat = 8
+        static let tipLabelTopPadding: CGFloat = 6
         static let largePadding: CGFloat = 32
         static let bottomPadding: CGFloat = 50
         static let pageControlBottomPadding: CGFloat = 130


### PR DESCRIPTION
## Pull Request Description

<!-- Briefly explain **what** this PR does and **why**. Mention the motivation, feature, or issue it's addressing. -->

Tighten the vertical space between the navigation bar and the tip label ("Sind alle Zahlungsinformationen gut sichtbar?" / "Make sure the payment details are visible") on the review screen (`ReviewViewController`), reducing the visible empty gap at the top of the content view.

[PP-2545]<!-- Closes ticket number PP-####; Replace with JIRA ticket if relevant -->

<!--

Some description of HOW you achieved it. Perhaps give a high level description of the chnages you did. Did you need to refactor something? What tradeoffs did you take?

-->

- Introduces a new layout constant `Constants.tipLabelTopPadding: CGFloat = 6` scoped to the tip label's top spacing.
- `tipLabel.topAnchor` in `tipLabelConstraints` now uses the new constant instead of the shared `Constants.padding` (16pt).
- No other spacing on the review screen changes — `Constants.padding` still drives collection view top, button-container spacing, options-stack leading/trailing, and bottom-nav padding.

## Notes for Reviewers

<!--

Explain how you verified the changes.
A clear testing scenario helps colleagues who may not be familiar with this part of the code quickly understand and verify the changes. Include steps they can follow to see the impact in action.

You can include:
- Simulators/Devices you used (e.g. iPhone 13, iPad Pro)
- iOS versions tested (e.g. 16.0, 17.5)
- Manual checks (e.g. flow tested: onboarding, permissions, error states)
- Unit tests added or updated

 Include screenshots, screen recordings, or simulator gifs for UI changes.

 - Optional: Anything that needs extra attention in review? Are there TODOs, known limitations, or follow-up work?

 -->

- Simulator: iPhone (iOS 26) — review screen in portrait, single- and multi-page.
- Flow: camera → review; confirmed the tip label now sits closer to the nav bar and the gap above it looks tight.
- No unit-test changes; pure layout constant.

[PP-2545]: https://ginis.atlassian.net/browse/PP-2545?atlOrigin=eyJpIjoiNWRkNTlj
<img width="1320" height="2868" alt="Simulator Screenshot - iPhone 17 Pro Max - 2026-07-21 at 17 06 54" src="https://github.com/user-attachments/assets/6fde9bca-f153-45dd-9cb4-eb36fbfc92c9" />
NzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
<img width="750" height="1334" alt="Simulator Screenshot - iPhone SE (3rd generation) - 2026-07-21 at 17 09 12" src="https://github.com/user-attachments/assets/c10faaa5-a470-4a71-b4f9-4b1ad3a12da6" />

