### PR TITLE
chore: Add shared gini-fix skill

### DIFF
--- a/.claude/skills/gini-fix/SKILL.md
+++ b/.claude/skills/gini-fix/SKILL.md
@@ -1,0 +1,127 @@
+---
+name: gini-fix
+description: Diagnose and fix a non-trivial bug ticket - reproduce it, find the root cause, write the diagnosis to specs/, then implement the fix with a regression test. Pass the ticket id as argument (e.g. PP-1234, IPC-42 - any board).
+---
+
+<!--
+  MIRRORED FILE — this file must stay byte-identical to
+  .claude/skills/gini-fix/SKILL.md in gini-mobile-ios.
+  If you change it here, open a paired PR in the other repo with the same
+  content. CI (shared-skills.check.yml) fails when the copies diverge.
+  Platform-specific rules do NOT belong here — they live in the sibling
+  platform.md, which is intentionally different per repo.
+-->
+
+You are diagnosing and fixing bug ticket $ARGUMENTS. Root cause comes before
+any fix: no code change until the diagnosis is written down and confirmed.
+Never fix a symptom whose cause you haven't found.
+
+## 0. Load platform conventions — REQUIRED FIRST
+
+Read `platform.md` in this skill's directory. It defines how to reproduce
+bugs in this repository (apps, build variants, logging), how to run tests,
+how to verify, and the commit conventions. Every platform-specific decision
+below MUST come from that file, never from your own defaults. If the file is
+missing, stop and tell the user this repository is not set up for the shared
+fix workflow.
+
+## 1. Fetch the ticket
+
+Fetch $ARGUMENTS from Jira (any board — PP or otherwise). Read the summary,
+description, comments, and linked issues, and mine them for: observed vs.
+expected behavior, stack traces or logs, affected SDK/app versions, device or
+OS specifics, and reproduction hints. If the ticket cannot be fetched, ask
+the user to paste its content instead of guessing.
+
+## 2. Reproduce the bug
+
+Reproduce it the way `platform.md` prescribes — prefer the cheapest faithful
+reproduction (a failing unit test beats launching an app). If you cannot
+reproduce it, do NOT start changing code on speculation: report what you
+tried and ask the user (via AskUserQuestion) for the missing detail —
+exact version, configuration, input document, locale, and so on.
+
+## 3. Find the root cause
+
+Run a disciplined hypothesis loop:
+
+- Form an explicit hypothesis about the cause; state it before testing it.
+- Gather evidence: read the involved code, follow the data flow, check the
+  git history of the suspicious lines (when did this last work?), add a
+  narrowing test or targeted logging where `platform.md` suggests.
+- Reject or confirm, then iterate. Keep going until you can name the root
+  cause at file-and-line precision and explain the mechanism from cause to
+  observed symptom.
+- Distinguish the root cause from where the symptom surfaces — they are
+  usually in different places. Fixing at the symptom site needs explicit
+  justification.
+
+## 4. Write the diagnosis
+
+Write `specs/$ARGUMENTS-bug.md` (create `specs/` if needed):
+
+```markdown
+# <Ticket ID>: <Title>
+
+Status: draft
+Ticket: <link to the Jira ticket>
+
+## Symptom
+Observed vs. expected behavior, in your own words.
+
+## Reproduction
+Exact steps or the failing test that demonstrates the bug.
+
+## Root cause
+The defect and its mechanism, referencing code with file paths and lines.
+How the cause produces the symptom.
+
+## Proposed fix
+What changes and where. Minimal — no drive-by refactoring. Note public API
+impact (should normally be "none" for a bug fix).
+
+## Regression test plan
+The test(s) that fail before the fix and pass after, their location, and the
+test stack to use (match neighboring tests — see platform.md).
+
+## Out of scope
+Related issues noticed but deliberately not fixed here (file tickets instead).
+
+## Open questions
+Anything still unresolved.
+```
+
+## 5. Checkpoint — confirm before fixing
+
+Show the user the root cause and proposed fix (via AskUserQuestion). They can:
+
+- confirm — continue to step 6 in this session, or
+- stop here — the diagnosis file stands on its own; the fix can be
+  implemented later with `/gini-build $ARGUMENTS` in a fresh session.
+
+Do not proceed to code changes without confirmation.
+
+## 6. Implement the fix, regression test first
+
+- Write the regression test first and run it: it MUST fail for the reason
+  the diagnosis describes. A regression test that passes before the fix
+  proves nothing — rework it until it fails correctly.
+- Apply the minimal fix from the diagnosis. Match the style of the file you
+  touch. No opportunistic refactoring, no scope creep into "Out of scope".
+- Re-run the regression test (now passing) and the tests around the touched
+  code.
+
+## 7. Verify
+
+Run the verification steps defined in `platform.md` for the affected modules,
+and re-check the original reproduction from step 2 no longer occurs. Fix what
+fails and re-run until clean. Report results honestly — if something still
+fails or was skipped, say so explicitly.
+
+## 8. Wrap up
+
+- Update the diagnosis file's `Status:` line from `draft` to `fixed`.
+- Summarize for the user: root cause, the fix (file paths), the regression
+  test, verification results, and anything left to manual QA.
+- Offer to commit following the commit conventions in `platform.md`, but do
+  not commit or push unless the user asks.

