### PR TITLE
chore: Add shared gini-build skill

### DIFF
--- a/.claude/skills/gini-build/SKILL.md
+++ b/.claude/skills/gini-build/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: gini-build
+description: Implement a feature from its spec written by gini-spec-feature. Pass the ticket id as argument (e.g. PP-1234, IPC-42) — the spec must already exist in specs/.
+---
+
+<!--
+  MIRRORED FILE — this file must stay byte-identical to
+  .claude/skills/gini-build/SKILL.md in gini-mobile-ios.
+  If you change it here, open a paired PR in the other repo with the same
+  content. CI (shared-skills.check.yml) fails when the copies diverge.
+  Platform-specific rules do NOT belong here — they live in the sibling
+  platform.md, which is intentionally different per repo.
+-->
+
+You are implementing ticket $ARGUMENTS from its spec. The spec is the contract:
+you build what it says, nothing more, and every requirement ends up tested.
+
+## 0. Load platform conventions — REQUIRED FIRST
+
+Read `platform.md` in this skill's directory. It defines how to build and
+verify in this repository (check suite, test commands), where code and tests
+live, and the commit conventions. Every platform-specific decision below MUST
+come from that file, never from your own defaults. If the file is missing,
+stop and tell the user this repository is not set up for the shared build
+workflow.
+
+## 1. Load the spec — no spec, no code
+
+Read `specs/$ARGUMENTS-feature.md`, or — for a bug diagnosed with
+`/gini-fix` — `specs/$ARGUMENTS-bug.md`. If neither exists, stop and tell
+the user to run `/gini-spec-feature $ARGUMENTS` (features) or
+`/gini-fix $ARGUMENTS` (bugs) first — do not improvise a spec from the
+ticket.
+
+From a feature spec, internalize: the numbered requirements, the affected
+modules, the public API impact, the technical conventions, the design, the
+test plan, and — just as important — the "Out of scope" section. From a bug
+diagnosis: the root cause, the proposed fix, and the regression test plan
+(the regression test must fail before the fix and pass after). If the "Open
+questions" section is non-empty, surface those questions to the user with
+AskUserQuestion before writing any code.
+
+## 2. Verify the spec against the code
+
+Read the code the spec's Design section references. Code may have drifted
+since the spec was written. If reality contradicts the spec (a class was
+renamed, a precedent was removed, an approach is no longer viable), stop and
+show the user the conflict — let them decide whether to update the spec or
+proceed differently. Do not silently deviate from the spec.
+
+## 3. Plan the implementation
+
+Produce an ordered list of changes, each mapped to the spec requirement(s) it
+satisfies. Order it so tests can be written first and the build stays green
+at every step. Keep the plan within the spec's affected modules; if you
+discover a module not listed in the spec must change, tell the user before
+touching it.
+
+## 4. Implement, test-first
+
+Work through the plan requirement by requirement:
+
+- Write or extend the tests from the spec's test plan first, matching the
+  test stack and locations of neighboring tests (see `platform.md`), then
+  write the code that makes them pass.
+- Follow the spec's "Technical conventions" section exactly — it was written
+  for this feature and this repository.
+- Match the style, naming, and idioms of the files you touch.
+- Do not implement anything in "Out of scope". Do not widen public API beyond
+  what "Public API impact" declares.
+
+## 5. Verify
+
+Run the verification steps defined in `platform.md` for the affected modules.
+Fix what fails and re-run until clean. Report results honestly — if something
+still fails or was skipped, say so explicitly.
+
+## 6. Wrap up
+
+- Update the spec's `Status:` line from `draft` to `implemented` (feature)
+  or `fixed` (bug).
+- Summarize for the user: each requirement and where it was implemented and
+  tested (file paths), verification results, and anything left to manual QA
+  per the spec's test plan.
+- Offer to commit following the commit conventions in `platform.md`, but do
+  not commit or push unless the user asks.

