### PR TITLE
Ai skills

### DIFF
--- a/.claude/skills/gini-build/SKILL.md
+++ b/.claude/skills/gini-build/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: gini-build
-description: Implement a feature from its spec written by gini-spec-feature. Pass the ticket id as argument (e.g. PP-1234, IPC-42) — the spec must already exist in specs/.
+description: Implement a feature from its spec written by gini-plan. Pass the ticket id as argument (e.g. PP-1234, IPC-42) — the spec must already exist in specs/.
 ---
 
 <!--
@@ -28,7 +28,7 @@ workflow.
 
 Read `specs/$ARGUMENTS-feature.md`, or — for a bug diagnosed with
 `/gini-fix` — `specs/$ARGUMENTS-bug.md`. If neither exists, stop and tell
-the user to run `/gini-spec-feature $ARGUMENTS` (features) or
+the user to run `/gini-plan $ARGUMENTS` (features) or
 `/gini-fix $ARGUMENTS` (bugs) first — do not improvise a spec from the
 ticket.
 

--- a/.claude/skills/gini-build/SKILL.md
+++ b/.claude/skills/gini-build/SKILL.md
@@ -48,13 +48,28 @@ renamed, a precedent was removed, an approach is no longer viable), stop and
 show the user the conflict — let them decide whether to update the spec or
 proceed differently. Do not silently deviate from the spec.
 
-## 3. Plan the implementation
+## 3. Plan the implementation — in the spec file, not just in your head
 
-Produce an ordered list of changes, each mapped to the spec requirement(s) it
-satisfies. Order it so tests can be written first and the build stays green
-at every step. Keep the plan within the spec's affected modules; if you
-discover a module not listed in the spec must change, tell the user before
-touching it.
+If the spec already contains an `## Implementation plan` section with
+unchecked steps, you are resuming an interrupted build: verify that the
+checked steps really exist in the working tree (a session can die mid-edit),
+then continue from the first unchecked step. Do not replan from scratch.
+
+Otherwise, produce an ordered list of steps, each mapped to the spec
+requirement(s) it satisfies. Order it so tests can be written first and the
+build stays green at every step. Keep the plan within the spec's affected
+modules; if you discover a module not listed in the spec must change, tell
+the user before touching it.
+
+Append the plan to the spec file so it survives the session:
+
+```markdown
+## Implementation plan
+- [ ] 1. <change, with the module and key files> (requirements 1, 3)
+- [ ] 2. <change> (requirement 2)
+```
+
+and set the spec's `Status:` line to `implementing (0/N)`.
 
 ## 4. Implement, test-first
 
@@ -68,17 +83,32 @@ Work through the plan requirement by requirement:
 - Match the style, naming, and idioms of the files you touch.
 - Do not implement anything in "Out of scope". Do not widen public API beyond
   what "Public API impact" declares.
+- After each planned step lands with its tests passing, tick its checkbox in
+  the spec's Implementation plan and update the `Status:` count
+  (`implementing (k/N)`). The spec on disk must always reflect true
+  progress — that is what lets an interrupted build resume at step 3.
 
 ## 5. Verify
 
 Run the verification steps defined in `platform.md` for the affected modules.
-Fix what fails and re-run until clean. Report results honestly — if something
-still fails or was skipped, say so explicitly.
+Fix what fails and re-run — with bounds:
+
+- Keep a running list of the fixes attempted for each distinct failure, and
+  never retry a fix already on that list.
+- After 3 failed fix attempts on the same failure, STOP. Show the user the
+  failure, each attempted fix and why it didn't work, and ask how to
+  proceed. Past that point you are thrashing, and a "fix" that merely
+  silences the symptom is worse than an honest stop.
+
+Report results honestly — if something still fails or was skipped, say so
+explicitly.
 
 ## 6. Wrap up
 
