### PR TITLE
chore: Ground gini-spec-feature platform.md in real repo state

### DIFF
--- a/.claude/skills/gini-spec-feature/platform.md
+++ b/.claude/skills/gini-spec-feature/platform.md
@@ -47,15 +47,19 @@ actually exists in the touched module:
   ViewModel MUST NOT import UIKit.
 - ViewController: layout + event forwarding only, no business logic.
 
-UIKit is the only UI framework used inside SDK targets. Do not introduce
-SwiftUI in SDK sources; example apps and utility surfaces are the only place
-SwiftUI appears. No Objective-C; Xamarin support has been removed and code
-marked "Xamarin only" is dead — don't treat it as a live ABI constraint.
+UIKit remains the pattern in GiniBankSDK, GiniCaptureSDK screens, and
+GiniHealthSDK view controllers. SwiftUI is the norm in
+**GiniInternalPaymentSDK** (payment review, keyboard accessory, carousels)
+and in the shared `GiniUtilites/SwiftUI/` helpers (font, color, layout,
+height preference keys). Match neighboring code in the touched module —
+don't rewrite a UIKit screen in SwiftUI opportunistically, and don't add a
+UIKit view controller inside a SwiftUI feature.
 
-Liquid Glass is being rolled out in a sequenced pair of release branches
-(`release/liquid_glass_health_sdk` first, `release/liquid_glass_bank_sdk`
-after). When the spec touches UI on either branch, call out Liquid Glass
-adoption impact explicitly (previews, glass effects, materials).
+Liquid Glass adoption is planned per SDK. Check `git branch -r | grep liquid`
+before assuming a release branch exists — the workflow is sequenced (Health
+SDK first, Bank SDK after) but neither branch is guaranteed to be live at any
+given time. When the spec targets an active `release/liquid_glass_*` branch,
+call out adoption impact explicitly (previews, glass effects, materials).
 
 ## Language rules
 
@@ -72,19 +76,28 @@ adoption impact explicitly (previews, glass effects, materials).
 
 ## UI rules
 
-- New UI: UIKit — `UIViewController` / `UIView` with AutoLayout. State
-  whether XIBs/storyboards are added or removed (prefer programmatic UI to
-  match the majority of the codebase).
-- Colors: `UIColor.GiniBank.*` / `UIColor.GiniCapture.*` namespaces. Dark
-  mode is required via `GiniColor(lightModeColor:darkModeColor:).uiColor()`
-  — never a raw hex or asset without a dark counterpart.
+- New UI framework: **UIKit** in GiniBankSDK, GiniCaptureSDK, and
+  GiniHealthSDK view controllers (`UIViewController` / `UIView` with
+  AutoLayout — prefer programmatic UI). **SwiftUI** in GiniInternalPaymentSDK
+  and `GiniUtilites/SwiftUI/` helpers. Match the touched module; call out in
+  the spec which framework new views use and why.
+- Colors: prefer **`GiniColorScheme`**
+  (`GiniUtilites/Color/GiniColorScheme.swift`, with module extensions like
+  `GiniBankColorScheme`) for new code — it's the current standard and
+  already the majority pattern outside CaptureSDK. The legacy
+  `UIColor.GiniBank.*` / `UIColor.GiniCapture.*` namespaces remain in place
+  and are still the norm inside CaptureSDK; match neighboring code when
+  extending existing files. Dark mode: `GiniColor(light:dark:).uiColor()`
+  is the underlying primitive that `GiniColorScheme` already wraps. Never
+  use a raw hex or asset without a dark counterpart.
 - Fonts: Dynamic Type via `textStyleFonts[textStyle]` from the design
   system.
 - Spacing: local `private enum Constants` inside the view/view controller —
   no magic numbers.
-- Liquid Glass: when the spec targets a `release/liquid_glass_*` branch,
-  list which glass effects / materials the new UI adopts and any fallbacks
-  for older OS versions.
+- Liquid Glass: check `git branch -r | grep liquid` before referencing a
+  release branch — when a `release/liquid_glass_*` branch is active and the
+  spec targets it, list which glass effects / materials the new UI adopts
+  and any fallbacks for older OS versions.
 
 ## Wiring
 
