### PR TITLE
ci: Configure function_body_length lint rule

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -56,6 +56,11 @@ file_length:
   warning: 1000
   # error: 2000 # Temporarily disabled
 
+function_body_length:
+  ignore_comment_only_lines: true
+  warning: 100
+  # error: 200 # Temporarily disabled
+
 large_tuple:
   warning: 4
   # error: 5 # Temporarily disabled


### PR DESCRIPTION
## Pull request overview

This PR adjusts the repository’s SwiftLint configuration by introducing a `function_body_length` rule configuration, aiming to reduce the need for per-file inline disables and standardize lint behavior across modules.

**Changes:**
- Adds a `function_body_length` rule with `warning: 100`.
- Configures `function_body_length` to ignore comment-only lines (`ignore_comment_only_lines: true`).
- Keeps the error threshold commented out (consistent with other rules marked “Temporarily disabled”).