-- Update the spec's `Status:` line from `draft` to `implemented` (feature)
-  or `fixed` (bug).
+- Check every box in the spec's Implementation plan is ticked, then update
+  the spec's `Status:` line from `implementing (N/N)` to `implemented`
+  (feature) or `fixed` (bug). An unticked box means unfinished work — resolve
+  it, don't paper over it.
 - Summarize for the user: each requirement and where it was implemented and
   tested (file paths), verification results, and anything left to manual QA
   per the spec's test plan.

--- a/.claude/skills/gini-build/SKILL.md
+++ b/.claude/skills/gini-build/SKILL.md
@@ -114,3 +114,6 @@ explicitly.
   per the spec's test plan.
 - Offer to commit following the commit conventions in `platform.md`, but do
   not commit or push unless the user asks.
+- If this session exposed a wrong, missing, or misleading convention in the
+  standing docs, suggest running `/gini-reflect` to fold the learning back —
+  otherwise don't mention it.

--- a/.claude/skills/gini-fix/SKILL.md
+++ b/.claude/skills/gini-fix/SKILL.md
@@ -147,3 +147,6 @@ explicitly.
   test, verification results, and anything left to manual QA.
 - Offer to commit following the commit conventions in `platform.md`, but do
   not commit or push unless the user asks.
+- If this session exposed a wrong, missing, or misleading convention in the
+  standing docs, suggest running `/gini-reflect` to fold the learning back —
+  otherwise don't mention it.

--- a/.claude/skills/gini-fix/SKILL.md
+++ b/.claude/skills/gini-fix/SKILL.md
@@ -16,6 +16,13 @@ You are diagnosing and fixing bug ticket $ARGUMENTS. Root cause comes before
 any fix: no code change until the diagnosis is written down and confirmed.
 Never fix a symptom whose cause you haven't found.
 
+**Escalation rule — applies at every step below.** The moment the work stops
+being a minimal fix — the change needs design decisions, alters public API,
+or spreads beyond the module(s) implicated by the root cause — stop and say
+so. Finish writing the diagnosis (it stays valuable), then route the ticket
+to `/gini-plan $ARGUMENTS`, which uses the diagnosis as input for a real
+spec. Do not let a "fix" quietly grow into an unplanned feature.
+
 ## 0. Load platform conventions — REQUIRED FIRST
 
 Read `platform.md` in this skill's directory. It defines how to reproduce
@@ -97,7 +104,10 @@ Show the user the root cause and proposed fix (via AskUserQuestion). They can:
 
 - confirm — continue to step 6 in this session, or
 - stop here — the diagnosis file stands on its own; the fix can be
-  implemented later with `/gini-build $ARGUMENTS` in a fresh session.
+  implemented later with `/gini-build $ARGUMENTS` in a fresh session, or
+- escalate — the proposed fix turned out bigger than a fix (see the
+  escalation rule above): keep the diagnosis and plan it properly with
+  `/gini-plan $ARGUMENTS`.
 
 Do not proceed to code changes without confirmation.
 

--- a/.claude/skills/gini-fix/SKILL.md
+++ b/.claude/skills/gini-fix/SKILL.md
@@ -105,7 +105,10 @@ Do not proceed to code changes without confirmation.
 
 - Write the regression test first and run it: it MUST fail for the reason
   the diagnosis describes. A regression test that passes before the fix
-  proves nothing — rework it until it fails correctly.
+  proves nothing — rework it until it fails correctly. If after 3 reworks
+  the test still cannot be made to fail for the diagnosed reason, the
+  diagnosis is probably wrong: go back to step 3 instead of forcing the
+  test.
 - Apply the minimal fix from the diagnosis. Match the style of the file you
   touch. No opportunistic refactoring, no scope creep into "Out of scope".
 - Re-run the regression test (now passing) and the tests around the touched
@@ -115,8 +118,17 @@ Do not proceed to code changes without confirmation.
 
 Run the verification steps defined in `platform.md` for the affected modules,
 and re-check the original reproduction from step 2 no longer occurs. Fix what