@@ -103,16 +116,31 @@ adoption impact explicitly (previews, glass effects, materials).
 
 ## Test stack
 
-- New tests use Swift Testing (`@Suite`, `@Test`, `#expect`) per the MyApp
-  Standards → Testing rule in `CLAUDE.md`. XCTest remains in legacy files
-  (GiniHealthSDK tests are still largely XCTest) — match the neighboring
-  file when extending an existing test suite; only new files are Swift
-  Testing by default.
+- Unit tests: `Tests/<SDK>Tests/` (e.g.
+  `BankSDK/GiniBankSDK/Tests/GiniBankSDKTests/`),
+  `<ClassUnderTest>Tests.swift`. Swift Testing (`@Suite`, `@Test`, `#expect`)
+  is fully adopted in GiniInternalPaymentSDK and used for most new suites in
+  GiniBankAPILibrary and GiniCaptureSDK; GiniBankSDK, GiniHealthSDK, and
+  GiniHealthAPILibrary tests remain mostly XCTest. Match the neighboring
+  test file when extending; for new files, follow the module's dominant
+  framework.
+- UI tests: `<SDK>Example/<SDK>ExampleUITests/` (e.g.
+  `GiniBankSDKExampleUITests`). Existing UI suites use a Page Object
+  pattern — screen selectors live under `Screens/` (`MainScreen.swift`,
+  `OnboardingScreen.swift`, …). Extend an existing screen object rather
+  than adding raw selectors. `GiniBankSDKExampleSwiftUIUITests/` covers the
+  SwiftUI example variant. No snapshot-testing library is in use.
 - Mocks: manual protocol conformances. No third-party mocking framework.
-- Fixtures: JSON files in `Tests/Resources/`, referenced via `.process`/
-  `.copy` in the package's test target.
+- Fixtures: `Tests/<SDK>Tests/Resources/`, referenced via `.process`/`.copy`
+  in the package's test target. Not only JSON — CaptureSDK ships `.pdf`
+  (rotated variants, multi-page), `.jpg`, and `.txt` extraction fixtures;
+  API libraries ship `.pdf` and `.png` payloads. Reuse an existing fixture
+  when possible.
 - Integration tests hitting the real API need `TEST_CLIENT_ID` and
-  `TEST_CLIENT_SECRET` environment variables (see `CLAUDE.md`).
+  `TEST_CLIENT_SECRET` environment variables (see `CLAUDE.md`). Example
+  apps have their own integration/unit split under
+  `BankSDK/GiniBankSDKExample/Tests/{IntegrationTests, UnitTests}/`
+  (SSL-pinning tests live under `IntegrationTests/SSLPinningTests/`).
 - Every new ViewModel and Service gets a unit test. Coverage is currently
   weakest on ViewControllers and Coordinators — the spec should not use
   that weakness as an excuse to omit tests for new coordinators.
@@ -125,11 +153,14 @@ modules actually touched:
 1. Language and access control: Swift, `internal` by default; `public` /
    `open` only where the public API impact section justifies it; doc-comment
    style (`/** */` for declarations, `///` inline) per `AGENTS.md`.
-2. UI: UIKit (`UIViewController` / `UIView`) in `UIColor.GiniBank.*` /
-   `UIColor.GiniCapture.*` with `GiniColor(light:dark:)` for dark mode,
-   Dynamic Type via `textStyleFonts[textStyle]`, spacing in a local
-   `enum Constants`; Liquid Glass adoption if on a `release/liquid_glass_*`
-   branch.
+2. UI: name the framework (UIKit `UIViewController`/`UIView` for
+   GiniBankSDK/GiniCaptureSDK/GiniHealthSDK; SwiftUI for
+   GiniInternalPaymentSDK and `GiniUtilites/SwiftUI/`); colors via
+   `GiniColorScheme` for new code (legacy `UIColor.GiniBank.*` /
+   `UIColor.GiniCapture.*` still norm inside CaptureSDK) with
+   `GiniColor(light:dark:)` under the hood for dark mode; Dynamic Type via
+   `textStyleFonts[textStyle]`; spacing in a local `enum Constants`; Liquid
+   Glass adoption when a `release/liquid_glass_*` branch is active.
 3. Architecture: MVVM + Coordinator; name the `<Feature>Coordinator`,
    `<Feature>ViewModel`, `<Feature>ViewModelDelegate`, and
    `<Feature>ViewController` types; entry point is a single static factory
