### PR TITLE
docs: Add graphify knowledge graph guidance to CLAUDE.md

### DIFF
--- a/.github/instructions/swift-documentation-style.md
+++ b/.github/instructions/swift-documentation-style.md
@@ -5,11 +5,11 @@ description: enforce a single swift documentation style for code comments and ap
 
 Rewrite Swift documentation and comments to match this exact house style. Do not preserve alternative doc styles.
 
+**Canonical source:** [Code documentation style (Platform Mobile)](https://ginis.atlassian.net/wiki/spaces/PLMO/pages/1290534919/Code+documentation+style). Keep this file in sync with that page.
+
 ## Rules to enforce
 
-1. // → used for inline comments inside method bodies ✅
-
-  /// → used for documentation comments on declarations (functions, classes, properties) ❌ for inline use
+1. Use `///` for inline explanatory comments inside function or method bodies.
 
 2. Use `/** ... */` for declaration documentation on functions, methods, classes, structs, enums, protocols, properties, initializers, and extensions.
 3. Do not use `///` as the documentation format for declarations.
@@ -68,9 +68,10 @@ Use this shape:
 
 ### Inline comment inside executable code
 Use this shape:
-// → used for inline comments inside method bodies ✅
 
-/// → used for documentation comments on declarations (functions, classes, properties) ❌ for inline use
+```swift
+/// Explains the behavior of the next line or block.
+```
 
 
 ## Style guidance
@@ -122,6 +123,29 @@ public func updateConfiguration(withCaptureConfiguration configuration: GiniConf
  If set to `true`, a hint is displayed in the payment flow to remind the user about the upcoming payment due date.
  */
 public var paymentDueHintEnabled: Bool = true
+```
+
+### Public protocol
+```swift
+/**
+ A protocol that provides bottom sheet presentation functionality to `UIViewController` instances.
+
+ Conforming view controllers can be presented using iOS 15+ sheet presentation controllers with
+ configurable detents and drag indicators. For iOS versions prior to 15, the view controller is
+ presented as a standard modal sheet.
+
+ - Note: This protocol leverages `UISheetPresentationController`, available from iOS 15.0+.
+
+ ## Topics
+
+ ### Configuring Bottom Sheet Behavior
+ - ``shouldShowDragIndicator``
+
+ ### Presentation Methods
+ - ``configureBottomSheet(shouldIncludeLargeDetent:)``
+ - ``updateBottomSheetHeight(_:)``
+ */
+public protocol GiniBottomSheetPresentable
 ```
 
 ### Method with parameters and return value

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ DerivedData
 fastlane/report.xml
 BankSDK/GiniBankSDK/.build
 CaptureSDK/GiniCaptureSDK/.build
+/graphify-out/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,17 +26,15 @@ make lint scheme=GiniCaptureSDK # For CaptureSDK changes
 
 When generating a pull request description:
 
-### Requirements
+**Requirements**
 
-- Use the repository PR template (`.github/pull_request_template.md`) exactly
-- Extract the Jira ticket from the commit message
-- Replace the placeholder ticket (e.g. PP-XXXX) with the real one
-- Describe:
-  - what changed
-  - why the change was needed
-  - how it was implemented (high level)
-- Mention affected modules, SDKs, flows, or APIs explicitly
-- Keep the description concise and reviewer-friendly
+- Use the repository PR template (`.github/pull_request_template.md`) exactly — it is the file GitHub pre-fills when a PR is opened.
+- If there is a Jira ticket, extract it from the commit message (the `<ticket-id>` line, e.g. `PP-1234`, `HEAL-99`, `XPL-42`).
+ - Replace the `[TICKET-ID]` placeholder with the real ticket, or `N/A` if no ticket applies.
+- Describe **what** changed, **why** the change was needed, and **how** it was implemented (high level).
+- Mention affected projects/modules explicitly in `<project>:<module>` form (e.g. `BankSDK`, `CaptureSDK`).
+- Keep the description concise and reviewer-friendly.
+
 
 ### Notes for Reviewers
 
@@ -73,6 +71,8 @@ Fill it in following the Requirements and Rules above:
 ## Swift Documentation and Comment Style
 
 Always write and rewrite Swift documentation and comments to match this exact house style. Do not preserve alternative documentation styles unless explicitly requested.
+
+**Canonical source:** [Code documentation style (Platform Mobile)](https://ginis.atlassian.net/wiki/spaces/PLMO/pages/1290534919/Code+documentation+style). Keep this section in sync with that page.
 
 ### Rules to Enforce
 
@@ -145,7 +145,7 @@ Always write and rewrite Swift documentation and comments to match this exact ho
 - Document behavior, side effects, defaults, constraints, and platform-specific details when relevant.
 - For booleans, prefer wording like "Indicates whether…" or "Specifies whether…".
 - For methods, start with an active verb: "Sets", "Updates", "Returns", "Configures", or "Retrieves".
-- For protocols, explain the capability the protocol provides.
+- For protocols, explain the capability the protocol provides; when useful, add a `- Note:` and `## Topics` groupings.
 - Preserve valid markdown links when they add value.
 
 ### Rewrite Workflow
@@ -167,15 +167,15 @@ Always write and rewrite Swift documentation and comments to match this exact ho
 
 ```swift
 func configureBottomSheet(shouldIncludeLargeDetent: Bool = false) {
-    // For iOS versions prior to 15, the view controller is presented as a standard modal sheet.
+    /// For iOS versions prior to 15, the view controller is presented as a standard modal sheet.
     if #available(iOS 15, *) {
         // ...
     }
 }
 ```
-// → used for inline comments inside method bodies ✅
+`///` → used for inline explanatory comments inside function or method bodies ✅
 
-/// → used for documentation comments on declarations (functions, classes, properties) ❌ for inline use
+`/** ... */` → used for documentation comments on declarations (functions, classes, properties, etc.)
 
 #### Public method
 
@@ -194,6 +194,30 @@ public func updateConfiguration(withCaptureConfiguration configuration: GiniConf
  If set to `true`, a hint is displayed in the payment flow to remind the user about the upcoming payment due date.
  */
 public var paymentDueHintEnabled: Bool = true
+```
+
+#### Public protocol
+
+```swift
+/**
+ A protocol that provides bottom sheet presentation functionality to `UIViewController` instances.
+
+ Conforming view controllers can be presented using iOS 15+ sheet presentation controllers with
+ configurable detents and drag indicators. For iOS versions prior to 15, the view controller is
+ presented as a standard modal sheet.
+
+ - Note: This protocol leverages `UISheetPresentationController`, available from iOS 15.0+.
+
+ ## Topics
+
+ ### Configuring Bottom Sheet Behavior
+ - ``shouldShowDragIndicator``
+
+ ### Presentation Methods
+ - ``configureBottomSheet(shouldIncludeLargeDetent:)``
+ - ``updateBottomSheetHeight(_:)``
+ */
+public protocol GiniBottomSheetPresentable
 ```
 
 #### Method with parameters and return value

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,7 +28,7 @@ When generating a pull request description:
 
 ### Requirements
 
-- Use the repository PR template exactly
+- Use the repository PR template (`.github/pull_request_template.md`) exactly
 - Extract the Jira ticket from the commit message
 - Replace the placeholder ticket (e.g. PP-XXXX) with the real one
 - Describe:
@@ -60,25 +60,13 @@ Include:
 
 ## PR Template
 
-### Pull Request Description
+The canonical PR template is [`.github/pull_request_template.md`](.github/pull_request_template.md) — the file GitHub pre-fills when a pull request is opened. Use it verbatim as the structure for every generated PR description; do not redefine or paraphrase the template here, so the two never drift apart.
 
-[JIRA-TICKET](https://ginis.atlassian.net/browse/JIRA-TICKET)
+Fill it in following the Requirements and Rules above:
 
-Briefly explain what this PR does and why it is needed.
-
-Add a short high-level explanation of how it was implemented. Mention relevant refactoring, tradeoffs, or architectural decisions if applicable.
-
-### Notes for Reviewers
-
-Explain how the changes were verified.
-
-Include:
-
-- test scenario(s) reviewers can follow
-- unit/integration tests added or updated
-- manual validation performed
-- anything that needs extra attention in review
-- known limitations or follow-up work, if any
+- Replace the `[PP-####]` placeholder with the real Jira ticket from the commit message.
+- Complete the **Pull Request Description** section — what changed and why, plus a high-level how.
+- Complete the **Notes for Reviewers** section — how the changes were verified, tests added or updated, and anything that needs extra attention in review.
 
 ---
 
@@ -228,3 +216,75 @@ private static func localizedBundle(parentBundle: Bundle, localeKey: String?) ->
 - When the user asks for a rewrite, return the rewritten Swift comments directly.
 - When the user asks for a review, point out every violation against this style and show the corrected form.
 - When generating new code documentation, produce comments in this style by default.
+
+---
+
+## graphify
+
+This monorepo has a **graphify knowledge graph** at `graphify-out/` covering all six SDKs
+(BankAPILibrary, HealthAPILibrary, CaptureSDK, BankSDK, HealthSDK, GiniComponents), built from
+Swift/Ruby/shell AST plus semantic extraction over the docs.
+
+### Rules
+
+- Before answering architecture or codebase questions, read `graphify-out/GRAPH_REPORT.md` for
+  the god nodes (`GiniCaptureSDK`, `GiniHealthAPILibrary`, `GiniConfiguration`,
+  `GiniBankAPILibrary`, `GiniBankConfiguration` …) and the community structure.
+- For cross-module "how does X relate to Y" questions, prefer graph traversal over grep — it
+  follows the graph's EXTRACTED + INFERRED edges instead of scanning files:
+  - `graphify query "<question>"` — broad context (BFS)
+  - `graphify path "<A>" "<B>"` — shortest path between two concepts (e.g. `"GiniBankSDK" "GiniUtilites"`)
+  - `graphify explain "<concept>"` — plain-language explanation of a node
+- Open `graphify-out/graph.html` in a browser for the interactive community view.
+- **The graph auto-rebuilds on branch switch** via a `post-checkout` git hook (AST-only, no API
+  cost), installed at `.git/hooks/post-checkout`. This is the only hook installed: commits do
+  **not** trigger a rebuild, and a plain `git pull` does **not** either (a pull fires no checkout).
+- After a `git pull` (e.g. pulling `main`) that you don't follow with a branch switch, run
+  `graphify update .` to refresh the graph against the pulled code.
+- After changing **docs, images, or PDFs** in a session (the hook only covers code), run
+  `/graphify --update` to fold them into the graph.
+- To rebuild manually at any time: `graphify update .` (AST-only, no API cost).
+
+---
+
+## MCP Tools: code-review-graph (optional — only if configured)
+
+> **NOTE:** The `code-review-graph` MCP server is **not currently connected** to this project.
+> The tools below are only available once that MCP server has been added to the Claude Code /
+> Claude Desktop config. Until then, use the `graphify` CLI commands in the `## graphify` section
+> above and fall back to Grep/Glob/Read. graphify can expose a subset of these live via
+> `/graphify --mcp` (tools: `query_graph`, `get_node`, `get_neighbors`, `get_community`,
+> `god_nodes`, `graph_stats`, `shortest_path`).
+
+**IF the `code-review-graph` MCP server is configured, prefer its tools BEFORE Grep/Glob/Read
+when exploring the codebase** — the graph is faster, cheaper (fewer tokens), and gives
+structural context (callers, dependents, test coverage) that file scanning cannot.
+
+### When to use graph tools first
+
+- **Exploring code**: `semantic_search_nodes` or `query_graph` instead of Grep
+- **Understanding impact**: `get_impact_radius` instead of manually tracing imports
+- **Code review**: `detect_changes` + `get_review_context` instead of reading entire files
+- **Finding relationships**: `query_graph` with callers_of / callees_of / imports_of / tests_for
+- **Architecture questions**: `get_architecture_overview` + `list_communities`
+
+Fall back to Grep/Glob/Read **only** when the graph doesn't cover what you need.
+
+### Key tools
+
+| Tool | Use when |
+|------|----------|
+| `detect_changes` | Reviewing code changes — gives risk-scored analysis |
+| `get_review_context` | Need source snippets for review — token-efficient |
+| `get_impact_radius` | Understanding blast radius of a change |
+| `get_affected_flows` | Finding which execution paths are impacted |
+| `query_graph` | Tracing callers, callees, imports, tests, dependencies |
+| `semantic_search_nodes` | Finding functions/classes by name or keyword |
+| `get_architecture_overview` | Understanding high-level codebase structure |
+| `refactor_tool` | Planning renames, finding dead code |
+
+### Workflow (when the MCP server is configured)
+
+1. Use `detect_changes` for code review.
+2. Use `get_affected_flows` to understand impact.
+3. Use `query_graph` with `pattern="tests_for"` to check coverage.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -202,10 +202,11 @@ init(compositeDocuments: [CompositeDocument]?,
   - Builders and factory methods
 
 
-# Pull Request Description Generation
-Refer to AGENTS.md for PR description generation and repository conventions.
+# Repository & Agent Conventions
 
-Always follow AGENTS.md instructions when generating pull request descriptions.
+Follow **AGENTS.md** for all repository and agent conventions in this repo — including the **graphify** knowledge-graph workflow (`## graphify`), the optional `code-review-graph` MCP tools, pull request description generation, and the Swift documentation style. Always follow AGENTS.md instructions when working here.
+
+Use the repository PR template at `.github/pull_request_template.md` (the file GitHub pre-fills for new PRs) as the canonical structure for PR descriptions.
 
 
 
@@ -225,77 +226,3 @@ Generates manual test cases from a Jira ticket, local spec file, or pasted text,
 - **Skill prompt:** `.claude/skills/generate-xray-tests/SKILL.md`
 - **Usage & arguments:** `.claude/skills/generate-xray-tests.md`
 - **GitHub Copilot Chat equivalent:** `.github/instructions/generate-xray-tests.instructions.md` · `.github/instructions/generate-xray-tests.md`
-
----
-
-## graphify
-
-This monorepo has a **graphify knowledge graph** at `graphify-out/` covering all six SDKs
-(BankAPILibrary, HealthAPILibrary, CaptureSDK, BankSDK, HealthSDK, GiniComponents).
-The graph is built primarily from Swift/Ruby/shell AST plus semantic extraction over the docs.
-
-**Rules:**
-
-- Before answering architecture or codebase questions, read `graphify-out/GRAPH_REPORT.md`
-  for god nodes (`GiniCaptureSDK`, `GiniHealthAPILibrary`, `GiniConfiguration`,
-  `GiniBankAPILibrary`, `GiniBankConfiguration` …) and community structure.
-- `graphify-out/wiki/index.md` exists — navigate the wiki instead of reading raw files when
-  you need a topic overview.
-- For cross-module "how does X relate to Y" questions, prefer graph traversal over grep — it
-  follows the graph's EXTRACTED + INFERRED edges instead of scanning files:
-  - `graphify query "<question>"` — broad context (BFS)
-  - `graphify path "<A>" "<B>"` — shortest path between two concepts (e.g. `"GiniBankSDK" "GiniUtilites"`)
-  - `graphify explain "<concept>"` — plain-language explanation of a node
-- **The graph auto-rebuilds on branch switch** via a `post-checkout` git hook (AST-only, no
-  API cost) — installed at `.git/hooks/post-checkout`. This is the only hook installed:
-  commits do **not** trigger a rebuild, and a plain `git pull` does **not** either (a pull
-  fires no checkout).
-- After a `git pull` (e.g. pulling main) that you don't follow with a branch switch, run
-  `graphify update .` to refresh the graph against the pulled code.
-- After changing **docs, images, or PDFs** in a session (the hook only covers code), run
-  `/graphify --update` to fold them into the graph.
-- To rebuild manually at any time: `graphify update .` (AST-only, no API cost).
-
----
-
-## MCP Tools: code-review-graph (optional — only if configured)
-
-> **NOTE:** The `code-review-graph` MCP server is **not currently connected** to this project.
-> The tools below are only available once that MCP server has been added to the Claude Code /
-> Claude Desktop config. Until then, use the `graphify` CLI commands above and fall back to
-> Grep/Glob/Read. graphify can expose a subset of these live via `/graphify --mcp`
-> (tools: `query_graph`, `get_node`, `get_neighbors`, `get_community`, `god_nodes`,
-> `graph_stats`, `shortest_path`).
-
-**IF the `code-review-graph` MCP server is configured, prefer its tools BEFORE Grep/Glob/Read
-when exploring the codebase** — the graph is faster, cheaper (fewer tokens), and gives
-structural context (callers, dependents, test coverage) that file scanning cannot.
-
-### When to use graph tools first
-
-- **Exploring code**: `semantic_search_nodes` or `query_graph` instead of Grep
-- **Understanding impact**: `get_impact_radius` instead of manually tracing imports
-- **Code review**: `detect_changes` + `get_review_context` instead of reading entire files
-- **Finding relationships**: `query_graph` with callers_of / callees_of / imports_of / tests_for
-- **Architecture questions**: `get_architecture_overview` + `list_communities`
-
-Fall back to Grep/Glob/Read **only** when the graph doesn't cover what you need.
-
-### Key tools
-
-| Tool | Use when |
-|------|----------|
-| `detect_changes` | Reviewing code changes — gives risk-scored analysis |
-| `get_review_context` | Need source snippets for review — token-efficient |
-| `get_impact_radius` | Understanding blast radius of a change |
-| `get_affected_flows` | Finding which execution paths are impacted |
-| `query_graph` | Tracing callers, callees, imports, tests, dependencies |
-| `semantic_search_nodes` | Finding functions/classes by name or keyword |
-| `get_architecture_overview` | Understanding high-level codebase structure |
-| `refactor_tool` | Planning renames, finding dead code |
-
-### Workflow (when the MCP server is configured)
-
-1. Use `detect_changes` for code review.
-2. Use `get_affected_flows` to understand impact.
-3. Use `query_graph` with `pattern="tests_for"` to check coverage.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -225,3 +225,77 @@ Generates manual test cases from a Jira ticket, local spec file, or pasted text,
 - **Skill prompt:** `.claude/skills/generate-xray-tests/SKILL.md`
 - **Usage & arguments:** `.claude/skills/generate-xray-tests.md`
 - **GitHub Copilot Chat equivalent:** `.github/instructions/generate-xray-tests.instructions.md` · `.github/instructions/generate-xray-tests.md`
+
+---
+
+## graphify
+
+This monorepo has a **graphify knowledge graph** at `graphify-out/` covering all six SDKs
+(BankAPILibrary, HealthAPILibrary, CaptureSDK, BankSDK, HealthSDK, GiniComponents).
+The graph is built primarily from Swift/Ruby/shell AST plus semantic extraction over the docs.
+
+**Rules:**
+
+- Before answering architecture or codebase questions, read `graphify-out/GRAPH_REPORT.md`
+  for god nodes (`GiniCaptureSDK`, `GiniHealthAPILibrary`, `GiniConfiguration`,
+  `GiniBankAPILibrary`, `GiniBankConfiguration` …) and community structure.
+- `graphify-out/wiki/index.md` exists — navigate the wiki instead of reading raw files when
+  you need a topic overview.
+- For cross-module "how does X relate to Y" questions, prefer graph traversal over grep — it
+  follows the graph's EXTRACTED + INFERRED edges instead of scanning files:
+  - `graphify query "<question>"` — broad context (BFS)
+  - `graphify path "<A>" "<B>"` — shortest path between two concepts (e.g. `"GiniBankSDK" "GiniUtilites"`)
+  - `graphify explain "<concept>"` — plain-language explanation of a node
+- **The graph auto-rebuilds on branch switch** via a `post-checkout` git hook (AST-only, no
+  API cost) — installed at `.git/hooks/post-checkout`. This is the only hook installed:
+  commits do **not** trigger a rebuild, and a plain `git pull` does **not** either (a pull
+  fires no checkout).
+- After a `git pull` (e.g. pulling main) that you don't follow with a branch switch, run
+  `graphify update .` to refresh the graph against the pulled code.
+- After changing **docs, images, or PDFs** in a session (the hook only covers code), run
+  `/graphify --update` to fold them into the graph.
+- To rebuild manually at any time: `graphify update .` (AST-only, no API cost).
+
+---
+
+## MCP Tools: code-review-graph (optional — only if configured)
+
+> **NOTE:** The `code-review-graph` MCP server is **not currently connected** to this project.
+> The tools below are only available once that MCP server has been added to the Claude Code /
+> Claude Desktop config. Until then, use the `graphify` CLI commands above and fall back to
+> Grep/Glob/Read. graphify can expose a subset of these live via `/graphify --mcp`
+> (tools: `query_graph`, `get_node`, `get_neighbors`, `get_community`, `god_nodes`,
+> `graph_stats`, `shortest_path`).
+
+**IF the `code-review-graph` MCP server is configured, prefer its tools BEFORE Grep/Glob/Read
+when exploring the codebase** — the graph is faster, cheaper (fewer tokens), and gives
+structural context (callers, dependents, test coverage) that file scanning cannot.
+
+### When to use graph tools first
+
+- **Exploring code**: `semantic_search_nodes` or `query_graph` instead of Grep
+- **Understanding impact**: `get_impact_radius` instead of manually tracing imports
+- **Code review**: `detect_changes` + `get_review_context` instead of reading entire files
+- **Finding relationships**: `query_graph` with callers_of / callees_of / imports_of / tests_for
+- **Architecture questions**: `get_architecture_overview` + `list_communities`
+
+Fall back to Grep/Glob/Read **only** when the graph doesn't cover what you need.
+
+### Key tools
+
+| Tool | Use when |
+|------|----------|
+| `detect_changes` | Reviewing code changes — gives risk-scored analysis |
+| `get_review_context` | Need source snippets for review — token-efficient |
+| `get_impact_radius` | Understanding blast radius of a change |
+| `get_affected_flows` | Finding which execution paths are impacted |
+| `query_graph` | Tracing callers, callees, imports, tests, dependencies |
+| `semantic_search_nodes` | Finding functions/classes by name or keyword |
+| `get_architecture_overview` | Understanding high-level codebase structure |
+| `refactor_tool` | Planning renames, finding dead code |
+
+### Workflow (when the MCP server is configured)
+
+1. Use `detect_changes` for code review.
+2. Use `get_affected_flows` to understand impact.
+3. Use `query_graph` with `pattern="tests_for"` to check coverage.


### PR DESCRIPTION
### Pull Request Description

_No associated Jira ticket — this is a documentation/tooling change. (The commit message contains no ticket ID, and per repo conventions none was invented.)_

Adds guidance for the **graphify knowledge graph** to the repo-root `CLAUDE.md`, and ignores generated graph artifacts via `.gitignore`.

**What changed**
- `CLAUDE.md`: new `## graphify` section documenting the graph location (`graphify-out/`), the `GRAPH_REPORT.md` audit report and `wiki/index.md` overview, the `graphify query` / `path` / `explain` CLI for cross-module questions, the `post-checkout` auto-rebuild hook, and the manual `graphify update .` / `/graphify --update` commands.
- `CLAUDE.md`: new `## MCP Tools: code-review-graph (optional — only if configured)` section, intentionally gated behind a NOTE that this MCP server is **not currently connected** to the project, so it can't mislead a future session into calling tools that don't exist.
- `.gitignore`: adds `/graphify-out/` so the locally-generated graph artifacts stay out of git.

**Why**
So future Claude Code / AI-agent sessions prefer the (faster, cheaper, structural) knowledge graph over blind file scanning when answering architecture questions about the monorepo, and so generated graph output never gets committed by accident.

**How**
Documentation only. No source, SDK, or test code is touched.

### Notes for Reviewers

**Verification**
- Docs/config only — no code paths affected, so there is no build or test impact. AGENTS.md's `make lint` compilation validation does not apply (no `BankSDK`/`CaptureSDK` source changed).
- The guidance was checked against the actual local setup: `graphify-out/` (graph.json, GRAPH_REPORT.md, wiki/index.md) exists, and the `post-checkout` hook is installed. Note the hook lives in `.git/hooks/` (local, per-clone) and is **not** part of this PR — teammates who want auto-rebuild run `graphify hook install` themselves.

**Tests**
- None added — documentation change.

**Needs extra attention**
- The `code-review-graph` MCP section describes tooling that is **not wired up in this repo today**. It is deliberately marked optional/conditional. Please confirm you're comfortable keeping it as forward-looking documentation, or say the word and I'll drop it.
- One accuracy note reviewers may want to sanity-check: the doc states auto-rebuild happens on **branch switch only** (`post-checkout`), not on commit or `git pull` — this matches the single hook that is actually installed.

**Known limitations / follow-up**
- Because `graphify-out/` is git-ignored, this PR ships documentation + the ignore rule only; each developer generates their own graph locally via the `/graphify` skill.