-fails and re-run until clean. Report results honestly — if something still
-fails or was skipped, say so explicitly.
+fails and re-run — with bounds:
+
+- Keep a running list of the fixes attempted for each distinct failure, and
+  never retry a fix already on that list.
+- After 3 failed fix attempts on the same failure, STOP. Show the user the
+  failure, each attempted fix and why it didn't work, and ask how to
+  proceed. Past that point you are thrashing, and a "fix" that merely
+  silences the symptom is worse than an honest stop.
+
+Report results honestly — if something still fails or was skipped, say so
+explicitly.
 
 ## 8. Wrap up
 

--- a/.claude/skills/gini-plan/SKILL.md
+++ b/.claude/skills/gini-plan/SKILL.md
@@ -87,7 +87,9 @@ Ticket: <link to the Jira ticket>
 What the user/integrator needs and why. In your own words, not a ticket copy-paste.
 
 ## Requirements
-Numbered, testable statements. Include decisions from the clarifying questions.
+Numbered Given/When/Then statements, each tagged MUST or SHOULD and
+categorized (entry / happy / error / async — see the format rules below).
+Include decisions from the clarifying questions.
 
 ## Affected modules
 Which modules change and how they relate.
@@ -117,6 +119,24 @@ Explicitly excluded work, so /gini-build doesn't drift into it.
 Anything still unresolved (should be empty or short after step 3).
 ```
 
+Requirements format: write each requirement as Given/When/Then — e.g.
+`R1 (MUST, entry): Given <integrator setup>, when <action>, then
+<observable result>` — tagged MUST (the feature is broken without it) or
+SHOULD (negotiable), and categorized so coverage is checkable:
+
+- **entry** — how the integrator reaches the feature: the public call,
+  callback, or configuration involved, and where its result becomes
+  observable.
+- **happy path** — the main flow with its concrete expected outcome.
+- **error path** — each failure mode and the exact error surface the
+  integrator sees (type/state/message), never just "an error is shown".
+- **async** — for asynchronous flows: what is observable while the work is
+  pending and how completion arrives.
+
+Where the outcome is data (an extraction, an amount, a parsed document), the
+"then" must depend on the "given": a criterion that would also pass with a
+hardcoded return value verifies nothing.
+
 Confidence marking: any claim in "Public API impact", "Technical
 conventions", or "Design" that you could not verify against code read in
 this session gets an explicit marker —
@@ -133,6 +153,9 @@ one. Check the finished spec against every item below:
 
 - [ ] Every requirement is testable as written — someone could write a
       failing test from the requirement alone, without asking what it means.
+- [ ] The requirements cover entry, happy path, and error path (and async
+      where the flow is asynchronous). A spec with no error-path
+      requirement is almost never complete.
 - [ ] No requirement hides behind vague words: "appropriate", "properly",
       "as needed", "correctly", "etc.", "and so on". Replace each with the
       concrete behavior meant.

--- a/.claude/skills/gini-plan/SKILL.md
+++ b/.claude/skills/gini-plan/SKILL.md
@@ -1,11 +1,11 @@
 ---
-name: gini-spec-feature
+name: gini-plan
 description: Fetch a ticket, clarify open questions, and write a feature spec before any code. Pass the ticket id as argument (e.g. PP-1234, IPC-42 — any board).
 ---
 
 <!--
   MIRRORED FILE — this file must stay byte-identical to
-  .claude/skills/gini-spec-feature/SKILL.md in gini-mobile-ios.
+  .claude/skills/gini-plan/SKILL.md in gini-mobile-ios.
   If you change it here, open a paired PR in the other repo with the same
   content. CI (shared-skills.check.yml) fails when the copies diverge.
   Platform-specific rules do NOT belong here — they live in the sibling

--- a/.claude/skills/gini-plan/SKILL.md
+++ b/.claude/skills/gini-plan/SKILL.md
@@ -109,7 +109,33 @@ Explicitly excluded work, so /gini-build doesn't drift into it.
 Anything still unresolved (should be empty or short after step 3).
 ```
 
