### PR TITLE
fix(GiniCaptureSDK): Tint camera frame red for invalid QR alert

### DIFF
--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Camera/Camera/CameraViewController.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Camera/Camera/CameraViewController.swift
@@ -725,6 +725,8 @@ final class CameraViewController: UIViewController {
         sendGiniAnalyticsEventForInvalidQRCode()
         playVoiceOverMessage(success: false)
 
+        cameraPreviewViewController.changeQRFrameColor(to: .GiniCapture.error3)
+
         let alert = UIAlertController(title: Strings.unsupportedQRAlertTitle,
                                       message: nil,
                                       preferredStyle: .alert)
@@ -746,6 +748,7 @@ final class CameraViewController: UIViewController {
         // feedback stays off for the remainder of this camera session.
         cameraPreviewViewController.camera.resumeQRDetection()
         detectedQRCodeDocument = nil
+        resetQRFrameColor()
         showQRScanOnlyModeUI()
     }
 
@@ -769,8 +772,13 @@ final class CameraViewController: UIViewController {
         // QR detection stays paused — resuming here would immediately re-trigger the alert
         isQRScanFlowActive = false
         detectedQRCodeDocument = nil
+        resetQRFrameColor()
         hideQRScanOnlyModeUI()
         showOnlyInvoiceTitles()
+    }
+
+    private func resetQRFrameColor() {
+        cameraPreviewViewController.changeQRFrameColor(to: .GiniCapture.light1)
     }
 
     private func hideQRScanOnlyModeUI() {

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Camera/Camera/CameraViewController.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Camera/Camera/CameraViewController.swift
@@ -748,7 +748,7 @@ final class CameraViewController: UIViewController {
         // feedback stays off for the remainder of this camera session.
         cameraPreviewViewController.camera.resumeQRDetection()
         detectedQRCodeDocument = nil
-        resetQRFrameColor()
+        restoreDefaultQRFrameColor()
         showQRScanOnlyModeUI()
     }
 
@@ -772,12 +772,12 @@ final class CameraViewController: UIViewController {
         // QR detection stays paused — resuming here would immediately re-trigger the alert
         isQRScanFlowActive = false
         detectedQRCodeDocument = nil
-        resetQRFrameColor()
+        restoreDefaultQRFrameColor()
         hideQRScanOnlyModeUI()
         showOnlyInvoiceTitles()
     }
 
-    private func resetQRFrameColor() {
+    private func restoreDefaultQRFrameColor() {
         cameraPreviewViewController.changeQRFrameColor(to: .GiniCapture.light1)
     }
 


### PR DESCRIPTION
PP-3290

## Pull Request Description

<!-- Briefly explain **what** this PR does and **why**. Mention the motivation, feature, or issue it's addressing. -->

[PP-3290](https://ginis.atlassian.net/browse/PP-3290)<!-- Closes ticket number PP-####; Replace with JIRA ticket if relevant -->

This PR updates the CaptureSDK camera QR-scanning flow to visually indicate an unsupported/invalid QR code by tinting the camera/QR frame to an error color when the “unsupported QR” alert is presented, and restoring the default frame color when the user chooses an alert action.
<!--

Some description of HOW you achieved it. Perhaps give a high level description of the chnages you did. Did you need to refactor something? What tradeoffs did you take?

-->

## Notes for Reviewers

- Tint the camera/QR frame to .GiniCapture.error3 when showing the unsupported QR alert.
Reset the QR frame tint back to .GiniCapture.light1 when the user chooses “Scan another QR code” or “Take photo of document”.
- Add a small helper (resetQRFrameColor()) to centralize the reset behavior.

<!--

Explain how you verified the changes.
A clear testing scenario helps colleagues who may not be familiar with this part of the code quickly understand and verify the changes. Include steps they can follow to see the impact in action.

You can include: 
- Simulators/Devices you used (e.g. iPhone 13, iPad Pro) 
- iOS versions tested (e.g. 16.0, 17.5) 
- Manual checks (e.g. flow tested: onboarding, permissions, error states) 
- Unit tests added or updated 
 
 Include screenshots, screen recordings, or simulator gifs for UI changes. 
 
 - Optional: Anything that needs extra attention in review? Are there TODOs, known limitations, or follow-up work? 
 
 -->

[PP-3290]: https://ginis.atlassian.net/browse/PP-3290?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