@@ -142,6 +173,12 @@ modules actually touched:
    `<sdk>.<feature>.<screen>.<element>`, list the `Sources/<SDK>/Resources/`
    locale `.strings` files that gain entries.
 6. Quality gates: `make lint scheme=<Scheme>` clean per `AGENTS.md`
-   (`GiniBankSDK` / `GiniCaptureSDK` at minimum for touched SDKs); Swift
-   Testing coverage expectations for every new class; multi-parameter
-   formatting rule from `CLAUDE.md`.
+   (`GiniBankSDK` / `GiniCaptureSDK` at minimum for touched SDKs). Note
+   the local-vs-CI destination drift: `make lint` runs on `iPhone 15 Pro /
+   iOS 17.2` (see `Makefile`) while CI (`.github/workflows/shared-config.yml`)
+   uses `iPhone 17 / iOS 26.2` — re-run failing checks in CI parity before
+   pushing. Test-framework coverage expectation per the module's dominant
+   framework (Swift Testing for GiniInternalPaymentSDK / new suites in
+   GiniBankAPILibrary and GiniCaptureSDK; XCTest for GiniBankSDK,
+   GiniHealthSDK, GiniHealthAPILibrary). Multi-parameter formatting rule
+   from `CLAUDE.md`.

--- a/.claude/skills/gini-spec-feature/platform.md
+++ b/.claude/skills/gini-spec-feature/platform.md
@@ -47,19 +47,21 @@ actually exists in the touched module:
   ViewModel MUST NOT import UIKit.
 - ViewController: layout + event forwarding only, no business logic.
 
-UIKit remains the pattern in GiniBankSDK, GiniCaptureSDK screens, and
-GiniHealthSDK view controllers. SwiftUI is the norm in
-**GiniInternalPaymentSDK** (payment review, keyboard accessory, carousels)
-and in the shared `GiniUtilites/SwiftUI/` helpers (font, color, layout,
-height preference keys). Match neighboring code in the touched module —
-don't rewrite a UIKit screen in SwiftUI opportunistically, and don't add a
-UIKit view controller inside a SwiftUI feature.
+SwiftUI is the default framework for new standalone views and feature
+entry points. SwiftUI is already the norm in **GiniInternalPaymentSDK**
+(payment review, keyboard accessory, carousels) and in the shared
+`GiniUtilites/SwiftUI/` helpers (font, color, layout, height preference
+keys). UIKit remains the existing pattern in GiniBankSDK, GiniCaptureSDK
+screens, and GiniHealthSDK view controllers — match neighboring code when
+extending an existing UIKit screen there. A new coordinator or feature
+entry point is SwiftUI unless there's a specific reason (e.g. a UIKit-only
+API dependency); integrator-facing SDK entry points still return a
+`UIViewController` per `CLAUDE.md`, wrapping the SwiftUI root in a
+`UIHostingController` when the feature is SwiftUI-native.
 
-Liquid Glass adoption is planned per SDK. Check `git branch -r | grep liquid`
-before assuming a release branch exists — the workflow is sequenced (Health
-SDK first, Bank SDK after) but neither branch is guaranteed to be live at any
-given time. When the spec targets an active `release/liquid_glass_*` branch,
-call out adoption impact explicitly (previews, glass effects, materials).
+Liquid Glass adoption is planned per SDK. When the spec targets a UI
+change that adopts Liquid Glass, call out impact explicitly (previews,
+glass effects, materials, older-OS fallbacks).
 
 ## Language rules
 
@@ -76,11 +78,13 @@ call out adoption impact explicitly (previews, glass effects, materials).
 
 ## UI rules
 
