### PR TITLE
ci: Introduce ai commit type and centralize type list in the template

### DIFF
--- a/.claude/skills/gini-build/platform.md
+++ b/.claude/skills/gini-build/platform.md
@@ -129,8 +129,9 @@ violated:
 
 ## Commit conventions
 
-Follow the template at `.git-stuff/commit-msg-template.txt`. `type` is one of
-`feat` | `fix` | `refactor` | `ci`; `project` is the module name
+The template at `.git-stuff/commit-msg-template.txt` (repo root) is the source
+of truth for the allowed `type` values and what each covers — read it rather
+than relying on a list duplicated here. `project` is the module name
 (e.g. `GiniBankSDK`), omit the parentheses for multi-module changes; the
 ticket id ($ARGUMENTS) goes in the footer. Never push release tags —
 `<PackageName>;<version>` tags trigger release workflows.

--- a/.git-stuff/commit-msg-template.txt
+++ b/.git-stuff/commit-msg-template.txt
@@ -14,9 +14,12 @@
 #     that do code cleanup (comments, restructuring, method name changes, etc.)
 #     or when refactoring tests.
 #   * ci: changes to build scripts or any other automation scripts or
-#     configs (e.g., jazzy config, sphinx config). Also for git related 
+#     configs (e.g., jazzy config, sphinx config). Also for git related
 #     changes (e.g., .gitignore or commit template)
-# * <project>: project that the commit makes changes to. If it makes 
+#   * ai: changes to AI tooling and assets — Claude Code (or other AI
+#     assistant) skills, agents, commands, and their markdown/config,
+#     e.g. files under .claude/ or .github/instructions/.
+# * <project>: project that the commit makes changes to. If it makes
 #   changes to many sections, or if no section in particular is 
 #   modified, leave blank without the parentheses. 
 #   Examples:
@@ -24,6 +27,8 @@
 #     feat(GiniBankSDK): Add error logging interface
 #   * Commit that changes the build script:
 #     ci: Send slack message with build result
+#   * Commit that changes AI agents/skills:
+#     ai: Add Claude Code agent skills for the iOS SDKs
 # * <subject>: short description in imperative mood summarising 
 #   the changes. For example: Add photo selection button.
 #   You can find more subject related advice here:

--- a/.github/instructions/commit-message-guideline.instructions.md
+++ b/.github/instructions/commit-message-guideline.instructions.md
@@ -16,15 +16,7 @@ Commit Message Format
 
 Type
 
-<type> must be one of the following:
-
-feat: New or modified features (including UI, public API changes, tests and documentation of the new feature)
-
-fix: Bug fixes
-
-refactor: Code changes without public breaking changes (no public API or UI modifications) or Maintenance changes (dependency updates, lint fixes, warnings, etc.)
-
-ci: CI/CD, build scripts, or automation config changes
+The commit template at `.git-stuff/commit-msg-template.txt` is the single source of truth for the allowed `<type>` values and what each covers. Read it there rather than relying on a list duplicated in this document.
 
 Project
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,7 +87,7 @@ Follow Conventional Commits with this structure:
 <ticket-id>
 ```
 
-- **Types:** `feat`, `fix`, `refactor`, `ci`
+- **Types:** see `.git-stuff/commit-msg-template.txt` — it is the source of truth for the allowed `type` values and what each covers; don't rely on a list duplicated here.
 - **Project:** Module name (e.g., `GiniBankSDK`). Omit parentheses for multi-module changes.
 - **Subject:** Imperative mood, no period
 - **Ticket ID:** Required on last line (e.g., `PP-4102`)


### PR DESCRIPTION
## What

Introduces a new commit `type` — **`ai`** — for changes to AI tooling and assets (Claude Code skills, agents, commands, and their markdown/config under `.claude/` or `.github/instructions/`), and makes the commit template the single source of truth for the type list.

- **`.git-stuff/commit-msg-template.txt`** — adds the `ai` type description and an example.
- **`CLAUDE.md`** — the "Commit Message Format" section now points to `.git-stuff/commit-msg-template.txt` for the type list instead of duplicating it.
- **`.claude/skills/gini-build/platform.md`** — defers to the template for `type` values.
- **`.github/instructions/commit-message-guideline.instructions.md`** — the `Type` section now references the template as the single source of truth instead of enumerating types inline.

## Why

The `type` list was duplicated in four places and could drift out of sync. Centralizing it in the template avoids future divergence, and the new `ai` type gives AI-tooling changes their own prefix alongside `ci`. Mirrors the equivalent change in the Android repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
