### PR TITLE
ai: Add push & PR workflow rules to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,21 @@ make lint scheme=GiniCaptureSDK # For CaptureSDK changes
 
 ---
 
+## Push & Pull Request Workflow
+
+Whenever the user asks to push and open a pull request, always do all of the following — without being asked each time:
+
+1. **PR description from the template.** Generate the PR body using the repository PR template (`.github/pull_request_template.md`), following the *Pull Request Description Generation* rules below. Never open a PR with an empty or free-form body.
+2. **Human reviewers — ask, never guess.** Always ask the user which reviewers to add before or right after opening the PR. Do not infer reviewers from git history or previous PRs.
+3. **Copilot — add automatically.** Always request a GitHub Copilot code review, without asking. `gh pr create/edit --reviewer` cannot resolve the Copilot bot; use the REST API instead:
+
+   ```bash
+   gh api -X POST repos/<owner>/<repo>/pulls/<number>/requested_reviewers \
+     -f 'reviewers[]=copilot-pull-request-reviewer[bot]'
+   ```
+
+---
+
 ## Pull Request Description Generation
 
 When generating a pull request description:


### PR DESCRIPTION
## Pull Request Description

Adds a **Push & Pull Request Workflow** section to `AGENTS.md` so AI agents follow a consistent process whenever asked to push and open a pull request:

- Always generate the PR body from the repository template (`.github/pull_request_template.md`), never free-form or empty.
- Always ask the user which human reviewers to add — never infer them from git history or previous PRs.
- Always request a GitHub Copilot code review automatically, using the REST API (`gh api ... requested_reviewers`), since `gh pr create/edit --reviewer` cannot resolve the Copilot bot.

N/A <!-- No Jira ticket; repository/agent-convention documentation change -->

Documentation-only change — no source modules affected (repo-root `AGENTS.md`).

## Notes for Reviewers

- Documentation-only: 15 lines added to `AGENTS.md`, no code changes, so no tests apply.
- Verify the new section is consistent with the existing *Pull Request Description Generation* rules directly below it.
- The `gh api` command for requesting Copilot review was taken from the working invocation used in this repo's workflow; no other verification steps needed.