--- a/.claude/skills/gini-fix/platform.md
+++ b/.claude/skills/gini-fix/platform.md
@@ -13,15 +13,23 @@ Prefer the cheapest faithful reproduction, in this order:
 
 1. **Unit test** — most SDK logic is testable without a simulator. Put the
    repro test where the regression test will live (`Tests/<SDK>Tests/` of the
-   module owning the root cause). Swift Testing for new files
-   (`@Suite`/`@Test`/`#expect`); XCTest when extending a legacy suite
-   (match the neighboring file).
+   module owning the root cause). Swift Testing (`@Suite`/`@Test`/`#expect`)
+   is dominant in GiniInternalPaymentSDK and used for most new suites in
+   GiniBankAPILibrary and GiniCaptureSDK; GiniBankSDK, GiniHealthSDK, and
+   GiniHealthAPILibrary remain mostly XCTest. Match the neighboring file's
+   framework.
 2. **UI test / example-app instrumentation** when the bug needs real UIKit
    or lifecycle behavior — run via the example app's UI test scheme on the
-   CI simulator (iPhone 16, iOS 26.2). Example: `GiniBankSDKExampleUITests`.
+   CI simulator (iPhone 17, iOS 26.2). Existing UI tests live in
+   `<SDK>Example/<SDK>ExampleUITests/` (e.g. `GiniBankSDKExampleUITests`)
+   and use a Page Object pattern — screen selectors live under `Screens/`
+   (`MainScreen.swift`, `OnboardingScreen.swift`, `CameraAccessScreen.swift`,
+   …). Extend an existing screen object rather than adding raw selectors.
+   `BankSDK/GiniBankSDKExample/GiniBankSDKExampleSwiftUIUITests/` covers the
+   SwiftUI example variant.
 3. **Example app on the simulator** as a last resort:
    - Bank: open `GiniMobile.xcworkspace`, run `GiniBankSDKExample` on iPhone
-     16 / iOS 26.2.
+     17 / iOS 26.2.
    - Health: `GiniHealthSDKExample`. Real API access needs credentials in
      `Credentials.plist` / `CredentialsManager.swift` (see the example
      target). Without them, network-backed flows fail closed.
@@ -41,7 +49,7 @@ the matching release branch, not `main` — see `RELEASE.md` /
   xcodebuild test \
     -project <SDK>/<SDK>Example/<SDK>Example.xcodeproj \
     -scheme "<SDK>ExampleTests" \
