### PR TITLE
fix(GiniCaptureSDK): Set take-photo as preferred action on unsupporte…

### DIFF
--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Camera/Camera/CameraViewController.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Camera/Camera/CameraViewController.swift
@@ -700,9 +700,12 @@ final class CameraViewController: UIViewController {
         alert.addAction(UIAlertAction(title: Strings.scanAnotherQRCode, style: .default) { [weak self] _ in
             self?.handleScanAnotherQRCode()
         })
-        alert.addAction(UIAlertAction(title: Strings.takePhotoOfDocument, style: .default) { [weak self] _ in
+
+        let takePhotoAction = UIAlertAction(title: Strings.takePhotoOfDocument, style: .default) { [weak self] _ in
             self?.handleTakePhotoOfDocument()
-        })
+        }
+        alert.addAction(takePhotoAction)
+        alert.preferredAction = takePhotoAction
 
         present(alert, animated: true)
     }


### PR DESCRIPTION

## Pull Request Description

<!-- Briefly explain **what** this PR does and **why**. Mention the motivation, feature, or issue it's addressing. -->


Updates the GiniCaptureSDK camera flow so that, when an unsupported QR code is detected, the alert defaults to the “Take photo of document” action to better guide the user.


<!--

Some description of HOW you achieved it. Perhaps give a high level description of the chnages you did. Did you need to refactor something? What tradeoffs did you take?

-->

## Notes for Reviewers

- Introduces a dedicated UIAlertAction instance for “Take photo of document”.
- Sets that action as alert.preferredAction in the unsupported QR alert.
<!--

Explain how you verified the changes.
A clear testing scenario helps colleagues who may not be familiar with this part of the code quickly understand and verify the changes. Include steps they can follow to see the impact in action.

You can include: 
- Simulators/Devices you used (e.g. iPhone 13, iPad Pro) 
- iOS versions tested (e.g. 16.0, 17.5) 
- Manual checks (e.g. flow tested: onboarding, permissions, error states) 
- Unit tests added or updated 
 
 Include screenshots, screen recordings, or simulator gifs for UI changes. 
 
 - Optional: Anything that needs extra attention in review? Are there TODOs, known limitations, or follow-up work? 
 
 -->