--- a/.claude/skills/gini-build/platform.md
+++ b/.claude/skills/gini-build/platform.md
@@ -1,0 +1,114 @@
+# gini-build platform conventions — iOS (gini-mobile-ios)
+
+<!--
+  NOT MIRRORED — this file is iOS-specific by design. The Android repo has its
+  own platform.md with the same section headings but Android content. If you
+  add a section here that the shared workflow depends on, add the matching
+  section to the Android platform.md too.
+-->
+
+## Where code and tests live
+
+- Swift Package Manager monorepo inside a single workspace,
+  `GiniMobile.xcworkspace`. Reference modules by SPM product name
+  (`GiniBankSDK`, `GiniCaptureSDK`, `GiniHealthSDK`, `GiniBankAPILibrary`,
+  `GiniHealthAPILibrary`, `GiniUtilites`, `GiniInternalPaymentSDK`) — see
+  `CLAUDE.md` for the dependency graph.
+- Source: `Sources/<SDK>/` — `Core/`, `Extensions/`, `Resources/` (`.strings`,
+  assets), `<SDK>Version.swift`, `PrivacyInfo.xcprivacy`.
+- Tests: `Tests/<SDK>Tests/` (Swift Testing preferred for new files,
+  `<ClassUnderTest>Tests.swift`; XCTest legacy remains in many files —
+  match neighboring tests when extending a suite). JSON fixtures in
+  `Tests/<SDK>Tests/Resources/`, referenced via `.process("Resources")` /
+  `.copy` in the test target.
+- Minimum deployment target: iOS 15+ (default), iOS 17+ for GiniHealthSDK
+  and GiniHealthAPILibrary.
+
+## Building and running tests during implementation
+
+Prefer `xcodebuild` against the example app's Xcode project (CI parity):
+
+```bash
+xcodebuild clean test \
+  -project BankSDK/GiniBankSDKExample/GiniBankSDKExample.xcodeproj \
+  -scheme "GiniBankSDKExampleTests" \
+  -destination "platform=iOS Simulator,name=iPhone 16,OS=26.2" \
+  CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO
+```
+
+Swap the project/scheme for other SDKs (`GiniCaptureSDKExample`,
+`GiniHealthSDKExample`, etc.). To iterate on a single test class or
+`@Suite`, add `-only-testing:<Scheme>/<TestClassOrSuite>`.
+
+Fastlane wrapper (same underlying commands):
+
+```bash
+bundle exec fastlane run_unit_tests
+```
+
+Integration tests hitting the Gini API require `TEST_CLIENT_ID` /
+`TEST_CLIENT_SECRET` in the environment — they'll be skipped or fail without
+them (`CLAUDE.md`).
+
+CI environment: Xcode 26.2, iPhone 16 simulator on iOS 26.2, macOS-latest
+runner. Local runs on the same simulator remove one variable.
+
+## Verification (step 5 of the workflow)
+
+For every affected module, run:
+
+```bash
+make lint scheme=<Scheme>     # AGENTS.md gate — compile check
+```
+
+e.g. `make lint scheme=GiniBankSDK` for BankSDK changes,
+`make lint scheme=GiniCaptureSDK` for CaptureSDK. Then run the unit tests
+of the touched module (`xcodebuild ... test` above, or
+`bundle exec fastlane run_unit_tests`). If the spec's test plan includes
+UI tests, run them in the example app's UI-test target on the CI simulator.
+All must pass.
+
+## Coding conventions
+
+The spec's "Technical conventions" section is the feature-specific contract.
+Repo-wide rules live in `AGENTS.md` and `CLAUDE.md`; the ones most often
+violated:
+
+- New Swift, `internal` by default; `public`/`open` only where the spec's
+  Public API impact justifies it.
+- Doc comments follow `AGENTS.md`: `/** ... */` for declarations, `///` only
+  inline inside function bodies.
+- Multi-parameter initializers and methods: first parameter on the opening
+  paren line, remaining parameters aligned vertically on new lines
+  (`CLAUDE.md` code style).
+- MVVM + Coordinator: every feature gets `<Feature>Coordinator`,
+  `<Feature>ViewModel`, `<Feature>ViewModelDelegate`,
+  `<Feature>ViewController`. ViewModels MUST NOT import UIKit.
+- Constructor injection; delegate back-references are the only permitted
+  post-init injection. SDK entry points expose a fluent value-type builder
+  (`GiniBankAPI.Builder` precedent).
+- Colors via `UIColor.GiniBank.*` / `UIColor.GiniCapture.*`; dark mode via
+  `GiniColor(light:dark:).uiColor()`. Dynamic Type via
+  `textStyleFonts[textStyle]`. Spacing in a local `enum Constants`.
+- Strings via typed `LocalizableStringResource` enums under
+  `<sdk>.<feature>.<screen>.<element>`; never raw `NSLocalizedString`.
+- No SwiftUI in SDK sources — UIKit only. No Objective-C. Xamarin has been
+  removed; treat "Xamarin only" as dead code.
+
+## Commit conventions
+
+Format (`CLAUDE.md` → Commit Message Format):
+
+```
+<type>(<project>): <subject>
+
+<body>
+
+<ticket-id>
+```
+
+`type` ∈ `feat` | `fix` | `refactor` | `ci` (`chore` for cross-cutting).
+`project` is the module name (e.g. `GiniBankSDK`); omit the parentheses for
+multi-module changes. Subject in imperative mood, no period. Ticket ID
+($ARGUMENTS) is required on the last line, e.g. `PP-4102`. Never push
+release tags — `{PackageName};{version}` tags trigger release workflows.

