### PR TITLE
Pp 3291 fix digital invoice switch clipped

### DIFF
--- a/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/ReturnAssistant/DigitalInvoice/Components/DigitalLineItemTableViewCell.swift
+++ b/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/ReturnAssistant/DigitalInvoice/Components/DigitalLineItemTableViewCell.swift
@@ -25,6 +25,7 @@ class DigitalLineItemTableViewCell: UITableViewCell {
     @IBOutlet weak var unitPriceLabel: UILabel!
     @IBOutlet weak var trailingConstraint: NSLayoutConstraint!
     @IBOutlet weak var leadingConstraint: NSLayoutConstraint!
+    @IBOutlet weak var modeSwitchTrailingConstraint: NSLayoutConstraint!
 
     override var canBecomeFocused: Bool {
         false
@@ -91,6 +92,13 @@ class DigitalLineItemTableViewCell: UITableViewCell {
 
         modeSwitch.removeTarget(self, action: #selector(modeSwitchValueChange(sender:)), for: .valueChanged)
         modeSwitch.addTarget(self, action: #selector(modeSwitchValueChange(sender:)), for: .valueChanged)
+
+        // The iOS 26 Liquid Glass UISwitch renders a visually wider pill than
+        // the legacy style, so the same trailing constant looks tighter to the
+        // card edge. Bump the constant on iOS 26+ to match the pre-26 padding.
+        if #available(iOS 26.0, *) {
+            modeSwitchTrailingConstraint.constant = Constants.modeSwitchTrailingLiquidGlass
+        }
     }
 
     private func updateUIWithViewModel() {
@@ -178,6 +186,7 @@ class DigitalLineItemTableViewCell: UITableViewCell {
 private extension DigitalLineItemTableViewCell {
     struct Constants {
         static let cornerRadius: CGFloat = 8.0
+        static let modeSwitchTrailingLiquidGlass: CGFloat = 23
     }
 }
 

--- a/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Resources/DigitalLineItemTableViewCell.xib
+++ b/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Resources/DigitalLineItemTableViewCell.xib
@@ -22,14 +22,17 @@
                             <rect key="frame" x="0.0" y="0.0" width="414" height="155"/>
                             <subviews>
                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="6LC-kT-CZp" userLabel="Separator View">
-                                    <rect key="frame" x="0.0" y="0.0" width="337" height="1"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="349" height="1"/>
                                     <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                     <constraints>
                                         <constraint firstAttribute="height" constant="1" id="w1f-up-Wj9"/>
                                     </constraints>
                                 </view>
                                 <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="CUJ-3d-daD">
-                                    <rect key="frame" x="337" y="17" width="63" height="28"/>
+                                    <rect key="frame" x="349" y="17" width="51" height="31"/>
+                                    <constraints>
+                                        <constraint firstAttribute="width" constant="49" id="6yf-59-2jq"/>
+                                    </constraints>
                                 </switch>
                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="751" insetsLayoutMarginsFromSafeArea="NO" text="Nike Sportswear Air Max 97 - Sneaker Low…" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" minimumScaleFactor="0.90000000000000002" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="ci3-Xk-SLN">
                                     <rect key="frame" x="16" y="17" width="226" height="42.5"/>
@@ -113,6 +116,7 @@
                 <outlet property="editButton" destination="ogc-mD-pz6" id="oiL-SO-VZw"/>
                 <outlet property="leadingConstraint" destination="Gbt-6K-DwO" id="HSk-PA-gFy"/>
                 <outlet property="modeSwitch" destination="CUJ-3d-daD" id="fEz-kD-dRR"/>
+                <outlet property="modeSwitchTrailingConstraint" destination="ZiN-p2-IdN" id="mst-Tr-lgP"/>
                 <outlet property="nameLabel" destination="ci3-Xk-SLN" id="whg-Zb-Jno"/>
                 <outlet property="priceLabel" destination="GOU-G0-cKp" id="eio-a5-2Wg"/>
                 <outlet property="separatorView" destination="6LC-kT-CZp" id="8Ue-hi-CsT"/>


### PR DESCRIPTION
## Pull Request Description

<!-- Briefly explain **what** this PR does and **why**. Mention the motivation, feature, or issue it's addressing. -->

[PP-3291](https://ginis.atlassian.net/browse/PP-3291)<!-- Closes ticket number PP-####; Replace with JIRA ticket if relevant -->

Updates the Digital Invoice line item cell layout in GiniBankSDK to prevent the mode UISwitch from appearing clipped (notably with the iOS 26 “Liquid Glass” switch style) by adjusting its trailing padding via an exposed Auto Layout constraint.




<!--

Some description of HOW you achieved it. Perhaps give a high level description of the chnages you did. Did you need to refactor something? What tradeoffs did you take?

-->

## Notes for Reviewers

- Exposes the switch trailing constraint from the XIB to code via a new IBOutlet.
- Adjusts the switch trailing padding on iOS 26+ to better match pre‑iOS 26 visual spacing.
- Updates the XIB layout for the separator/switch positioning (and adds a switch width constraint, which should be reconsidered).
<!--

Explain how you verified the changes.
A clear testing scenario helps colleagues who may not be familiar with this part of the code quickly understand and verify the changes. Include steps they can follow to see the impact in action.

You can include: 
- Simulators/Devices you used (e.g. iPhone 13, iPad Pro) 
- iOS versions tested (e.g. 16.0, 17.5) 
- Manual checks (e.g. flow tested: onboarding, permissions, error states) 
- Unit tests added or updated 
 
 Include screenshots, screen recordings, or simulator gifs for UI changes. 
 
 - Optional: Anything that needs extra attention in review? Are there TODOs, known limitations, or follow-up work? 
 
 -->

[PP-3291]: https://ginis.atlassian.net/browse/PP-3291?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