-- New UI framework: **UIKit** in GiniBankSDK, GiniCaptureSDK, and
-  GiniHealthSDK view controllers (`UIViewController` / `UIView` with
-  AutoLayout — prefer programmatic UI). **SwiftUI** in GiniInternalPaymentSDK
-  and `GiniUtilites/SwiftUI/` helpers. Match the touched module; call out in
-  the spec which framework new views use and why.
+- New UI framework: **SwiftUI** by default for new standalone views and
+  feature entry points. Match the touched module — extending an existing
+  UIKit screen inside GiniBankSDK, GiniCaptureSDK, or GiniHealthSDK stays
+  UIKit (`UIViewController` / `UIView` with AutoLayout — prefer
+  programmatic UI). SwiftUI is already the norm in GiniInternalPaymentSDK
+  and `GiniUtilites/SwiftUI/`. Call out in the spec which framework new
+  views use and why.
 - Colors: prefer **`GiniColorScheme`**
   (`GiniUtilites/Color/GiniColorScheme.swift`, with module extensions like
   `GiniBankColorScheme`) for new code — it's the current standard and
@@ -94,10 +98,9 @@ call out adoption impact explicitly (previews, glass effects, materials).
   system.
 - Spacing: local `private enum Constants` inside the view/view controller —
   no magic numbers.
-- Liquid Glass: check `git branch -r | grep liquid` before referencing a
-  release branch — when a `release/liquid_glass_*` branch is active and the
-  spec targets it, list which glass effects / materials the new UI adopts
-  and any fallbacks for older OS versions.
+- Liquid Glass: when the spec targets a UI change that adopts Liquid
+  Glass, list which glass effects / materials the new UI adopts and any
+  fallbacks for older OS versions.
 
 ## Wiring
 
@@ -153,14 +156,15 @@ modules actually touched:
 1. Language and access control: Swift, `internal` by default; `public` /
    `open` only where the public API impact section justifies it; doc-comment
    style (`/** */` for declarations, `///` inline) per `AGENTS.md`.
-2. UI: name the framework (UIKit `UIViewController`/`UIView` for
-   GiniBankSDK/GiniCaptureSDK/GiniHealthSDK; SwiftUI for
-   GiniInternalPaymentSDK and `GiniUtilites/SwiftUI/`); colors via
-   `GiniColorScheme` for new code (legacy `UIColor.GiniBank.*` /
-   `UIColor.GiniCapture.*` still norm inside CaptureSDK) with
-   `GiniColor(light:dark:)` under the hood for dark mode; Dynamic Type via
-   `textStyleFonts[textStyle]`; spacing in a local `enum Constants`; Liquid
-   Glass adoption when a `release/liquid_glass_*` branch is active.
+2. UI: name the framework (SwiftUI by default for new views; UIKit
+   `UIViewController`/`UIView` when extending existing UIKit screens in
+   GiniBankSDK/GiniCaptureSDK/GiniHealthSDK); colors via `GiniColorScheme`
+   for new code (legacy `UIColor.GiniBank.*` / `UIColor.GiniCapture.*`
+   still norm inside CaptureSDK) with `GiniColor(light:dark:)` under the
+   hood for dark mode; Dynamic Type via `textStyleFonts[textStyle]`;
+   spacing in a local `enum Constants`; Liquid Glass adoption impact
+   (glass effects, materials, older-OS fallbacks) when the spec targets
+   it.
 3. Architecture: MVVM + Coordinator; name the `<Feature>Coordinator`,
    `<Feature>ViewModel`, `<Feature>ViewModelDelegate`, and
    `<Feature>ViewController` types; entry point is a single static factory


### PR DESCRIPTION
## Pull Request Description

<!-- Briefly explain **what** this PR does and **why**. Mention the motivation, feature, or issue it's addressing. -->

Follow-up to #1223 and #1224 — brings the merged `gini-spec-feature/platform.md` in line with the same audit-based corrections applied there. Same class of drift (UI framework, colors, test stack, Liquid Glass, Objective-C/Xamarin, CI destination).

<!-- Closes ticket number PP-####; Replace with JIRA ticket if relevant -->
No Jira ticket — internal tooling change.

<!--

Some description of HOW you achieved it. Perhaps give a high level description of the chnages you did. Did you need to refactor something? What tradeoffs did you take?

-->

**How it was implemented:**

Verified each edit against `origin/main` at time of writing. Ratios cited come from `grep -rl` counts across `Sources/` and `Tests/`.

