### PR TITLE
refactor(GiniBankSDKExample): Derive BrowserStack artifact names per …

### DIFF
--- a/BankSDK/GiniBankSDKExample/GiniBankSDKExampleUITests/Scripts/bs_shared.sh
+++ b/BankSDK/GiniBankSDKExample/GiniBankSDKExampleUITests/Scripts/bs_shared.sh
@@ -29,8 +29,18 @@ BUILD_PRODUCTS="$DERIVED_DATA/Build/Products/Debug-iphoneos"
 SIGNING_CONFIG="$DERIVED_DATA/BrowserStackSigning.xcconfig"
 SAMPLES_DIR="$SCRIPT_DIR/../TestSamples/TestSamplesForBS"
 
-IPA_OUTPUT="$SCRIPT_DIR/GiniBankSDKExample.ipa"
-TEST_SUITE_OUTPUT="$SCRIPT_DIR/GiniBankSDKExampleUITests.zip"
+SCRIPT_NAME="$(basename "$0" .sh)"
+case "$SCRIPT_NAME" in
+    bs_run_smoke_tests)  BUILD_LABEL="SmokeTests" ;;
+    bs_run_cx_normal)    BUILD_LABEL="Capture-Normal" ;;
+    bs_run_cx_multipage) BUILD_LABEL="Capture-Multipage" ;;
+    bs_run_cx_no_results) BUILD_LABEL="Capture-NoResults" ;;
+    bs_run_skonto)       BUILD_LABEL="Skonto" ;;
+    bs_run_ra)           BUILD_LABEL="ReturnAssistant" ;;
+    *)                   BUILD_LABEL="$SCRIPT_NAME" ;;
+esac
+IPA_OUTPUT="$SCRIPT_DIR/${BUILD_LABEL}.ipa"
+TEST_SUITE_OUTPUT="$SCRIPT_DIR/${BUILD_LABEL}-Tests.zip"
 
 # ── Devices ───────────────────────────────────────────────────────────────────
 DEVICE_1="iPhone 17-26"


### PR DESCRIPTION

## Pull Request Description

<!-- Briefly explain **what** this PR does and **why**. Mention the motivation, feature, or issue it's addressing. -->


Refactors the BrowserStack UI test helper script to derive IPA and test-suite artifact filenames from the invoking bs_run_*.sh script, enabling per-suite artifacts instead of always producing the same fixed output names.




<!--

Some description of HOW you achieved it. Perhaps give a high level description of the chnages you did. Did you need to refactor something? What tradeoffs did you take?

-->

## Notes for Reviewers

Derives a BUILD_LABEL from the calling script name ($0) via a case mapping.
Uses BUILD_LABEL to generate suite-specific IPA_OUTPUT and TEST_SUITE_OUTPUT filenames.
<!--

Explain how you verified the changes.
A clear testing scenario helps colleagues who may not be familiar with this part of the code quickly understand and verify the changes. Include steps they can follow to see the impact in action.

You can include: 
- Simulators/Devices you used (e.g. iPhone 13, iPad Pro) 
- iOS versions tested (e.g. 16.0, 17.5) 
- Manual checks (e.g. flow tested: onboarding, permissions, error states) 
- Unit tests added or updated 
 
 Include screenshots, screen recordings, or simulator gifs for UI changes. 
 
 - Optional: Anything that needs extra attention in review? Are there TODOs, known limitations, or follow-up work? 
 
 -->