-    -destination "platform=iOS Simulator,name=iPhone 16,OS=26.2" \
+    -destination "platform=iOS Simulator,name=iPhone 17,OS=26.2" \
     -only-testing:<SDK>ExampleTests/<TestClassOrSuiteName>
   ```
 - History of a suspicious file: `git log --follow -p -- <path>` and
@@ -55,16 +63,26 @@ the matching release branch, not `main` — see `RELEASE.md` /
 
 ## Regression test conventions
 
-- Unit tests in `Tests/<SDK>Tests/`, `<ClassUnderTest>Tests.swift`. New
-  files use Swift Testing (`@Suite`, `@Test`, `#expect`) per the MyApp
-  Standards rule in `CLAUDE.md`; when extending an XCTest suite, keep it
-  XCTest and match the file's style.
-- Manual protocol-conformance mocks — no third-party mocking framework.
-  JSON fixtures in `Tests/<SDK>Tests/Resources/`.
+- Unit tests in `Tests/<SDK>Tests/` (e.g.
+  `BankSDK/GiniBankSDK/Tests/GiniBankSDKTests/`), `<ClassUnderTest>Tests.swift`.
+  Swift Testing (`@Suite`, `@Test`, `#expect`) is fully adopted in
+  GiniInternalPaymentSDK and used for most new suites in GiniBankAPILibrary
+  and GiniCaptureSDK; GiniBankSDK, GiniHealthSDK, and GiniHealthAPILibrary
+  remain mostly XCTest. Match the neighboring test file when extending;
+  for a fresh location, follow the module's dominant framework.
+- Manual protocol-conformance mocks — no third-party mocking framework. No
+  snapshot-testing library in use.
+- Fixtures in `Tests/<SDK>Tests/Resources/`. Not only JSON — CaptureSDK
+  ships `.pdf` (rotated variants, multi-page), `.jpg`, and `.txt` extraction
+  fixtures; API libraries ship `.pdf` and `.png` payloads. Prefer an
+  existing fixture when your regression test needs a real document.
 - Name the test after the behavior. Reference the ticket in a comment only
   if the file's existing tests already do so — match local style.
-- Integration tests hitting the Gini API need `TEST_CLIENT_ID` /
-  `TEST_CLIENT_SECRET` in the environment (`CLAUDE.md`).
+- Integration tests: SDK-embedded integration tests hitting the Gini API
+  need `TEST_CLIENT_ID` / `TEST_CLIENT_SECRET` in the environment
+  (`CLAUDE.md`). Example apps have their own integration/unit split under
+  `BankSDK/GiniBankSDKExample/Tests/{IntegrationTests, UnitTests}/`
+  (SSL-pinning tests live under `IntegrationTests/SSLPinningTests/`).
 
 ## Verification (step 7 of the workflow)
 
