### PR TITLE
ai: Add shared Claude skills sync with gini-mobile-android

### DIFF
--- a/.github/mirrored-skills.txt
+++ b/.github/mirrored-skills.txt
@@ -1,0 +1,11 @@
+# Shared Claude skill files that must stay byte-identical between
+# gini-mobile-android and gini-mobile-ios. One repo-relative path per line.
+# Only list the general SKILL.md files — never platform.md, which is
+# platform-specific by design. The list itself is mirrored too, so additions
+# propagate to the other repo via the sync PR instead of drifting.
+# Read by shared-skills.check.yml and shared-skills.sync.yml in both repos.
+.claude/skills/gini-plan/SKILL.md
+.claude/skills/gini-build/SKILL.md
+.claude/skills/gini-fix/SKILL.md
+.claude/skills/gini-reflect/SKILL.md
+.github/mirrored-skills.txt

--- a/.github/workflows/shared-skills.check.yml
+++ b/.github/workflows/shared-skills.check.yml
@@ -1,0 +1,87 @@
+name: Check shared Claude skills are in sync with Android
+
+# The general part of shared Claude skills (SKILL.md) must stay byte-identical
+# between gini-mobile-ios and gini-mobile-android; only platform.md may differ.
+#
+# The intended flow when a mirrored file changes here: merge to main →
+# shared-skills.sync.yml opens a PR in gini-mobile-android → merge there →
+# converged. Divergence during that window is expected, so on pull_request
+# and push events it is only a WARNING. It is a hard FAILURE on the weekly
+# schedule and on manual dispatch, where divergence means lasting drift
+# (an abandoned sync PR, or the Android copy was edited directly).
+
+permissions:
+  contents: read
+
+on:
+  pull_request:
+    paths:
+      - '.claude/skills/**'
+      - '.github/mirrored-skills.txt'
+      - '.github/workflows/shared-skills.check.yml'
+  push:
+    branches:
+      - main
+    paths:
+      - '.claude/skills/**'
+      - '.github/mirrored-skills.txt'
+  schedule:
+    - cron: '0 6 * * 1'
+  workflow_dispatch:
+
+jobs:
+  check-sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Compare mirrored skill files against gini-mobile-android
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          # The list of mirrored files lives in .github/mirrored-skills.txt,
+          # shared with shared-skills.sync.yml.
+          ANDROID_RAW="https://raw.githubusercontent.com/gini/gini-mobile-android/main"
+
+          # Divergence severity depends on the trigger (see header comment).
+          if [ "$EVENT_NAME" = "schedule" ] || [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            drift_level="error"
+          else
+            drift_level="warning"
+          fi
+
+          failed=0
+
+          while IFS= read -r f; do
+            case "$f" in ''|\#*) continue ;; esac
+            if [ ! -f "$f" ]; then
+              echo "::error file=$f::listed as mirrored but missing in this repo"
+              failed=1
+              continue
+            fi
+
+            http_code=$(curl -s -o android-copy.tmp -w "%{http_code}" "$ANDROID_RAW/$f")
+
+            if [ "$http_code" = "404" ]; then
+              echo "::warning file=$f::no counterpart in gini-mobile-android yet — add it there to activate the sync check"
+              continue
+            fi
+
+            if [ "$http_code" != "200" ]; then
+              echo "::error file=$f::could not fetch Android counterpart (HTTP $http_code)"
+              failed=1
+              continue
+            fi
+
+            if ! diff -u android-copy.tmp "$f" > diff-output.tmp; then
+              if [ "$drift_level" = "error" ]; then
+                echo "::error file=$f::out of sync with gini-mobile-android — no open sync should be pending; check for an abandoned sync PR in gini-mobile-android or a direct edit of the Android copy"
+                failed=1
+              else
+                echo "::warning file=$f::differs from gini-mobile-android — expected mid-flow; after merging to main, shared-skills.sync.yml opens the sync PR in gini-mobile-android"
+              fi
+              cat diff-output.tmp
+            fi
+          done < .github/mirrored-skills.txt
+
+          exit $failed

--- a/.github/workflows/shared-skills.sync.yml
+++ b/.github/workflows/shared-skills.sync.yml
@@ -62,7 +62,7 @@ jobs:
           done < .github/mirrored-skills.txt
 
       - name: Create pull request in gini-mobile-android
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7.0.11
         with:
           path: android-repo
           token: ${{ steps.generate-token.outputs.token }}

--- a/.github/workflows/shared-skills.sync.yml
+++ b/.github/workflows/shared-skills.sync.yml
@@ -1,0 +1,87 @@
+name: Open sync PR in Android repo for shared Claude skills
+
+# When a mirrored Claude skill file changes on main, open (or update) a PR in
+# gini-mobile-android carrying the same change, so the byte-identical contract
+# checked by shared-skills.check.yml is easy to keep.
+#
+# Auth: reuses the MOBILE_CI GitHub App (same secrets as the docs/release
+# workflows) to mint a short-lived installation token scoped to
+# gini-mobile-android. The app must be installed on that repo with
+# Contents: read/write and Pull requests: read/write.
+#
+# No sync loop can occur even though the Android repo runs the mirror-image
+# workflow: the PR only carries already-merged content, so once both repos
+# converge the copy step produces no diff and create-pull-request skips PR
+# creation.
+
+# The default GITHUB_TOKEN only checks out this repo — all writes to
+# gini-mobile-android use the app installation token minted in the job.
+permissions:
+  contents: read
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - '.claude/skills/**'
+      - '.github/mirrored-skills.txt'
+  workflow_dispatch:
+
+jobs:
+  sync-to-android:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Generate a token for gini-mobile-android
+        id: generate-token
+        uses: actions/create-github-app-token@064492a9a1762067169d50c792a7dc02bc3d1254 # v2.0.0
+        with:
+          app-id: ${{ secrets.MOBILE_CI_APP_ID }}
+          private-key: ${{ secrets.MOBILE_CI_APP_PRIVATE_KEY }}
+          owner: gini
+          repositories: gini-mobile-android
+
+      - uses: actions/checkout@v4
+        with:
+          repository: gini/gini-mobile-android
+          token: ${{ steps.generate-token.outputs.token }}
+          path: android-repo
+
+      - name: Copy mirrored skill files into the Android checkout
+        run: |
+          while IFS= read -r f; do
+            case "$f" in ''|\#*) continue ;; esac
+            if [ ! -f "$f" ]; then
+              echo "::error file=.github/mirrored-skills.txt::listed file $f is missing in this repo"
+              exit 1
+            fi
+            mkdir -p "android-repo/$(dirname "$f")"
+            cp "$f" "android-repo/$f"
+          done < .github/mirrored-skills.txt
+
+      - name: Create pull request in gini-mobile-android
+        uses: peter-evans/create-pull-request@v7
+        with:
+          path: android-repo
+          token: ${{ steps.generate-token.outputs.token }}
+          committer: '${{ steps.generate-token.outputs.app-slug }}[bot] <${{ steps.generate-token.outputs.app-slug }}[bot]@users.noreply.github.com>'
+          author: '${{ steps.generate-token.outputs.app-slug }}[bot] <${{ steps.generate-token.outputs.app-slug }}[bot]@users.noreply.github.com>'
+          branch: sync/shared-claude-skills
+          delete-branch: true
+          commit-message: |
+            ai: Sync shared Claude skills from gini-mobile-ios
+
+            Automated mirror of the shared (general) Claude skill files.
+          title: 'ai: Sync shared Claude skills from gini-mobile-ios'
+          body: |
+            Automated sync of the mirrored Claude skill files from
+            [gini-mobile-ios](https://github.com/gini/gini-mobile-ios)
+            (see `.github/mirrored-skills.txt` there for the list).
+
+            The general `SKILL.md` files must stay byte-identical across the
+            Android and iOS repos; each repo's `platform.md` is intentionally
+            different and is never synced.
+
+            Triggered by ${{ github.sha }}.


### PR DESCRIPTION
## Pull Request Description

Sets up the iOS side of the shared-Claude-skills sync with [gini-mobile-android](https://github.com/gini/gini-mobile-android), as the exact mirror image of what the Android repo already runs.

**The contract:** the general `SKILL.md` of the shared skills (`gini-plan`, `gini-build`, `gini-fix`, `gini-reflect`) must stay **byte-identical** between gini-mobile-android and gini-mobile-ios. Each repo's `platform.md` is intentionally platform-specific and is never synced. The Android repo already has the check workflow, the sync workflow that opens PRs here, and the file list — this PR adds the three counterparts so the sync works in both directions:

- **`.github/mirrored-skills.txt`** — the list of mirrored files, one repo-relative path per line. The list is itself part of the byte-identical contract, so additions propagate to the other repo via the sync PR instead of drifting.
- **`.github/workflows/shared-skills.check.yml`** — compares each listed file against the Android `main` copy. Divergence is only a **warning** on `pull_request`/`push` (expected mid-flow, while a sync PR is in flight) and a **hard failure** on the weekly schedule and manual dispatch (lasting drift: an abandoned sync PR, or a direct edit of the Android copy).
- **`.github/workflows/shared-skills.sync.yml`** — when a mirrored file changes on `main`, opens (or updates) a PR in gini-mobile-android carrying the same change on branch `sync/shared-claude-skills`.

**Auth:** the sync workflow reuses the MOBILE_CI GitHub App (`MOBILE_CI_APP_ID` / `MOBILE_CI_APP_PRIVATE_KEY`) — the same secrets already used by this repo's docs/release workflows — to mint a short-lived installation token scoped to gini-mobile-android.

**No sync loop can occur** even though both repos run the mirror-image workflow: a sync PR only carries content already merged to the source repo's `main`. Once both repos converge, the copy step produces an empty diff and `peter-evans/create-pull-request` skips PR creation, so nothing ping-pongs.

**Overlap with the in-flight sync PR #1238:** the Android repo's sync workflow has already opened #1238 here (branch `sync/shared-claude-skills`), updating `.claude/skills/gini-build/SKILL.md` to Android's newer version (fix-to-plan escalation + resume hardening). This PR does not touch any `SKILL.md`, so the two don't conflict — but **merge #1238 before this PR** (or before the next push to `main` touching `.claude/skills/**`): otherwise the new sync workflow here would propose reverting Android's newer `gini-build/SKILL.md` with our stale copy. `.github/mirrored-skills.txt` here is byte-identical to Android's `main` copy already, so no sync round-trip is needed for it.

<!-- No JIRA ticket — AI tooling change, consistent with previous ai: commits. -->

## Notes for Reviewers

No SDK or app code is touched — the change is three new files under `.github/`; no other workflows were modified and no workflow runs were triggered.

Verification performed:
- **Pre-flight drift check:** each of the four `SKILL.md` files was diffed against `https://raw.githubusercontent.com/gini/gini-mobile-android/main/<path>`. Three are byte-identical; `gini-build/SKILL.md` differs exactly by the change carried by the in-flight sync PR #1238 (Android → iOS), so the drift is explained and resolves by merging that PR.
- **`mirrored-skills.txt` bytes:** byte-identical to the copy on gini-mobile-android `main` (em dashes, self-listing line, and trailing newline included).
- **YAML validity:** both workflow files pass `actionlint` with no findings.
- The four skill files exist locally at the listed paths under `.claude/skills/`.

To sanity-check the check workflow after merge: run it via *Actions → Check shared Claude skills are in sync with Android → Run workflow* — it should pass fully once #1238 is merged.
