### PR TITLE
fix(GiniBankSDKExample): Keep Custom_Files folder on clean state wipe

### DIFF
--- a/BankSDK/GiniBankSDKExample/GiniBankSDKExample/AppDelegate.swift
+++ b/BankSDK/GiniBankSDKExample/GiniBankSDKExample/AppDelegate.swift
@@ -38,10 +38,9 @@ import Firebase
             }
             if let docs = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first,
                let contents = try? FileManager.default.contentsOfDirectory(at: docs, includingPropertiesForKeys: nil) {
-                // Preserve PDF test fixtures placed by the UI test setUpWithError copy;
-                // wipe everything else so tests start clean.
+                // Preserve PDF test fixtures and the Custom_Files folder BrowserStack places at launch; wipe everything else so tests start clean.
                 contents
-                    .filter { $0.pathExtension.lowercased() != "pdf" }
+                    .filter { $0.pathExtension.lowercased() != "pdf" && $0.lastPathComponent.lowercased() != "custom_files" }
                     .forEach { try? FileManager.default.removeItem(at: $0) }
             }
         }


### PR DESCRIPTION
## Summary
- BrowserStack drops upload-test media into the app's Documents/Custom_Files folder before launch
- `-StartFromCleanState` wipe in `AppDelegate` deleted everything except `.pdf` files, taking the Custom_Files folder with it, breaking BrowserStack upload tests
- Same root shape as the earlier PDF-fixture fix (2e4142daa, PP-2483) — copy-then-wipe timing collision, now extended to exclude Custom_Files too

## Test plan
- [x] Re-run BrowserStack media-upload UI test suite, confirm Custom_Files survives clean-state launch
- [x] Confirm existing PDF-fixture based tests still pass (regression check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)