### PR TITLE
Pp 3238 update label after qr optout

### DIFF
--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Camera/Camera/CameraViewController.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Camera/Camera/CameraViewController.swift
@@ -143,8 +143,9 @@ final class CameraViewController: UIViewController {
 
     fileprivate func configureTitle() {
         let device = UIDevice.current
-        // True once the user has opted out of QR scanning via "Take photo of document".
-        let didOptOutOfQRScanning = cameraPane.cameraTitleLabel?.text == Strings.onlyInvoice
+        // The camera UI already shows "Scan invoice" — from initial config with QR disabled,
+        // or after the user tapped "Take photo of document".
+        let cameraTitleAlreadyReadsInvoice = cameraPane.cameraTitleLabel?.text == Strings.onlyInvoice
             || title == Strings.onlyInvoice
 
         if device.isIphone && device.isPortrait {
@@ -152,8 +153,8 @@ final class CameraViewController: UIViewController {
             return
         }
 
-        // Keep "Scan invoice" title across rotation after the user opted out of QR scanning.
-        if didOptOutOfQRScanning {
+        // Preserve the "Scan invoice" title on rotation after the opt-out.
+        if cameraTitleAlreadyReadsInvoice {
             title = Strings.onlyInvoice
             return
         }

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Camera/Camera/CameraViewController.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Camera/Camera/CameraViewController.swift
@@ -722,6 +722,8 @@ final class CameraViewController: UIViewController {
         cameraPreviewViewController.cameraFrameView.isHidden = false
         isQRScanFlowActive = false
         detectedQRCodeDocument = nil
+        cameraPane.cameraTitleLabel?.text = Strings.onlyInvoice
+        cameraPaneHorizontal?.cameraTitleLabel?.text = Strings.onlyInvoice
     }
 
     private func isAccessibilityLargeTextEnabled() -> Bool {

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Camera/Camera/CameraViewController.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Camera/Camera/CameraViewController.swift
@@ -726,7 +726,7 @@ final class CameraViewController: UIViewController {
         detectedQRCodeDocument = nil
     }
 
-    private func handleTakePhotoOfDocument() {
+    func handleTakePhotoOfDocument() {
         // QR detection stays paused — resuming here would immediately re-trigger the alert
         cameraPreviewViewController.cameraFrameView.isHidden = false
         isQRScanFlowActive = false

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Camera/Camera/CameraViewController.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Camera/Camera/CameraViewController.swift
@@ -143,9 +143,18 @@ final class CameraViewController: UIViewController {
 
     fileprivate func configureTitle() {
         let device = UIDevice.current
+        // True once the user has opted out of QR scanning via "Take photo of document".
+        let didOptOutOfQRScanning = cameraPane.cameraTitleLabel?.text == Strings.onlyInvoice
+            || title == Strings.onlyInvoice
 
         if device.isIphone && device.isPortrait {
             title = giniConfiguration.onlyQRCodeScanningEnabled ? Strings.onlyQr : Strings.cameraTitle
+            return
+        }
+
+        // Keep "Scan invoice" title across rotation after the user opted out of QR scanning.
+        if didOptOutOfQRScanning {
+            title = Strings.onlyInvoice
             return
         }
 
@@ -722,8 +731,14 @@ final class CameraViewController: UIViewController {
         cameraPreviewViewController.cameraFrameView.isHidden = false
         isQRScanFlowActive = false
         detectedQRCodeDocument = nil
+        showOnlyInvoiceTitles()
+    }
+
+    private func showOnlyInvoiceTitles() {
         cameraPane.cameraTitleLabel?.text = Strings.onlyInvoice
         cameraPaneHorizontal?.cameraTitleLabel?.text = Strings.onlyInvoice
+        title = Strings.onlyInvoice
+        configureTitle()
     }
 
     private func isAccessibilityLargeTextEnabled() -> Bool {

--- a/CaptureSDK/GiniCaptureSDK/Tests/GiniCaptureSDKTests/CameraPreviewViewControllerTests.swift
+++ b/CaptureSDK/GiniCaptureSDK/Tests/GiniCaptureSDKTests/CameraPreviewViewControllerTests.swift
@@ -162,6 +162,75 @@ final class CameraPreviewViewControllerTests: XCTestCase {
         XCTAssertEqual(output.metadataObjectTypes, [.qr],
                        "metadataObjectTypes should be set to [.qr] when .qr is available")
     }
+
+    // MARK: - CameraViewController opt-out title behavior
+
+    func testOptOutFollowedByRotationPreservesScanInvoiceTitle() {
+        let giniConfiguration = GiniConfiguration()
+        giniConfiguration.qrCodeScanningEnabled = true
+        let viewController = CameraViewController(giniConfiguration: giniConfiguration,
+                                                  viewModel: CameraButtonsViewModel())
+        viewController.loadViewIfNeeded()
+
+        let onlyInvoiceLabel = NSLocalizedString("ginicapture.camera.infoLabel.only.invoice",
+                                                 bundle: giniCaptureBundle(),
+                                                 comment: "")
+
+        // Simulate the post-"Take photo of document" state (handleTakePhotoOfDocument is private).
+        viewController.cameraPane.cameraTitleLabel?.text = onlyInvoiceLabel
+        viewController.cameraPaneHorizontal?.cameraTitleLabel?.text = onlyInvoiceLabel
+        viewController.title = onlyInvoiceLabel
+
+        // Simulate a rotation — viewWillTransition invokes configureTitle inside its coordinator.
+        viewController.viewWillTransition(to: CGSize(width: 800, height: 600),
+                                          with: ImmediateTransitionCoordinator())
+
+        XCTAssertEqual(viewController.cameraPane.cameraTitleLabel?.text, onlyInvoiceLabel,
+                       "Bottom pane info label should still read 'Scan invoice' after opt-out and rotation")
+
+        // Nav title carries "Scan invoice" only on layouts without the bottom pane label
+        // (iPad and iPhone landscape). Portrait iPhone intentionally keeps the default cameraTitle.
+        if !(UIDevice.current.isIphone && UIDevice.current.isPortrait) {
+            XCTAssertEqual(viewController.title, onlyInvoiceLabel,
+                           "Navigation title should stay 'Scan invoice' after opt-out and rotation on iPad / iPhone landscape")
+        }
+    }
+}
+
+// Fires the animate closure synchronously so tests can exercise viewWillTransition without a real transition.
+private final class ImmediateTransitionCoordinator: NSObject, UIViewControllerTransitionCoordinator {
+    var isAnimated: Bool = false
+    var presentationStyle: UIModalPresentationStyle = .none
+    var initiallyInteractive: Bool = false
+    var isInterruptible: Bool = false
+    var isInteractive: Bool = false
+    var isCancelled: Bool = false
+    var transitionDuration: TimeInterval = 0
+    var percentComplete: CGFloat = 0
+    var completionVelocity: CGFloat = 0
+    var completionCurve: UIView.AnimationCurve = .linear
+    var containerView: UIView = UIView()
+    var targetTransform: CGAffineTransform = .identity
+
+    func animate(alongsideTransition animation: ((UIViewControllerTransitionCoordinatorContext) -> Void)?,
+                 completion: ((UIViewControllerTransitionCoordinatorContext) -> Void)? = nil) -> Bool {
+        animation?(self)
+        completion?(self)
+        return true
+    }
+
+    func animateAlongsideTransition(in view: UIView?,
+                                    animation: ((UIViewControllerTransitionCoordinatorContext) -> Void)?,
+                                    completion: ((UIViewControllerTransitionCoordinatorContext) -> Void)?) -> Bool {
+        animation?(self)
+        completion?(self)
+        return true
+    }
+
+    func notifyWhenInteractionEnds(_ handler: @escaping (UIViewControllerTransitionCoordinatorContext) -> Void) {}
+    func notifyWhenInteractionChanges(_ handler: @escaping (UIViewControllerTransitionCoordinatorContext) -> Void) {}
+    func view(forKey key: UITransitionContextViewKey) -> UIView? { nil }
+    func viewController(forKey key: UITransitionContextViewControllerKey) -> UIViewController? { nil }
 }
 
 // Test stub that pretends .qr is supported, allowing the `availableMetadataObjectTypes.contains(.qr)`

--- a/CaptureSDK/GiniCaptureSDK/Tests/GiniCaptureSDKTests/CameraPreviewViewControllerTests.swift
+++ b/CaptureSDK/GiniCaptureSDK/Tests/GiniCaptureSDKTests/CameraPreviewViewControllerTests.swift
@@ -176,10 +176,8 @@ final class CameraPreviewViewControllerTests: XCTestCase {
                                                  bundle: giniCaptureBundle(),
                                                  comment: "")
 
-        // Simulate the post-"Take photo of document" state (handleTakePhotoOfDocument is private).
-        viewController.cameraPane.cameraTitleLabel?.text = onlyInvoiceLabel
-        viewController.cameraPaneHorizontal?.cameraTitleLabel?.text = onlyInvoiceLabel
-        viewController.title = onlyInvoiceLabel
+        // Real entry point — mirrors the alert's "Take photo of document" action.
+        viewController.handleTakePhotoOfDocument()
 
         // Simulate a rotation — viewWillTransition invokes configureTitle inside its coordinator.
         viewController.viewWillTransition(to: CGSize(width: 800, height: 600),


### PR DESCRIPTION
## Pull Request Description

<!-- Briefly explain **what** this PR does and **why**. Mention the motivation, feature, or issue it's addressing. -->

[PP-3238](https://ginis.atlassian.net/browse/PP-3238)<!-- Closes ticket number PP-####; Replace with JIRA ticket if relevant -->

This PR updates CameraViewController (CaptureSDK) to keep the camera screen’s navigation title consistent after a user opts out of QR scanning via “Take photo of document”, especially when the device rotates.

<!--

Some description of HOW you achieved it. Perhaps give a high level description of the chnages you did. Did you need to refactor something? What tradeoffs did you take?

-->

## Notes for Reviewers

- Adds an “opt-out” check inside configureTitle() intended to preserve the “Scan invoice” title after QR opt-out.
Introduces showOnlyInvoiceTitles() and calls it when the user selects “Take photo of document” from the unsupported-QR alert.
<!--

Explain how you verified the changes.
A clear testing scenario helps colleagues who may not be familiar with this part of the code quickly understand and verify the changes. Include steps they can follow to see the impact in action.

You can include: 
- Simulators/Devices you used (e.g. iPhone 13, iPad Pro) 
- iOS versions tested (e.g. 16.0, 17.5) 
- Manual checks (e.g. flow tested: onboarding, permissions, error states) 
- Unit tests added or updated 
 
 Include screenshots, screen recordings, or simulator gifs for UI changes. 
 
 - Optional: Anything that needs extra attention in review? Are there TODOs, known limitations, or follow-up work? 
 
 -->

[PP-3238]: https://ginis.atlassian.net/browse/PP-3238?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