- **Architecture / UI framework** (was: "UIKit is the only UI framework used inside SDK targets. Do not introduce SwiftUI in SDK sources"). SwiftUI is actually widespread:

  | Module | SwiftUI source files |
  |---|---|
  | GiniInternalPaymentSDK | 15 (payment review is SwiftUI-first) |
  | CaptureSDK | 5 |
  | GiniUtilites | 5 (shared SwiftUI helpers) |
  | GiniHealthSDK | 1 |
  | GiniBankSDK | 0 |

  Reframed as UIKit-in-Bank/Capture/Health-screens, SwiftUI-in-InternalPayment/Utilities.

- **Drop "No Objective-C. Xamarin removed"** — 35 `@objc` annotations exist for framework interop, and no Xamarin code remains on main, so the warning is misleading and stale.

- **Liquid Glass release branches** — neither `release/liquid_glass_health_sdk` nor `release/liquid_glass_bank_sdk` exists on origin at this writing. Replaced the aspirational branch names with a `git branch -r | grep liquid` check-first caveat.

- **Colors** — prefer the newer `GiniColorScheme` (`GiniUtilites/Color/GiniColorScheme.swift`, with module extensions like `GiniBankColorScheme`) for new code. Grep counts: `GiniColorScheme` = 43, `UIColor.GiniCapture.*` = 58 (still dominant inside CaptureSDK), `UIColor.GiniBank.*` = 7. Guidance: prefer the new API; match neighboring code inside CaptureSDK.

- **Test stack** — Swift Testing adoption is very lumpy. `@Suite` files vs `XCTestCase` files per module:

  | Module | @Suite | XCTestCase |
  |---|---|---|
  | GiniInternalPaymentSDK | **31** | 1 |
  | BankAPILibrary | 7 | 14 |
  | CaptureSDK | 4 | 18 |
  | GiniBankSDK | 1 | 10 |
  | GiniUtilites | 1 | 2 |
  | HealthAPILibrary | 0 | 17 |
  | GiniHealthSDK | 0 | 3 |

  Also added: UI-test Page Object pattern under `<SDK>Example/<SDK>ExampleUITests/Screens/`, SwiftUI-UI example variant (`GiniBankSDKExampleSwiftUIUITests`), non-JSON fixtures (`.pdf` rotated variants, `.jpg`, `.png`, `.txt` extraction fixtures), example-app integration/unit split under `Tests/{IntegrationTests, UnitTests}/`, and the absence of a snapshot-testing library.

- **Conventions checklist item 6** — documented the local-vs-CI destination drift: `make lint` runs on `iPhone 15 Pro / iOS 17.2` (see `Makefile`), CI uses `iPhone 17 / iOS 26.2` (see `.github/workflows/shared-config.yml`). Aligned the test-framework coverage expectation with the per-module reality.

## Notes for Reviewers

<!--

Explain how you verified the changes.
A clear testing scenario helps colleagues who may not be familiar with this part of the code quickly understand and verify the changes. Include steps they can follow to see the impact in action.

You can include: 
- Simulators/Devices you used (e.g. iPhone 13, iPad Pro) 
- Unit tests added or updated 
 
 -->

No product code changes — only `.claude/skills/gini-spec-feature/platform.md`. No simulator or unit-test run needed.

Verification performed:

- Each ratio cited (SwiftUI files per module, `@Suite` vs `XCTestCase` counts, `GiniColorScheme` reference count) was measured on the branch cut from `origin/main` at PR-open time via `grep -rl … | wc -l`.
- Liquid Glass release-branch check: `git branch -r | grep -i liquid` on origin returned nothing.
- Objective-C check: `find . -name "*.m"` returned only BrowserStack third-party framework headers, not our code. `grep '@objc' --include="*.swift"` returned 35 hits — the "No Objective-C" line was misleading.

Things to look at:

- Section-by-section rewrites in `## Architecture patterns in use`, `## UI rules`, `## Test stack`, and Conventions checklist items 2 and 6. Please sanity-check the per-module framework and testing splits against your intuition of the codebase.
- The Liquid Glass caveat — reasonable to keep the branch names as "planned" pointers, or should they be dropped entirely?

Sibling PRs applying the same-class edits:
- #1223 — `gini-build/platform.md` (merged / open, review edits applied)
- #1224 — `gini-fix/platform.md` (open, review edits applied)