@@ -78,8 +96,13 @@ e.g. `make lint scheme=GiniBankSDK` for BankSDK, `make lint scheme=GiniCaptureSD
 for CaptureSDK. Then run the unit tests of the touched module
 (`xcodebuild ... test` or `bundle exec fastlane run_unit_tests`). If the
 regression test is a UI test, run the example app's UI-test scheme on iPhone
-16 / iOS 26.2. Re-check the original reproduction from step 2 no longer
+17 / iOS 26.2. Re-check the original reproduction from step 2 no longer
 occurs.
+
+**Local vs CI destination:** `make lint` runs on `iPhone 15 Pro / iOS 17.2`
+(see `Makefile`) for faster iteration; CI's `shared-config.yml` uses
+`iPhone 17 / iOS 26.2`. Re-run failing checks in CI parity before pushing —
+behavior can differ on iOS-26-only APIs.
 
 ## Commit conventions
 

--- a/.claude/skills/gini-fix/platform.md
+++ b/.claude/skills/gini-fix/platform.md
@@ -1,0 +1,99 @@
+# gini-fix platform conventions — iOS (gini-mobile-ios)
+
+<!--
+  NOT MIRRORED — this file is iOS-specific by design. The Android repo has its
+  own platform.md with the same section headings but iOS content. If you add a
+  section here that the shared workflow depends on, add the matching section
+  to the Android platform.md too.
+-->
+
+## Reproducing bugs
+
+Prefer the cheapest faithful reproduction, in this order:
+
+1. **Unit test** — most SDK logic is testable without a simulator. Put the
+   repro test where the regression test will live (`Tests/<SDK>Tests/` of the
+   module owning the root cause). Swift Testing for new files
+   (`@Suite`/`@Test`/`#expect`); XCTest when extending a legacy suite
+   (match the neighboring file).
+2. **UI test / example-app instrumentation** when the bug needs real UIKit
+   or lifecycle behavior — run via the example app's UI test scheme on the
+   CI simulator (iPhone 16, iOS 26.2). Example: `GiniBankSDKExampleUITests`.
+3. **Example app on the simulator** as a last resort:
+   - Bank: open `GiniMobile.xcworkspace`, run `GiniBankSDKExample` on iPhone
+     16 / iOS 26.2.
+   - Health: `GiniHealthSDKExample`. Real API access needs credentials in
+     `Credentials.plist` / `CredentialsManager.swift` (see the example
+     target). Without them, network-backed flows fail closed.
+   - Capture: `GiniCaptureSDKExample`.
+   - Console logs: run from Xcode and read the debug console, or filter
+     `Console.app` by the app's bundle identifier.
+
+Version-specific bugs: check the ticket's SDK version against
+`Sources/<SDK>/<SDK>Version.swift`. Fixes for older major branches ship from
+the matching release branch, not `main` — see `RELEASE.md` /
+`RELEASE-ORDER.md`.
+
+## Root-cause tools
+
+- Narrow to a single test class while iterating:
+  ```bash
+  xcodebuild test \
+    -project <SDK>/<SDK>Example/<SDK>Example.xcodeproj \
+    -scheme "<SDK>ExampleTests" \
+    -destination "platform=iOS Simulator,name=iPhone 16,OS=26.2" \
+    -only-testing:<SDK>ExampleTests/<TestClassOrSuiteName>
+  ```
+- History of a suspicious file: `git log --follow -p -- <path>` and
+  `git blame <path>`. Release tags follow `<PackageName>;<version>`
+  (e.g. `GiniBankSDK;4.1.1`) — they tell you which release introduced a
+  change.
+- Inter-module effects: a bug surfacing in GiniBankSDK may root-cause in
+  GiniCaptureSDK, GiniBankAPILibrary, or GiniUtilites — see the dependency
+  graph in `CLAUDE.md`. GiniHealthSDK's chain goes through
+  GiniInternalPaymentSDK + GiniHealthAPILibrary.
+
+## Regression test conventions
+
+- Unit tests in `Tests/<SDK>Tests/`, `<ClassUnderTest>Tests.swift`. New
+  files use Swift Testing (`@Suite`, `@Test`, `#expect`) per the MyApp
+  Standards rule in `CLAUDE.md`; when extending an XCTest suite, keep it
+  XCTest and match the file's style.
+- Manual protocol-conformance mocks — no third-party mocking framework.
+  JSON fixtures in `Tests/<SDK>Tests/Resources/`.
+- Name the test after the behavior. Reference the ticket in a comment only
+  if the file's existing tests already do so — match local style.
+- Integration tests hitting the Gini API need `TEST_CLIENT_ID` /
+  `TEST_CLIENT_SECRET` in the environment (`CLAUDE.md`).
+
+## Verification (step 7 of the workflow)
+
+For every affected module, run:
+
+```bash
+make lint scheme=<Scheme>     # AGENTS.md gate — compile check
+```
+
+e.g. `make lint scheme=GiniBankSDK` for BankSDK, `make lint scheme=GiniCaptureSDK`
+for CaptureSDK. Then run the unit tests of the touched module
+(`xcodebuild ... test` or `bundle exec fastlane run_unit_tests`). If the
+regression test is a UI test, run the example app's UI-test scheme on iPhone
+16 / iOS 26.2. Re-check the original reproduction from step 2 no longer
+occurs.
+
+## Commit conventions
+
+Format (`CLAUDE.md` → Commit Message Format):
+
+```
+fix(<project>): <subject>
+
+<body: what was broken, the root cause, what the fix does>
+
+<ticket-id>
+```
+
+`project` is the module name (e.g. `GiniBankSDK`); omit the parentheses for
+multi-module fixes. Subject in imperative mood, no period. Ticket ID
+($ARGUMENTS) is required on the last line. Never push release tags —
+`<PackageName>;<version>` tags trigger release workflows.

--- a/.claude/skills/gini-fix/platform.md
+++ b/.claude/skills/gini-fix/platform.md
@@ -83,17 +83,8 @@ occurs.
 
 ## Commit conventions
 
-Format (`CLAUDE.md` → Commit Message Format):
-
-```
-fix(<project>): <subject>
-
-<body: what was broken, the root cause, what the fix does>
-
-<ticket-id>
-```
-
-`project` is the module name (e.g. `GiniBankSDK`); omit the parentheses for
-multi-module fixes. Subject in imperative mood, no period. Ticket ID
-($ARGUMENTS) is required on the last line. Never push release tags —
-`<PackageName>;<version>` tags trigger release workflows.
+Follow the template at `.git-stuff/commit-msg-template.txt` with `type` = `fix`.
+`project` is the module name (e.g. `GiniBankSDK`), omit the parentheses for
+multi-module fixes; the body says what was broken, the root cause, and what
+the fix does; the ticket id ($ARGUMENTS) goes in the footer. Never push
+release tags — `<PackageName>;<version>` tags trigger release workflows.


### PR DESCRIPTION
## Pull Request Description