-## 5. Hand off
+## 5. Concreteness gate — REQUIRED before handoff
+
+A vague spec makes /gini-build improvise, which defeats the point of writing
+one. Check the finished spec against every item below:
+
+- [ ] Every requirement is testable as written — someone could write a
+      failing test from the requirement alone, without asking what it means.
+- [ ] No requirement hides behind vague words: "appropriate", "properly",
+      "as needed", "correctly", "etc.", "and so on". Replace each with the
+      concrete behavior meant.
+- [ ] Affected modules are named exactly, using the module naming convention
+      in `platform.md` — not "the bank SDK" but the precise module path.
+- [ ] The integrator-visible entry point is named exactly: which public
+      declaration an integrator calls, implements, or observes to use this
+      feature — or the spec states the feature has no public entry point.
+- [ ] "Public API impact" names each changed declaration and whether the
+      change is additive or breaking — or states "none". No "minor API
+      changes".
+- [ ] The test plan names concrete test classes/locations and the test stack,
+      not "add unit tests".
+- [ ] The "Design" section references real, existing code by file path — and
+      you have read those files in this session, not assumed them.
+
+If any item fails, do NOT hand off: return to step 2 (re-explore) or step 3
+(ask the user) and fix the spec. Only a spec that passes every item moves on.
+
+## 6. Hand off
 
 Show the user a short summary of the spec and where it was written. Remind
 them to review/edit it, then run `/gini-build $ARGUMENTS` (ideally in a fresh

--- a/.claude/skills/gini-plan/SKILL.md
+++ b/.claude/skills/gini-plan/SKILL.md
@@ -48,6 +48,12 @@ how things actually work today. In particular, establish:
 - How new code in that module is wired: dependency injection, string
   resources/localization, and theming, per `platform.md`.
 
+Grade your confidence in each of these findings as you go: HIGH means you
+read the actual declaration or precedent in this session; LOW means you are
+inferring from convention, naming, or memory. Keep track of the LOW ones —
+they are exactly what step 3 must ask about. A LOW-confidence flag is worth
+more than a confident guess.
+
 ## 3. Ask clarifying questions — REQUIRED, before writing the spec
 
 Use the AskUserQuestion tool. Never skip this step, even if the ticket seems
@@ -60,6 +66,8 @@ clear. Ask about the things the ticket leaves open, for example:
 - Backwards compatibility and migration expectations
 - Testing expectations (unit only, or integration/UI tests too?)
 - Anything where you would otherwise have to assume
+- Any LOW-confidence finding from step 2 that the user can settle faster
+  than further code archaeology can
 
 Only ask questions whose answers change the spec. If a second round of
 questions is needed after the first answers, ask again.
@@ -109,6 +117,15 @@ Explicitly excluded work, so /gini-build doesn't drift into it.
 Anything still unresolved (should be empty or short after step 3).
 ```
 
+Confidence marking: any claim in "Public API impact", "Technical
+conventions", or "Design" that you could not verify against code read in
+this session gets an explicit marker —
+`(confidence: LOW — <what would confirm it>)`. Unmarked claims assert HIGH
+confidence, and /gini-build will rely on them without re-checking. Every LOW
+marker must either be resolved by a step-3 question or appear in "Open
+questions" — a silent guess presented as fact is the one thing this spec
+must never contain.
+
 ## 5. Concreteness gate — REQUIRED before handoff
 
 A vague spec makes /gini-build improvise, which defeats the point of writing
@@ -131,6 +148,10 @@ one. Check the finished spec against every item below:
       not "add unit tests".
 - [ ] The "Design" section references real, existing code by file path — and
       you have read those files in this session, not assumed them.
+- [ ] Every `(confidence: LOW …)` marker left in the spec has a matching
+      entry in "Open questions". If a LOW marker sits on something
+      load-bearing (the entry point, the architecture pattern, the API
+      impact), it must not be left — resolve it in step 2 or 3 first.
 
 If any item fails, do NOT hand off: return to step 2 (re-explore) or step 3
 (ask the user) and fix the spec. Only a spec that passes every item moves on.

--- a/.claude/skills/gini-plan/SKILL.md
+++ b/.claude/skills/gini-plan/SKILL.md
@@ -107,10 +107,21 @@ How it will work: key classes, data flow, integration points. Reference
 existing code with file paths.
 
 ## Test plan
-Which tests prove each requirement. Name test classes/locations AND the test
-stack to use — match neighboring tests in the module (see platform.md). State
-the expectation that every new class gets a unit test, and list what is left
-to manual QA.
+Which tests prove each requirement — every MUST requirement maps to at least
+one named test. Name test classes/locations AND the test stack to use —
+match neighboring tests in the module (see platform.md). State the
+expectation that every new class gets a unit test.
+
+For each test class, say whether it extends an existing test class or
+creates a new one — prefer extending the neighboring class that already
+covers the code being changed. Give a rough test count per class (a focused
+class usually needs 3–6 tests; a multi-path component 6–12) and justify a
+plan that calls for more — test count is not test quality.
+
+### Not tested
+What is deliberately not tested and why (framework behavior, third-party
+code, trivial delegation), and what is left to manual QA. An explicit gap
+a reviewer can see beats an accidental one.
 
 ## Out of scope
 Explicitly excluded work, so /gini-build doesn't drift into it.

--- a/.claude/skills/gini-plan/SKILL.md
+++ b/.claude/skills/gini-plan/SKILL.md
@@ -30,6 +30,11 @@ Fetch $ARGUMENTS from Jira (any board — PP or otherwise). Read the summary,
 description, acceptance criteria, comments, and linked issues. If the ticket
 cannot be fetched, ask the user to paste its content instead of guessing.
 
+If `specs/$ARGUMENTS-bug.md` exists, this ticket was escalated from
+`/gini-fix`: read the diagnosis first. Its root cause, reproduction, and
+rejected minimal fix are established facts your spec builds on, not
+questions to re-open.
+
 ## 2. Explore the code
 
 Identify which modules are affected, using the module map in `platform.md`.

--- a/.claude/skills/gini-plan/platform.md
+++ b/.claude/skills/gini-plan/platform.md
@@ -1,4 +1,4 @@
-# gini-spec-feature platform conventions — iOS (gini-mobile-ios)
+# gini-plan platform conventions — iOS (gini-mobile-ios)
 
 <!--
   NOT MIRRORED — this file is iOS-specific by design. The Android repo has its

--- a/.claude/skills/gini-reflect/SKILL.md
+++ b/.claude/skills/gini-reflect/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: gini-reflect
+description: Capture durable learnings after a completed task — conventions that proved wrong, missing, or misleading get folded back into the repo's standing docs. Run after /gini-build or /gini-fix wraps up, or after any substantial session. Zero learnings is a valid outcome.
+---
+
+<!--
+  MIRRORED FILE — this file must stay byte-identical to
+  .claude/skills/gini-reflect/SKILL.md in gini-mobile-ios.
+  If you change it here, open a paired PR in the other repo with the same
+  content. CI (shared-skills.check.yml) fails when the copies diverge.
+  Platform-specific rules do NOT belong here — they live in the sibling
+  platform.md, which is intentionally different per repo.
+-->
+
+You are reflecting on work just completed in this session (typically a
+/gini-build or /gini-fix run). The goal is to fold what this session learned
+the hard way back into the repository's standing documentation, so no future
+session rediscovers it. This is a documentation task — do not change any
+production code.
+
+## 0. Load platform conventions — REQUIRED FIRST
+
+Read `platform.md` in this skill's directory. It names this repository's
+standing convention documents (where durable learnings live) and the
+evidence sources to check. If the file is missing, stop and tell the user
+this repository is not set up for the shared reflect workflow.
+
+## 1. Reconstruct what happened
+
+From this session and the artifacts it left behind (the spec or diagnosis in
+specs/, the diff, verification output — see `platform.md` for the evidence
+sources), list the moments where reality pushed back:
+
+- a documented convention that turned out wrong or outdated
+- something you had to discover that the docs should have told you upfront
+- a fix or verification loop that stalled or burned several attempts
+- a skill step you had to work around rather than follow
+
+If the session was smooth and the docs held up, say so and stop here.
+**Zero learnings is the normal outcome** — inventing learnings pollutes the
+docs, and most sessions should end at this step.
+
+## 2. Distill learnings — at most 3, evidence required
+
+For each surviving candidate write:
+
+- **Learning**: one sentence, an actionable directive in the imperative
+  ("Run X before Y", "Module Z uses A, not B"). If it needs a paragraph,
+  it is analysis, not a learning — cut it down or drop it.
+- **Evidence**: what concretely happened in this session that proves it.
+
+Reject anything that is already documented, one-off trivia tied to this
+ticket, a style opinion without a failure behind it, or a guess.
+
+## 3. Route each learning to its home
+
+Choose the target using the map of standing documents in `platform.md`:
+
+- platform-specific guidance on how to plan, build, or fix → the relevant
+  skill's `platform.md`
+- a repo-wide fact every session needs → the repository's agent
+  instructions file
+- a flaw in the shared workflow itself → the relevant mirrored `SKILL.md`,
+  flagging that the change needs the paired PR in the sibling repo
+- fits none of these durably → drop it
+
+## 4. Confirm with the user — REQUIRED before writing
+
+Present each learning with AskUserQuestion: the one-sentence directive, the
+evidence, the target file, and the exact edit. Apply only what the user
+approves — never self-edit skills or standing docs silently.
+
+## 5. Apply and wrap up
+
+Make the approved edits, matching each target file's existing structure and
+tone — extend an existing section before inventing a new one. Summarize what
+was written where. Offer to commit following the commit conventions in
+`platform.md`, but do not commit or push unless the user asks.

--- a/.claude/skills/gini-reflect/platform.md
+++ b/.claude/skills/gini-reflect/platform.md
@@ -1,0 +1,66 @@
+# gini-reflect platform conventions — iOS (gini-mobile-ios)
+
+<!--
+  NOT MIRRORED — this file is iOS-specific by design. The Android repo has its
+  own platform.md with the same section headings but Android content. If you
+  add a section here that the shared workflow depends on, add the matching
+  section to the Android platform.md too.
+-->
+
+## Standing convention documents (learning targets)
+
+- `AGENTS.md` (repo root) — verification gates, PR workflow, Swift
+  documentation style, and the graphify workflow, loaded into every agent
+  session (`CLAUDE.md` defers to it). Keep entries terse and imperative;
+  extend the existing section that fits (e.g. "Verification" for gates,
+  "Swift Documentation and Comment Style" for doc rules) instead of adding
+  new sections.
+- `CLAUDE.md` (repo root) — build/test commands, module layout, commit
+  format, MyApp Standards (architecture, DI, design system, testing,
+  localization), and code style. A repo-wide rule that agents keep
+  getting wrong belongs here or in AGENTS.md, whichever already owns the
+  topic. If the rule is also stated in `.claude/rules/mandatory-rules.md`,
+  update that file in the same pass — CLAUDE.md/AGENTS.md win when they
+  drift.
+- `.claude/skills/gini-plan/platform.md`,
+  `.claude/skills/gini-build/platform.md`,
+  `.claude/skills/gini-fix/platform.md`,
+  `.claude/skills/gini-reflect/platform.md` — iOS-specific guidance for
+  the shared skills. Target the skill whose step the learning improves.
+- `.claude/skills/*/SKILL.md` — only for flaws in the shared workflow
+  itself. These are mirrored byte-identical with gini-mobile-android
+  (CI: shared-skills.check.yml in that repo), so every change needs a
+  paired Android PR.
+
+NOT learning targets:
+
+- `README.md`, `RELEASE.md`, `RELEASE-ORDER.md` — human-maintained
+  release-process docs; surface a suggestion to the user instead of
+  editing.
+- The assistant's private memory — durable learnings belong in the repo,
+  where the whole team and CI benefit from them.
+
+## Evidence sources
+
+- The session conversation itself: failed attempts, retries, surprises,
+  instructions that were worked around.
+- `specs/<ticket>-feature.md` / `specs/<ticket>-bug.md` — open questions
+  that stayed open, implementation-plan steps that needed rework.
+- `git diff` / `git log` on the branch — what actually changed versus what
+  the spec predicted.
+- `make lint scheme=<Scheme>` and `xcodebuild ... test` output — which
+  verification gate failed and why. A local-pass/CI-fail split often traces
+  to the destination mismatch (`make lint` on iPhone 15 Pro / iOS 17.2 vs
+  CI's iPhone 17 / iOS 26.2 — see `.github/workflows/shared-config.yml`).
+
+## Commit conventions
+
+Learnings are AI-tooling changes (see `.git-stuff/commit-msg-template.txt`):
+
+```
+ai: <subject>
+
+<body: the learning and the session evidence behind it>
+
+<ticket-id of the session's ticket, if any>
+```


### PR DESCRIPTION
## Pull Request Description

Evolves the shared AI skill workflow under `.claude/skills/` — renames the spec skill, hardens the plan → build → fix loop against vague specs and thrashing fix loops, and adds a new reflection skill for folding session learnings back into the standing docs. No production SDK code is touched.

N/A <!-- No Jira ticket — AI-tooling change (`ai:` commits) -->

**What changed, per skill:**

- **`gini-plan` (renamed from `gini-spec-feature`)** — the spec-writing skill gets:
  - Structured acceptance criteria: requirements are now Given/When/Then, tagged MUST/SHOULD and categorized (entry / happy / error / async).
  - Confidence grading: findings from code exploration are graded HIGH/LOW; every LOW-confidence claim must be resolved via a clarifying question or listed in "Open questions" — never presented as fact.
  - A concreteness gate: a required checklist the spec must pass before handoff (testable requirements, exact module names, named entry points, concrete test classes, no vague wording).
  - Test economy rules: prefer extending existing test classes, give rough test counts per class, and an explicit "Not tested" section for deliberate gaps.
  - Awareness of escalated bugs: if `specs/<ticket>-bug.md` exists, the diagnosis from `/gini-fix` is treated as established input.
- **`gini-build`** — the implementation plan is now persisted as a checklist in the spec file (with a `Status: implementing (k/N)` line) so an interrupted build can resume; fix loops are bounded (never retry the same fix, stop and ask after 3 failed attempts on one failure).
- **`gini-fix`** — adds an escalation rule: when a "fix" grows into design decisions, public API changes, or cross-module scope, keep the diagnosis and route the ticket to `/gini-plan`; also bounds regression-test rework (3 attempts, then revisit the diagnosis) and verification fix loops, mirroring `gini-build`.
- **`gini-reflect` (new)** — post-task skill that distills at most 3 evidence-backed learnings from a session and routes them into the right standing doc (`AGENTS.md`, `CLAUDE.md`, or a skill's `platform.md`), with user confirmation before any edit. Comes with an iOS-specific `platform.md` mapping the learning targets and evidence sources. `gini-build` and `gini-fix` now suggest running it when a session exposed a wrong or missing convention.

## Notes for Reviewers

- Documentation/tooling-only change — everything lives under `.claude/skills/`; no Swift code, no SDK behavior, no tests to run.
- The `SKILL.md` files are mirrored byte-identical with `gini-mobile-android` (enforced by `shared-skills.check.yml` in that repo), so the `gini-plan` and `gini-reflect` `SKILL.md` changes need a paired PR there with identical content. The `platform.md` files are intentionally iOS-specific and not mirrored.
- Verified by reading the skills end-to-end for internal consistency: cross-references between skills (`/gini-plan` ↔ `/gini-build` ↔ `/gini-fix` ↔ `/gini-reflect`) all point at the new names, and a repo-wide grep confirms no references to the removed `gini-spec-feature` remain anywhere.
