### PR TITLE
fix(GiniCaptureSDK): Preserve camera frame color across rotation

### DIFF
--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Camera/CameraPreviewViewController.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Camera/CameraPreviewViewController.swift
@@ -50,6 +50,10 @@ final class CameraPreviewViewController: UIViewController {
     }()
 
     private let cameraFocusImage = UIImageNamedPreferred(named: "cameraFocus")
+    /// Color currently applied to the camera frame, reapplied after the frame
+    /// image is rebuilt on rotation so feedback states (e.g. invalid QR red)
+    /// survive orientation changes.
+    private var currentFrameColor: UIColor?
     lazy var cameraFrameView: UIImageView = {
         let imageView = UIImageView()
         imageView.image = cameraFocusImage
@@ -263,12 +267,19 @@ final class CameraPreviewViewController: UIViewController {
                 cameraFrameViewHeightAnchorPortrait,
                 cameraFrameViewHeightAnchorLandscape
             ])
+            let orientedImage = UIImage(cgImage: image,
+                                        scale: 1.0,
+                                        orientation: isLandscape ? .left : .up)
             if isLandscape {
                 cameraFrameViewHeightAnchorLandscape.isActive = true
-                cameraFrameView.image = UIImage(cgImage: image, scale: 1.0, orientation: .left)
             } else {
                 cameraFrameViewHeightAnchorPortrait.isActive = true
-                cameraFrameView.image = UIImage(cgImage: image, scale: 1.0, orientation: .up)
+            }
+            /// Rebuilding from the raw asset discards any applied tint — restore it.
+            if let currentFrameColor {
+                cameraFrameView.image = orientedImage.tintedImageWithColor(currentFrameColor)
+            } else {
+                cameraFrameView.image = orientedImage
             }
 
             if UIDevice.current.isIphone {
@@ -374,6 +385,7 @@ final class CameraPreviewViewController: UIViewController {
     }
 
     func changeCameraFrameColor(to color: UIColor) {
+        currentFrameColor = color
         cameraFrameView.image = cameraFrameView.image?.tintedImageWithColor(color)
     }
 

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Camera/CameraPreviewViewController.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Camera/CameraPreviewViewController.swift
@@ -275,12 +275,8 @@ final class CameraPreviewViewController: UIViewController {
             } else {
                 cameraFrameViewHeightAnchorPortrait.isActive = true
             }
-            /// Rebuilding from the raw asset discards any applied tint — restore it.
-            if let currentFrameColor {
-                cameraFrameView.image = orientedImage.tintedImageWithColor(currentFrameColor)
-            } else {
-                cameraFrameView.image = orientedImage
-            }
+            // Rebuilding from the raw asset discards any applied tint — restore it.
+            cameraFrameView.image = tintedForCurrentColor(orientedImage)
 
             if UIDevice.current.isIphone {
                 cameraFrameViewBottomConstrant.constant = isLandscape
@@ -386,7 +382,14 @@ final class CameraPreviewViewController: UIViewController {
 
     func changeCameraFrameColor(to color: UIColor) {
         currentFrameColor = color
-        cameraFrameView.image = cameraFrameView.image?.tintedImageWithColor(color)
+        if let image = cameraFrameView.image {
+            cameraFrameView.image = tintedForCurrentColor(image)
+        }
+    }
+
+    private func tintedForCurrentColor(_ image: UIImage) -> UIImage? {
+        guard let currentFrameColor else { return image }
+        return image.tintedImageWithColor(currentFrameColor)
     }
 
     // MARK: - IBAN detection

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Camera/CameraPreviewViewController.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Camera/CameraPreviewViewController.swift
@@ -50,9 +50,10 @@ final class CameraPreviewViewController: UIViewController {
     }()
 
     private let cameraFocusImage = UIImageNamedPreferred(named: "cameraFocus")
-    /// Color currently applied to the camera frame, reapplied after the frame
-    /// image is rebuilt on rotation so feedback states (e.g. invalid QR red)
-    /// survive orientation changes.
+    /**
+     Color currently applied to the camera frame.
+     Reapplied after the frame image is rebuilt on rotation so feedback states (for example invalid-QR red) survive orientation changes.
+     */
     private var currentFrameColor: UIColor?
     lazy var cameraFrameView: UIImageView = {
         let imageView = UIImageView()

--- a/CaptureSDK/GiniCaptureSDK/Tests/GiniCaptureSDKTests/CameraPreviewViewControllerTests.swift
+++ b/CaptureSDK/GiniCaptureSDK/Tests/GiniCaptureSDKTests/CameraPreviewViewControllerTests.swift
@@ -103,7 +103,9 @@ final class CameraPreviewViewControllerTests: XCTestCase {
                       "frame image should stay red after an orientation update")
     }
 
-    /// Scans the image for at least one mostly-opaque pixel whose color matches `color`.
+    /**
+     Scans the image for at least one mostly-opaque pixel whose color matches `color`.
+     */
     private func hasPixel(matching color: UIColor, in image: UIImage?) -> Bool {
         guard let cgImage = image?.cgImage else { return false }
         let width = cgImage.width

--- a/CaptureSDK/GiniCaptureSDK/Tests/GiniCaptureSDKTests/CameraPreviewViewControllerTests.swift
+++ b/CaptureSDK/GiniCaptureSDK/Tests/GiniCaptureSDKTests/CameraPreviewViewControllerTests.swift
@@ -85,6 +85,62 @@ final class CameraPreviewViewControllerTests: XCTestCase {
         XCTAssertNotEqual(defaultFlashState, camera.isFlashOn, "camera flash state should change it after toggle it")
     }
 
+    // MARK: - Camera frame color across rotation (PP-3305)
+
+    func testCameraFrameKeepsColorAfterOrientationUpdate() {
+        _ = cameraPreviewViewController.view
+        XCTAssertNotNil(UIImageNamedPreferred(named: "cameraFocus"),
+                        "cameraFocus asset must be available for this test to be meaningful")
+
+        cameraPreviewViewController.changeCameraFrameColor(to: .red)
+        XCTAssertTrue(hasPixel(matching: .red, in: cameraPreviewViewController.cameraFrameView.image),
+                      "frame image should be tinted red after changeCameraFrameColor")
+
+        // What viewWillTransition triggers on device rotation — it rebuilds the frame image.
+        cameraPreviewViewController.updatePreviewViewOrientation()
+
+        XCTAssertTrue(hasPixel(matching: .red, in: cameraPreviewViewController.cameraFrameView.image),
+                      "frame image should stay red after an orientation update")
+    }
+
+    /// Scans the image for at least one mostly-opaque pixel whose color matches `color`.
+    private func hasPixel(matching color: UIColor, in image: UIImage?) -> Bool {
+        guard let cgImage = image?.cgImage else { return false }
+        let width = cgImage.width
+        let height = cgImage.height
+        var data = [UInt8](repeating: 0, count: width * height * 4)
+        let colorSpace = CGColorSpaceCreateDeviceRGB()
+        guard let context = CGContext(data: &data,
+                                      width: width,
+                                      height: height,
+                                      bitsPerComponent: 8,
+                                      bytesPerRow: width * 4,
+                                      space: colorSpace,
+                                      bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue) else {
+            return false
+        }
+        context.draw(cgImage, in: CGRect(x: 0, y: 0, width: width, height: height))
+
+        var red: CGFloat = 0, green: CGFloat = 0, blue: CGFloat = 0, alpha: CGFloat = 0
+        color.getRed(&red, green: &green, blue: &blue, alpha: &alpha)
+
+        let tolerance: CGFloat = 0.1
+        for index in stride(from: 0, to: data.count, by: 4) {
+            let pixelAlpha = CGFloat(data[index + 3]) / 255
+            guard pixelAlpha > 0.5 else { continue }
+            /// Un-premultiply before comparing against the target color.
+            let pixelRed = CGFloat(data[index]) / 255 / pixelAlpha
+            let pixelGreen = CGFloat(data[index + 1]) / 255 / pixelAlpha
+            let pixelBlue = CGFloat(data[index + 2]) / 255 / pixelAlpha
+            if abs(pixelRed - red) < tolerance,
+               abs(pixelGreen - green) < tolerance,
+               abs(pixelBlue - blue) < tolerance {
+                return true
+            }
+        }
+        return false
+    }
+
     // MARK: - QR Detection Pause/Resume
 
     private func makeCamera() -> Camera {

--- a/specs/PP-3305-bug.md
+++ b/specs/PP-3305-bug.md
@@ -1,0 +1,89 @@
+# PP-3305: [iOS] Camera frame changes color from red to white during rotation
+
+Status: fixed
+Ticket: https://ginis.atlassian.net/browse/PP-3305
+
+## Symptom
+
+Observed: point camera at an invalid (non-payment) QR code — frame corners turn
+red (`GiniCapture.error3`, set when the unsupported-QR alert appears, PP-3290).
+Rotate the device: the corners revert to white.
+
+Expected: the frame stays red across rotation while the invalid-QR state is
+active. Reproduced by QA on iPhone and iPad, iOS 15–26.
+
+## Reproduction
+
+Cheapest faithful reproduction is a unit test (no simulator rotation needed —
+the image rebuild happens on every `updatePreviewViewOrientation()` call,
+regardless of whether the orientation actually changed):
+
+1. Load `CameraPreviewViewController`'s view.
+2. `changeCameraFrameColor(to: .red)` — frame image now tinted red.
+3. Call `updatePreviewViewOrientation()` (what `viewWillTransition` invokes).
+4. Inspect `cameraFrameView.image` pixels: no red remains — image was rebuilt
+   from the pristine white asset.
+
+## Root cause
+
+`CameraPreviewViewController.updateFrameOrientation(with:)`
+(`CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Camera/CameraPreviewViewController.swift:259-280`),
+called from `updatePreviewViewOrientation()` on every rotation
+(`viewWillTransition`, line 251), rebuilds the frame image from the **original
+untinted asset**:
+
+```swift
+if let image = cameraFocusImage?.cgImage {
+    ...
+    cameraFrameView.image = UIImage(cgImage: image, scale: 1.0, orientation: .left) // or .up
+```
+
+`cameraFocusImage` (line 52) is the pristine white "cameraFocus" asset. Any
+tint previously applied by `changeCameraFrameColor(to:)` /
+`changeQRFrameColor(to:)` (lines 371-378) is baked into a *copy* of the image
+via `tintedImageWithColor`, so rebuilding from the raw asset discards it.
+The controller keeps no record of the currently applied color, so nothing
+restores it after the rebuild.
+
+Mechanism cause → symptom: invalid QR sets frame to `error3` red
+(`CameraViewController.showUnsupportedQRCodeAlert`, line 728) → user rotates →
+`viewWillTransition` → `updatePreviewViewOrientation()` →
+`updateFrameOrientation` re-assigns the white asset → red lost.
+
+Note: `qrCodeFrameView` is *not* rebuilt on rotation, so QR-only mode keeps its
+tint; only `cameraFrameView` (the document frame visible in the ticket's
+photopayment flow) is affected.
+
+## Proposed fix
+
+Track the applied color and reapply it after the rebuild, all inside
+`CameraPreviewViewController`:
+
+- Add `private var currentFrameColor: UIColor?`.
+- `changeCameraFrameColor(to:)` stores the color before tinting.
+- `updateFrameOrientation(with:)` applies `tintedImageWithColor(currentFrameColor)`
+  to the freshly built oriented image when a color is stored.
+
+Minimal, no public API impact, fixes at the cause site (the rebuild), works
+for every colored state (red error3, yellow warning3, green success2, white
+light1).
+
+## Regression test plan
+
+Extend `CaptureSDK/GiniCaptureSDK/Tests/GiniCaptureSDKTests/CameraPreviewViewControllerTests.swift`
+(XCTest — matches the file's existing framework):
+
+- `testCameraFrameKeepsColorAfterOrientationUpdate`: load view, tint frame
+  red, call `updatePreviewViewOrientation()`, assert the rebuilt
+  `cameraFrameView.image` still contains red pixels (pixel-scan helper).
+  Fails before the fix (image rebuilt white), passes after.
+
+## Out of scope
+
+- Refactoring the tint approach to template rendering + `tintColor` (broader
+  change across frame views and `GiniBarButton`).
+- Android twin PP-3219 (already Done).
+
+## Open questions
+
+None.


### PR DESCRIPTION
## Pull Request Description

Camera frame corners revert from red to white when device rotates while invalid-QR feedback is active.

[PP-3305]

`updateFrameOrientation` rebuilt the frame image from the pristine untinted `cameraFocus` asset on every rotation, discarding whatever tint (e.g. red `error3` for invalid QR) was previously applied via `changeCameraFrameColor(to:)`. Fix stores the currently applied color and reapplies it after the orientation rebuild.

## Notes for Reviewers

- Root cause diagnosis: `specs/PP-3305-bug.md`
- Regression test added: `CameraPreviewViewControllerTests.testCameraFrameKeepsColorAfterOrientationUpdate` — pixel-scans the frame image for red after simulating a rotation via `updatePreviewViewOrientation()`. Fails before the fix, passes after.
- `GiniCaptureSDK` full unit test suite passes; scheme builds clean.
- Manual QA still needed: real-device rotation with invalid QR + unsupported-QR alert on screen (iPhone + iPad).

[PP-3305]: https://ginis.atlassian.net/browse/PP-3305?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