--- a/.claude/skills/gini-build/platform.md
+++ b/.claude/skills/gini-build/platform.md
@@ -16,11 +16,25 @@
   `CLAUDE.md` for the dependency graph.
 - Source: `Sources/<SDK>/` — `Core/`, `Extensions/`, `Resources/` (`.strings`,
   assets), `<SDK>Version.swift`, `PrivacyInfo.xcprivacy`.
-- Tests: `Tests/<SDK>Tests/` (Swift Testing preferred for new files,
-  `<ClassUnderTest>Tests.swift`; XCTest legacy remains in many files —
-  match neighboring tests when extending a suite). JSON fixtures in
-  `Tests/<SDK>Tests/Resources/`, referenced via `.process("Resources")` /
-  `.copy` in the test target.
+- Unit tests: `Tests/<SDK>Tests/` (e.g.
+  `BankSDK/GiniBankSDK/Tests/GiniBankSDKTests/`),
+  `<ClassUnderTest>Tests.swift`. Swift Testing (`@Suite`/`@Test`/`#expect`)
+  is fully adopted in **GiniInternalPaymentSDK** and used for most new suites
+  in GiniBankAPILibrary and GiniCaptureSDK. GiniBankSDK, GiniHealthSDK, and
+  GiniHealthAPILibrary tests remain mostly XCTest. Match the neighboring
+  test file when extending; for new files, follow the module's dominant
+  framework.
+- UI tests: `<SDK>Example/<SDK>ExampleUITests/` (`GiniBankSDKExampleUITests`,
+  `GiniHealthSDKExampleTests`, etc.). Existing UI suites use a Page Object
+  pattern — screen selectors live under `Screens/` (`MainScreen.swift`,
+  `OnboardingScreen.swift`, …). Extend an existing screen object rather
+  than adding raw selectors. `GiniBankSDKExampleSwiftUIUITests/` covers the
+  SwiftUI example variant. No snapshot-testing library is in use.
+- Fixtures: `Tests/<SDK>Tests/Resources/`, referenced via
+  `.process("Resources")` / `.copy` in the test target. Not only JSON —
+  CaptureSDK ships `.pdf` (rotated variants, multi-page), `.jpg`, and
+  `.txt` extraction fixtures; API libraries ship `.pdf` and `.png`
+  payloads. Reuse an existing fixture when possible.
 - Minimum deployment target: iOS 15+ (default), iOS 17+ for GiniHealthSDK
   and GiniHealthAPILibrary.
 
@@ -32,7 +46,7 @@ Prefer `xcodebuild` against the example app's Xcode project (CI parity):
 xcodebuild clean test \
   -project BankSDK/GiniBankSDKExample/GiniBankSDKExample.xcodeproj \
   -scheme "GiniBankSDKExampleTests" \
