### PR TITLE
 fix(GiniCaptureSDK): Fall back to legacy warning in QR-only mode

### DIFF
--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Camera/Camera/CameraViewController.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Camera/Camera/CameraViewController.swift
@@ -632,10 +632,10 @@ final class CameraViewController: UIViewController {
 
         // In QR-only mode, fall back to the legacy yellow overlay: the new alert's
         // "Take photo of document" action is invalid when document capture is disabled.
-        let shouldShowUnsupportedQRAlert = sessionUnsupportedQRCodeWarningEnabled == true
+        let shouldShowUnsupportedQRCodeAlert = sessionUnsupportedQRCodeWarningEnabled == true
             && !giniConfiguration.onlyQRCodeScanningEnabled
 
-        if shouldShowUnsupportedQRAlert {
+        if shouldShowUnsupportedQRCodeAlert {
             showUnsupportedQRCodeAlert()
         } else {
             showInvalidQRCodeFeedback()

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Camera/Camera/CameraViewController.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Camera/Camera/CameraViewController.swift
@@ -630,7 +630,12 @@ final class CameraViewController: UIViewController {
             didCaptureSessionUnsupportedQRCodeWarning = true
         }
 
-        if sessionUnsupportedQRCodeWarningEnabled == true {
+        // In QR-only mode, fall back to the legacy yellow overlay: the new alert's
+        // "Take photo of document" action is invalid when document capture is disabled.
+        let shouldShowUnsupportedQRAlert = sessionUnsupportedQRCodeWarningEnabled == true
+            && !giniConfiguration.onlyQRCodeScanningEnabled
+
+        if shouldShowUnsupportedQRAlert {
             showUnsupportedQRCodeAlert()
         } else {
             showInvalidQRCodeFeedback()


### PR DESCRIPTION
## Pull Request Description

<!-- Briefly explain **what** this PR does and **why**. Mention the motivation, feature, or issue it's addressing. -->

[PP-3283](https://ginis.atlassian.net/browse/PP-3283 )<!-- Closes ticket number PP-####; Replace with JIRA ticket if relevant -->

Updates GiniCaptureSDK camera QR handling so that when the SDK runs in QR-only mode it no longer presents the “unsupported QR code” alert (whose “Take photo of document” action is not applicable), and instead falls back to the legacy invalid-QR overlay feedback.

<!--

Some description of HOW you achieved it. Perhaps give a high level description of the chnages you did. Did you need to refactor something? What tradeoffs did you take?

-->

## Notes for Reviewers

- Add a shouldShowUnsupported… gate that suppresses the unsupported-QR alert when giniConfiguration.onlyQRCodeScanningEnabled is enabled.
- Keep showing the legacy invalid-QR overlay feedback in QR-only mode.
<!--

Explain how you verified the changes.
A clear testing scenario helps colleagues who may not be familiar with this part of the code quickly understand and verify the changes. Include steps they can follow to see the impact in action.

You can include: 
- Simulators/Devices you used (e.g. iPhone 13, iPad Pro) 
- iOS versions tested (e.g. 16.0, 17.5) 
- Manual checks (e.g. flow tested: onboarding, permissions, error states) 
- Unit tests added or updated 
 
 Include screenshots, screen recordings, or simulator gifs for UI changes. 
 
 - Optional: Anything that needs extra attention in review? Are there TODOs, known limitations, or follow-up work? 
 
 -->

[PP-3283]: https://ginis.atlassian.net/browse/PP-3283?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