<!-- Briefly explain **what** this PR does and **why**. Mention the motivation, feature, or issue it's addressing. -->

Adds the shared `gini-fix` Claude skill, mirroring [gini/gini-mobile-android#959](https://github.com/gini/gini-mobile-android/pull/959). Follows the same split introduced by #1222: a platform-neutral `SKILL.md` byte-identical to the Android copy, plus an iOS-specific `platform.md`.

`gini-fix` diagnoses a bug ticket root-cause-first, writes the diagnosis to `specs/<ticket>-bug.md`, and — only after user confirmation — implements the minimal fix with a regression test that fails before and passes after. It never fixes symptoms whose cause hasn't been found.

<!-- Closes ticket number PP-####; Replace with JIRA ticket if relevant -->
No Jira ticket — internal tooling change.

<!--

Some description of HOW you achieved it. Perhaps give a high level description of the chnages you did. Did you need to refactor something? What tradeoffs did you take?

-->

**How it was implemented:**

- `.claude/skills/gini-fix/SKILL.md` — general workflow. Byte-identical to the Android copy on branch `sdd-workflow-setup` at time of push (verified via `diff`).
- `.claude/skills/gini-fix/platform.md` — iOS conventions grounded in `CLAUDE.md` + `AGENTS.md`:
  - **Reproduction ladder:** unit test first → UI test in the example app → running the example app on iPhone 16 / iOS 26.2 (`GiniBankSDKExample`, `GiniHealthSDKExample`, `GiniCaptureSDKExample`); notes on `Credentials.plist` / `CredentialsManager.swift` for real API access.
  - **Root-cause tools:** narrow-test `xcodebuild ... -only-testing:...` recipe, `git log --follow -p` / `git blame`, release-tag format `<PackageName>;<version>` for pinpointing when a change landed, inter-module effects via the dependency graph in `CLAUDE.md`.
  - **Regression tests:** Swift Testing for new files, XCTest when extending a legacy suite; manual protocol-conformance mocks; JSON fixtures in `Tests/<SDK>Tests/Resources/`; `TEST_CLIENT_ID`/`SECRET` for integration tests.
  - **Verification:** `make lint scheme=<Scheme>` plus the touched module's unit tests; UI regression tests run on iPhone 16 / iOS 26.2.
  - **Commits:** `fix(<Project>): <subject>` with ticket footer per `CLAUDE.md`; never push release tags.

Not touched in this PR (per user's "focus on skills"): `.github/mirrored-skills.txt` and the two `shared-skills.*.yml` workflows already on `main`. Follow-up if desired: append `.claude/skills/gini-fix/SKILL.md` to `mirrored-skills.txt` to activate the sync check for this file.

## Notes for Reviewers

<!--

Explain how you verified the changes.
A clear testing scenario helps colleagues who may not be familiar with this part of the code quickly understand and verify the changes. Include steps they can follow to see the impact in action.

You can include: 
- Simulators/Devices you used (e.g. iPhone 13, iPad Pro) 
- iOS versions tested (e.g. 16.0, 17.5) 
- Manual checks (e.g. flow tested: onboarding, permissions, error states) 
- Unit tests added or updated 
 
 Include screenshots, screen recordings, or simulator gifs for UI changes. 
 
 - Optional: Anything that needs extra attention in review? Are there TODOs, known limitations, or follow-up work? 
 
 -->

No product code changes — only `.claude/skills/gini-fix/**`. No simulator or unit-test run needed.

Verification performed:

- **Byte-identical check** — `diff` between the local `SKILL.md` and the Android copy on `sdd-workflow-setup` returns 0. Once `mirrored-skills.txt` is extended, `shared-skills.check.yml` will start enforcing this on every PR.

Things to look at:

- `.claude/skills/gini-fix/platform.md` — the iOS-specific rules. Please sanity-check:
  - the reproduction ladder (does the team really reach for a unit test first?);
  - the example-app credentials note (still `Credentials.plist` + `CredentialsManager.swift`?);
  - the narrow-test `xcodebuild` recipe and the `<Scheme>ExampleTests/<TestClassOrSuiteName>` syntax;
  - the regression-test framework guidance (Swift Testing preferred / XCTest legacy).
- Decide whether we want to also update `.github/mirrored-skills.txt` in a follow-up so the sync workflow starts enforcing byte-identity for `gini-fix/SKILL.md`.