-  -destination "platform=iOS Simulator,name=iPhone 16,OS=26.2" \
+  -destination "platform=iOS Simulator,name=iPhone 17,OS=26.2" \
   CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO
 ```
 
@@ -50,8 +64,9 @@ Integration tests hitting the Gini API require `TEST_CLIENT_ID` /
 `TEST_CLIENT_SECRET` in the environment — they'll be skipped or fail without
 them (`CLAUDE.md`).
 
-CI environment: Xcode 26.2, iPhone 16 simulator on iOS 26.2, macOS-latest
-runner. Local runs on the same simulator remove one variable.
+CI environment: Xcode 26.2, iPhone 17 simulator on iOS 26.2, macOS-latest
+runner (see `.github/workflows/shared-config.yml`). Local runs on the same
+simulator remove one variable.
 
 ## Verification (step 5 of the workflow)
 
@@ -67,6 +82,11 @@ of the touched module (`xcodebuild ... test` above, or
 `bundle exec fastlane run_unit_tests`). If the spec's test plan includes
 UI tests, run them in the example app's UI-test target on the CI simulator.
 All must pass.
+
+**Local vs CI destination:** `make lint` runs on `iPhone 15 Pro / iOS 17.2`
+(see `Makefile`) for faster iteration; CI's `shared-config.yml` uses
+`iPhone 17 / iOS 26.2`. Behavior can differ on iOS-26-only APIs — re-run
+failing checks in CI parity before pushing.
 
 ## Coding conventions
 
@@ -87,15 +107,25 @@ violated:
 - Constructor injection; delegate back-references are the only permitted
   post-init injection. SDK entry points expose a fluent value-type builder
   (`GiniBankAPI.Builder` precedent).
-- Colors via `UIColor.GiniBank.*` / `UIColor.GiniCapture.*`; dark mode via
-  `GiniColor(light:dark:).uiColor()`. Dynamic Type via
-  `textStyleFonts[textStyle]`. Spacing in a local `enum Constants`.
+- Colors: prefer **`GiniColorScheme`**
+  (`GiniUtilites/Color/GiniColorScheme.swift`, with module extensions like
+  `GiniBankColorScheme`) for new code — it's the current standard and
+  already the majority pattern outside CaptureSDK. The legacy
+  `UIColor.GiniBank.*` / `UIColor.GiniCapture.*` namespaces remain in place
+  and are still the norm inside CaptureSDK; match neighboring code when
+  extending existing files. Dark mode: `GiniColor(light:dark:).uiColor()`
+  is the underlying primitive that `GiniColorScheme` already wraps.
+  Dynamic Type via `textStyleFonts[textStyle]`. Spacing in a local
+  `enum Constants`.
 - Strings via typed `LocalizableStringResource` enums under
   `<sdk>.<feature>.<screen>.<element>`; never raw `NSLocalizedString`.
-- UIKit is the default in SDK sources today; SwiftUI is not banned — adopt
-  it when the spec calls for it and a precedent exists in the touched
-  module. No Objective-C. Xamarin has been removed; treat "Xamarin only"
-  as dead code.
+- UIKit remains the pattern in GiniBankSDK, GiniCaptureSDK screens, and
+  GiniHealthSDK view controllers. SwiftUI is the norm in
+  **GiniInternalPaymentSDK** (payment review, keyboard accessory, carousels)
+  and in the shared `GiniUtilites/SwiftUI/` helpers (font, color, layout,
+  height preference keys). Match neighboring code in the touched module —
+  don't rewrite a UIKit screen in SwiftUI opportunistically, and don't add
+  a UIKit view controller inside a SwiftUI feature.
 
 ## Commit conventions
 

--- a/.claude/skills/gini-build/platform.md
+++ b/.claude/skills/gini-build/platform.md
@@ -92,23 +92,15 @@ violated:
   `textStyleFonts[textStyle]`. Spacing in a local `enum Constants`.
 - Strings via typed `LocalizableStringResource` enums under
   `<sdk>.<feature>.<screen>.<element>`; never raw `NSLocalizedString`.
-- No SwiftUI in SDK sources — UIKit only. No Objective-C. Xamarin has been
-  removed; treat "Xamarin only" as dead code.
+- UIKit is the default in SDK sources today; SwiftUI is not banned — adopt
+  it when the spec calls for it and a precedent exists in the touched
+  module. No Objective-C. Xamarin has been removed; treat "Xamarin only"
+  as dead code.
 
 ## Commit conventions
 
-Format (`CLAUDE.md` → Commit Message Format):
-
-```
-<type>(<project>): <subject>
-
-<body>
-
-<ticket-id>
-```
-
-`type` ∈ `feat` | `fix` | `refactor` | `ci` (`chore` for cross-cutting).
-`project` is the module name (e.g. `GiniBankSDK`); omit the parentheses for
-multi-module changes. Subject in imperative mood, no period. Ticket ID
-($ARGUMENTS) is required on the last line, e.g. `PP-4102`. Never push
-release tags — `{PackageName};{version}` tags trigger release workflows.
+Follow the template at `.git-stuff/commit-msg-template.txt`. `type` is one of
+`feat` | `fix` | `refactor` | `ci`; `project` is the module name
+(e.g. `GiniBankSDK`), omit the parentheses for multi-module changes; the
+ticket id ($ARGUMENTS) goes in the footer. Never push release tags —
+`<PackageName>;<version>` tags trigger release workflows.


### PR DESCRIPTION
## Pull Request Description

<!-- Briefly explain **what** this PR does and **why**. Mention the motivation, feature, or issue it's addressing. -->

Adds the shared `gini-build` Claude skill, mirroring [gini/gini-mobile-android#959](https://github.com/gini/gini-mobile-android/pull/959). Follows the same split introduced by #1222: a platform-neutral `SKILL.md` byte-identical to the Android copy, plus an iOS-specific `platform.md`.

`gini-build` is the implementation-phase companion to `gini-spec-feature` / `gini-fix`: it reads the spec/diagnosis, plans changes, implements test-first, verifies, and hands back to the user for commit. It never invents a spec of its own.

<!-- Closes ticket number PP-####; Replace with JIRA ticket if relevant -->
No Jira ticket — internal tooling change.

<!--

Some description of HOW you achieved it. Perhaps give a high level description of the chnages you did. Did you need to refactor something? What tradeoffs did you take?

-->

**How it was implemented:**

- `.claude/skills/gini-build/SKILL.md` — general workflow. Byte-identical to the Android copy on branch `sdd-workflow-setup` at time of push (verified via `diff`).
- `.claude/skills/gini-build/platform.md` — iOS conventions grounded in `CLAUDE.md` + `AGENTS.md`:
  - **Where code lives:** SPM packages inside `GiniMobile.xcworkspace`; product-name references (`GiniBankSDK` etc.); iOS 15+ default, iOS 17+ for Health.
  - **Build/test:** `xcodebuild ... -destination "platform=iOS Simulator,name=iPhone 16,OS=26.2"` against each `<SDK>Example.xcodeproj`; Fastlane wrapper; `TEST_CLIENT_ID`/`SECRET` note.
  - **Verification:** `make lint scheme=<Scheme>` (AGENTS.md gate) plus unit tests for touched modules.
  - **Coding conventions:** MVVM+Coordinator, UIKit-only in SDK sources, `UIColor.GiniBank.*` / `GiniColor(light:dark:)`, doc-comment style, multi-parameter formatting rule, `LocalizableStringResource` for strings.
  - **Commits:** Conventional Commits with ticket footer per `CLAUDE.md`; never push release tags.

Not touched in this PR (per user's "focus on skills"): `.github/mirrored-skills.txt` and the two `shared-skills.*.yml` workflows already on `main`. Follow-up if desired: append `.claude/skills/gini-build/SKILL.md` to `mirrored-skills.txt` to activate the sync check for this file.

## Notes for Reviewers

<!--

Explain how you verified the changes.
A clear testing scenario helps colleagues who may not be familiar with this part of the code quickly understand and verify the changes. Include steps they can follow to see the impact in action.

You can include: 
- Simulators/Devices you used (e.g. iPhone 13, iPad Pro) 
- iOS versions tested (e.g. 16.0, 17.5) 
- Manual checks (e.g. flow tested: onboarding, permissions, error states) 
- Unit tests added or updated 
 
 Include screenshots, screen recordings, or simulator gifs for UI changes. 
 
 - Optional: Anything that needs extra attention in review? Are there TODOs, known limitations, or follow-up work? 
 
 -->

No product code changes — only `.claude/skills/gini-build/**`. No simulator or unit-test run needed.

Verification performed:

- **Byte-identical check** — `diff` between the local `SKILL.md` and the Android copy on `sdd-workflow-setup` returns 0. Once `mirrored-skills.txt` is extended, `shared-skills.check.yml` will start enforcing this on every PR.

Things to look at:

- `.claude/skills/gini-build/platform.md` — the iOS-specific rules. Please sanity-check the module map, the `xcodebuild` recipe (project name, scheme, destination), the verification command (`make lint scheme=...`), and the coding-conventions bullets against real practice. The Android platform.md has the same section headings; content diverges by design.
- Decide whether we want to also update `.github/mirrored-skills.txt` in a follow-up so the sync workflow starts enforcing byte-identity for `gini-build/SKILL.md`.