### PR TITLE
PP-2263: Remove compound extractions for Credit Note feature

### DIFF
--- a/BankAPILibrary/GiniBankAPILibrary/Tests/GiniBankAPILibraryTests/ExtractionsContainerTest.swift
+++ b/BankAPILibrary/GiniBankAPILibrary/Tests/GiniBankAPILibraryTests/ExtractionsContainerTest.swift
@@ -53,6 +53,21 @@ final class ExtractionsContainerTest: XCTestCase {
         XCTAssertTrue(group.contains(ibanExtraction), "Group should contain the expected IBAN extraction with name set")
     }
 
+    func testCreditNoteExtractionsDecoding() throws {
+        let json = loadFile(withName: "extractionsContainerCreditNote", ofType: "json")
+        let container = try JSONDecoder().decode(ExtractionsContainer.self, from: json)
+
+        XCTAssertEqual(container.extractions.count, 8)
+        XCTAssertEqual(container.extractions.first(where: { $0.name == "businessDocType" })?.value,
+                       "CreditNote")
+        XCTAssertEqual(container.extractions.first(where: { $0.name == "amountToPay" })?.value,
+                       "12.75:EUR")
+        XCTAssertNil(container.compoundExtractions, "Credit note payload carries no compound extractions")
+        XCTAssertNil(container.returnReasons)
+        XCTAssertEqual(container.candidates.count, 4)
+        XCTAssertEqual(container.candidates["ibans"]?.count, 2)
+    }
+
     func testExtractionsContainerDecoding() throws {
         
         let container = try JSONDecoder().decode(ExtractionsContainer.self, from: extractionsContainerJson)

--- a/BankAPILibrary/GiniBankAPILibrary/Tests/GiniBankAPILibraryTests/Resources/extractionsContainerCreditNote.json
+++ b/BankAPILibrary/GiniBankAPILibrary/Tests/GiniBankAPILibraryTests/Resources/extractionsContainerCreditNote.json
@@ -1,0 +1,109 @@
+{
+  "extractions": {
+    "docType": {
+      "entity": "doctype",
+      "value": "Invoice"
+    },
+    "businessDocType": {
+      "entity": "businessdoctype",
+      "value": "CreditNote"
+    },
+    "iban": {
+      "entity": "iban",
+      "value": "DE16700202700005713153",
+      "box": {
+        "top": 3371.9,
+        "left": 1622.9,
+        "width": 361.0,
+        "height": 32.0,
+        "page": 1
+      },
+      "candidates": "ibans"
+    },
+    "paymentPurpose": {
+      "entity": "text",
+      "value": "ReNr 1191832864/04, KdNr 33038783"
+    },
+    "instantPayment": {
+      "entity": "text",
+      "value": "false"
+    },
+    "bic": {
+      "entity": "bic",
+      "value": "HYVEDEMMXXX",
+      "box": {
+        "top": 3371.9,
+        "left": 2124.9,
+        "width": 231.0,
+        "height": 32.0,
+        "page": 1
+      },
+      "candidates": "bics"
+    },
+    "amountToPay": {
+      "entity": "amount",
+      "value": "12.75:EUR",
+      "candidates": "amounts"
+    },
+    "paymentRecipient": {
+      "entity": "companyname",
+      "value": "TELEFÓNICA GERMANY GMBH & CO. OHG",
+      "candidates": "paymentRecipients"
+    }
+  },
+  "candidates": {
+    "amounts": [
+      {
+        "entity": "amount",
+        "value": "12.75:EUR"
+      }
+    ],
+    "bics": [
+      {
+        "entity": "bic",
+        "value": "HYVEDEMMXXX",
+        "box": {
+          "top": 3371.9,
+          "left": 2124.9,
+          "width": 231.0,
+          "height": 32.0,
+          "page": 1
+        }
+      }
+    ],
+    "ibans": [
+      {
+        "entity": "iban",
+        "value": "DE16700202700005713153",
+        "box": {
+          "top": 3371.9,
+          "left": 1622.9,
+          "width": 361.0,
+          "height": 32.0,
+          "page": 1
+        }
+      },
+      {
+        "entity": "iban",
+        "value": "DE16700202700005713153"
+      }
+    ],
+    "paymentRecipients": [
+      {
+        "entity": "companyname",
+        "value": "TELEFÓNICA GERMANY GMBH & CO. OHG"
+      },
+      {
+        "entity": "companyname",
+        "value": "Telefónica Germany GmbH & Co. OHG",
+        "box": {
+          "top": 559.5,
+          "left": 283.5,
+          "width": 448.0,
+          "height": 35.0,
+          "page": 1
+        }
+      }
+    ]
+  }
+}

--- a/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/GiniBankNetworkingScreenApiCoordinator.swift
+++ b/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/GiniBankNetworkingScreenApiCoordinator.swift
@@ -373,7 +373,7 @@ extension GiniBankNetworkingScreenApiCoordinator {
             if !document.isReviewable {
                 uploadAndStartAnalysisWithReturnAssistant(document: document,
                                                           networkDelegate: networkDelegate,
-                                                          uploadDidFail: {
+                                                          uploadDidFail:{
                     self.didCapture(document: document, networkDelegate: networkDelegate)
                 })
             } else if giniConfiguration.multipageEnabled {
@@ -548,7 +548,8 @@ private extension GiniBankNetworkingScreenApiCoordinator {
         if shouldProceedWithCreditNote(extractionResult) {
             presentDocumentMarkedAsCreditNoteBottomSheet(extractionResult) { [weak self] in
                 guard let self else { return }
-                let filteredResult = self.excludingAmountToPay(from: extractionResult)
+                let strippedResult = self.excludingCompoundExtractions(from: extractionResult)
+                let filteredResult = self.excludingAmountToPay(from: strippedResult)
                 self.presentTransactionDocsAlert(extractionResult: filteredResult,
                                                  delegate: delegate)
             }
@@ -803,6 +804,21 @@ internal extension GiniBankNetworkingScreenApiCoordinator {
                                 lineItems: extractionResult.lineItems,
                                 returnReasons: extractionResult.returnReasons,
                                 skontoDiscounts: extractionResult.skontoDiscounts,
+                                candidates: extractionResult.candidates)
+    }
+
+    /**
+     Returns a copy of the extraction result with the compound extractions
+     (`lineItems`, `skontoDiscounts`) and `returnReasons` removed.
+     Used for credit-note documents (PP-2263): without compound extractions the
+     Return Assistant and Skonto flows are never triggered and the host app
+     never receives them, matching the Android implementation.
+     */
+    func excludingCompoundExtractions(from extractionResult: ExtractionResult) -> ExtractionResult {
+        return ExtractionResult(extractions: extractionResult.extractions,
+                                lineItems: nil,
+                                returnReasons: nil,
+                                skontoDiscounts: nil,
                                 candidates: extractionResult.candidates)
     }
 

--- a/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/GiniBankNetworkingScreenApiCoordinator.swift
+++ b/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/GiniBankNetworkingScreenApiCoordinator.swift
@@ -810,9 +810,6 @@ internal extension GiniBankNetworkingScreenApiCoordinator {
     /**
      Returns a copy of the extraction result with the compound extractions
      (`lineItems`, `skontoDiscounts`) and `returnReasons` removed.
-     Used for credit-note documents (PP-2263): without compound extractions the
-     Return Assistant and Skonto flows are never triggered and the host app
-     never receives them, matching the Android implementation.
      */
     func excludingCompoundExtractions(from extractionResult: ExtractionResult) -> ExtractionResult {
         return ExtractionResult(extractions: extractionResult.extractions,

--- a/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/GiniBankNetworkingScreenApiCoordinator.swift
+++ b/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/GiniBankNetworkingScreenApiCoordinator.swift
@@ -548,9 +548,7 @@ private extension GiniBankNetworkingScreenApiCoordinator {
         if shouldProceedWithCreditNote(extractionResult) {
             presentDocumentMarkedAsCreditNoteBottomSheet(extractionResult) { [weak self] in
                 guard let self else { return }
-                let strippedResult = self.excludingCompoundExtractions(from: extractionResult)
-                let filteredResult = self.excludingAmountToPay(from: strippedResult)
-                self.presentTransactionDocsAlert(extractionResult: filteredResult,
+                self.presentTransactionDocsAlert(extractionResult: self.creditNoteDeliveryResult(from: extractionResult),
                                                  delegate: delegate)
             }
             return
@@ -817,6 +815,17 @@ internal extension GiniBankNetworkingScreenApiCoordinator {
                                 returnReasons: nil,
                                 skontoDiscounts: nil,
                                 candidates: extractionResult.candidates)
+    }
+
+    /**
+     Builds the extraction result delivered for a confirmed credit-note document:
+     compound extractions (`lineItems`, `skontoDiscounts`, `returnReasons`) are stripped so
+     the Return Assistant and Skonto flows are never triggered, and `amountToPay` is removed
+     so the host app does not pre-fill a payment amount for a credit note.
+     */
+    func creditNoteDeliveryResult(from extractionResult: ExtractionResult) -> ExtractionResult {
+        let strippedResult = excludingCompoundExtractions(from: extractionResult)
+        return excludingAmountToPay(from: strippedResult)
     }
 
     /**

--- a/BankSDK/GiniBankSDK/Tests/GiniBankSDKTests/GiniBankConfigurationTests.swift
+++ b/BankSDK/GiniBankSDK/Tests/GiniBankSDKTests/GiniBankConfigurationTests.swift
@@ -29,7 +29,7 @@ struct GiniBankConfigurationFeatureFlagsTests {
 
         // NOTE: Update this value whenever you add or remove a stored property.
         let propertyCount = mirror.children.count
-        let expectedCount = 65 // Current number of stored properties in GiniBankConfiguration
+        let expectedCount = 67 // Current number of stored properties in GiniBankConfiguration
         #expect(propertyCount == expectedCount,
              "A new property was added to GiniBankConfiguration. Please update feature flag tests accordingly.")
     }

--- a/BankSDK/GiniBankSDK/Tests/GiniBankSDKTests/GiniBankConfigurationTests.swift
+++ b/BankSDK/GiniBankSDK/Tests/GiniBankSDKTests/GiniBankConfigurationTests.swift
@@ -8,365 +8,367 @@ import Testing
 @testable import GiniBankSDK
 @testable import GiniCaptureSDK
 
-@Suite("GiniBankConfiguration Feature Flags")
-struct GiniBankConfigurationFeatureFlagsTests {
-    /**
-     Ensures that any change to the stored properties of `GiniBankConfiguration`
-     is intentionally reflected in the test suite.
+extension GiniConfigurationSharedStateSuite {
+    @Suite("GiniBankConfiguration Feature Flags")
+    struct GiniBankConfigurationFeatureFlagsTests {
+        /**
+         Ensures that any change to the stored properties of `GiniBankConfiguration`
+         is intentionally reflected in the test suite.
 
-     This test uses reflection (`Mirror`) to count stored properties.
-     If a new property is added or removed, the count changes and the test fails.
+         This test uses reflection (`Mirror`) to count stored properties.
+         If a new property is added or removed, the count changes and the test fails.
 
-     When this happens:
-     - Add tests for the new property (default value, toggling, propagation).
-     - Update the expected property count in this test.
+         When this happens:
+         - Add tests for the new property (default value, toggling, propagation).
+         - Update the expected property count in this test.
 
-     This acts as a safeguard to ensure configuration changes never go untested.
-     */
-    @Test("GiniBankConfiguration must not change stored properties without updating tests")
-    func configurationPropertyCount() {
-        let mirror = Mirror(reflecting: GiniBankConfiguration())
+         This acts as a safeguard to ensure configuration changes never go untested.
+         */
+        @Test("GiniBankConfiguration must not change stored properties without updating tests")
+        func configurationPropertyCount() {
+            let mirror = Mirror(reflecting: GiniBankConfiguration())
 
-        // NOTE: Update this value whenever you add or remove a stored property.
-        let propertyCount = mirror.children.count
-        let expectedCount = 67 // Current number of stored properties in GiniBankConfiguration
-        #expect(propertyCount == expectedCount,
-             "A new property was added to GiniBankConfiguration. Please update feature flag tests accordingly.")
-    }
+            // NOTE: Update this value whenever you add or remove a stored property.
+            let propertyCount = mirror.children.count
+            let expectedCount = 67 // Current number of stored properties in GiniBankConfiguration
+            #expect(propertyCount == expectedCount,
+                 "A new property was added to GiniBankConfiguration. Please update feature flag tests accordingly.")
+        }
 
-    // MARK: - Default Flag Values
+        // MARK: - Default Flag Values
 
-    @Test("Default flag values are correct")
-    func defaultFlagValues() {
-        let configuration = GiniBankConfiguration()
+        @Test("Default flag values are correct")
+        func defaultFlagValues() {
+            let configuration = GiniBankConfiguration()
 
-        #expect(!configuration.bottomNavigationBarEnabled, "Expected bottomNavigationBarEnabled to be false by default")
-        #expect(!configuration.multipageEnabled, "Expected multipageEnabled to be false by default")
-        #expect(!configuration.qrCodeScanningEnabled, "Expected qrCodeScanningEnabled to be false by default")
-        #expect(!configuration.onlyQRCodeScanningEnabled, "Expected onlyQRCodeScanningEnabled to be false by default")
-        #expect(!configuration.flashToggleEnabled, "Expected flashToggleEnabled to be false by default")
-        #expect(!configuration.flashOnByDefault, "Expected flashOnByDefault to be false by default")
-        #expect(!configuration.onboardingShowAtLaunch, "Expected onboardingShowAtLaunch to be false by default")
-        #expect(configuration.onboardingShowAtFirstLaunch, "Expected onboardingShowAtFirstLaunch to be true by default")
-        #expect(!configuration.openWithEnabled, "Expected openWithEnabled to be false by default")
-        #expect(configuration.returnAssistantEnabled, "Expected returnAssistantEnabled to be true by default")
-        #expect(!configuration.enableReturnReasons, "Expected enableReturnReasons to be false by default")
-        #expect(configuration.skontoEnabled, "Expected skontoEnabled to be true by default")
-        #expect(configuration.transactionDocsEnabled, "Expected transactionDocsEnabled to be true by default")
-        #expect(configuration.alreadyPaidHintEnabled, "Expected alreadyPaidHintEnabled to be true by default")
-        #expect(configuration.savePhotosLocallyEnabled, "Expected savePhotosLocallyEnabled to be true by default")
-        #expect(configuration.paymentDueHintEnabled, "Expected paymentDueHintEnabled to be true by default")
-        #expect(configuration.paymentDueHintThresholdDays == 5, "Expected paymentDueHintThresholdDays to be 5 by default")
-        #expect(configuration.creditNoteHintEnabled, "Expected creditNoteHintEnabled to be true by default")
-        #expect(configuration.shouldShowSupportedFormatsScreen, "Expected shouldShowSupportedFormatsScreen to be true by default")
-        #expect(configuration.shouldShowDragAndDropTutorial, "Expected shouldShowDragAndDropTutorial to be true by default")
-        #expect(configuration.giniErrorLoggerIsOn, "Expected giniErrorLoggerIsOn to be true by default")
-        #expect(!configuration.debugModeOn, "Expected debugModeOn to be false by default")
-    }
+            #expect(!configuration.bottomNavigationBarEnabled, "Expected bottomNavigationBarEnabled to be false by default")
+            #expect(!configuration.multipageEnabled, "Expected multipageEnabled to be false by default")
+            #expect(!configuration.qrCodeScanningEnabled, "Expected qrCodeScanningEnabled to be false by default")
+            #expect(!configuration.onlyQRCodeScanningEnabled, "Expected onlyQRCodeScanningEnabled to be false by default")
+            #expect(!configuration.flashToggleEnabled, "Expected flashToggleEnabled to be false by default")
+            #expect(!configuration.flashOnByDefault, "Expected flashOnByDefault to be false by default")
+            #expect(!configuration.onboardingShowAtLaunch, "Expected onboardingShowAtLaunch to be false by default")
+            #expect(configuration.onboardingShowAtFirstLaunch, "Expected onboardingShowAtFirstLaunch to be true by default")
+            #expect(!configuration.openWithEnabled, "Expected openWithEnabled to be false by default")
+            #expect(configuration.returnAssistantEnabled, "Expected returnAssistantEnabled to be true by default")
+            #expect(!configuration.enableReturnReasons, "Expected enableReturnReasons to be false by default")
+            #expect(configuration.skontoEnabled, "Expected skontoEnabled to be true by default")
+            #expect(configuration.transactionDocsEnabled, "Expected transactionDocsEnabled to be true by default")
+            #expect(configuration.alreadyPaidHintEnabled, "Expected alreadyPaidHintEnabled to be true by default")
+            #expect(configuration.savePhotosLocallyEnabled, "Expected savePhotosLocallyEnabled to be true by default")
+            #expect(configuration.paymentDueHintEnabled, "Expected paymentDueHintEnabled to be true by default")
+            #expect(configuration.paymentDueHintThresholdDays == 5, "Expected paymentDueHintThresholdDays to be 5 by default")
+            #expect(configuration.creditNoteHintEnabled, "Expected creditNoteHintEnabled to be true by default")
+            #expect(configuration.shouldShowSupportedFormatsScreen, "Expected shouldShowSupportedFormatsScreen to be true by default")
+            #expect(configuration.shouldShowDragAndDropTutorial, "Expected shouldShowDragAndDropTutorial to be true by default")
+            #expect(configuration.giniErrorLoggerIsOn, "Expected giniErrorLoggerIsOn to be true by default")
+            #expect(!configuration.debugModeOn, "Expected debugModeOn to be false by default")
+        }
 
-    // MARK: - Multipage Feature
+        // MARK: - Multipage Feature
 
-    @Test("Multipage feature can be enabled and disabled")
-    func multipageEnabled() {
-        let configuration = GiniBankConfiguration()
+        @Test("Multipage feature can be enabled and disabled")
+        func multipageEnabled() {
+            let configuration = GiniBankConfiguration()
 
-        configuration.multipageEnabled = true
-        #expect(configuration.multipageEnabled, "Expected multipageEnabled to be true after enabling")
+            configuration.multipageEnabled = true
+            #expect(configuration.multipageEnabled, "Expected multipageEnabled to be true after enabling")
 
-        configuration.multipageEnabled = false
-        #expect(!configuration.multipageEnabled, "Expected multipageEnabled to be false after disabling")
-    }
+            configuration.multipageEnabled = false
+            #expect(!configuration.multipageEnabled, "Expected multipageEnabled to be false after disabling")
+        }
 
-    // MARK: - QR Code Scanning
+        // MARK: - QR Code Scanning
 
-    @Test("QR code scanning can be enabled and disabled")
-    func qrCodeScanningEnabled() {
-        let configuration = GiniBankConfiguration()
+        @Test("QR code scanning can be enabled and disabled")
+        func qrCodeScanningEnabled() {
+            let configuration = GiniBankConfiguration()
 
-        configuration.qrCodeScanningEnabled = true
-        #expect(configuration.qrCodeScanningEnabled, "Expected qrCodeScanningEnabled to be true after enabling")
+            configuration.qrCodeScanningEnabled = true
+            #expect(configuration.qrCodeScanningEnabled, "Expected qrCodeScanningEnabled to be true after enabling")
 
-        configuration.qrCodeScanningEnabled = false
-        #expect(!configuration.qrCodeScanningEnabled, "Expected qrCodeScanningEnabled to be false after disabling")
-    }
+            configuration.qrCodeScanningEnabled = false
+            #expect(!configuration.qrCodeScanningEnabled, "Expected qrCodeScanningEnabled to be false after disabling")
+        }
 
-    @Test("Only QR code scanning can be enabled and disabled")
-    func onlyQRCodeScanningEnabled() {
-        let configuration = GiniBankConfiguration()
+        @Test("Only QR code scanning can be enabled and disabled")
+        func onlyQRCodeScanningEnabled() {
+            let configuration = GiniBankConfiguration()
 
-        configuration.onlyQRCodeScanningEnabled = true
-        #expect(configuration.onlyQRCodeScanningEnabled, "Expected onlyQRCodeScanningEnabled to be true after enabling")
+            configuration.onlyQRCodeScanningEnabled = true
+            #expect(configuration.onlyQRCodeScanningEnabled, "Expected onlyQRCodeScanningEnabled to be true after enabling")
 
-        configuration.onlyQRCodeScanningEnabled = false
-        #expect(!configuration.onlyQRCodeScanningEnabled, "Expected onlyQRCodeScanningEnabled to be false after disabling")
-    }
+            configuration.onlyQRCodeScanningEnabled = false
+            #expect(!configuration.onlyQRCodeScanningEnabled, "Expected onlyQRCodeScanningEnabled to be false after disabling")
+        }
 
-    @Test("Both QR code scanning flags can be enabled together")
-    func qrCodeScanningFlagsBothEnabled() {
-        let configuration = GiniBankConfiguration()
+        @Test("Both QR code scanning flags can be enabled together")
+        func qrCodeScanningFlagsBothEnabled() {
+            let configuration = GiniBankConfiguration()
 
-        configuration.qrCodeScanningEnabled = true
-        configuration.onlyQRCodeScanningEnabled = true
+            configuration.qrCodeScanningEnabled = true
+            configuration.onlyQRCodeScanningEnabled = true
 
-        #expect(configuration.qrCodeScanningEnabled, "Expected qrCodeScanningEnabled to be true")
-        #expect(configuration.onlyQRCodeScanningEnabled, "Expected onlyQRCodeScanningEnabled to be true")
-    }
+            #expect(configuration.qrCodeScanningEnabled, "Expected qrCodeScanningEnabled to be true")
+            #expect(configuration.onlyQRCodeScanningEnabled, "Expected onlyQRCodeScanningEnabled to be true")
+        }
 
-    // MARK: - Flash Toggle
+        // MARK: - Flash Toggle
 
-    @Test("Flash toggle can be enabled and disabled")
-    func flashToggleEnabled() {
-        let configuration = GiniBankConfiguration()
+        @Test("Flash toggle can be enabled and disabled")
+        func flashToggleEnabled() {
+            let configuration = GiniBankConfiguration()
 
-        configuration.flashToggleEnabled = true
-        #expect(configuration.flashToggleEnabled, "Expected flashToggleEnabled to be true after enabling")
+            configuration.flashToggleEnabled = true
+            #expect(configuration.flashToggleEnabled, "Expected flashToggleEnabled to be true after enabling")
         
-        configuration.flashToggleEnabled = false
-        #expect(!configuration.flashToggleEnabled, "Expected flashToggleEnabled to be false after disabling")
-    }
+            configuration.flashToggleEnabled = false
+            #expect(!configuration.flashToggleEnabled, "Expected flashToggleEnabled to be false after disabling")
+        }
 
-    @Test("Flash on by default can be enabled and disabled")
-    func flashOnByDefault() {
-        let configuration = GiniBankConfiguration()
+        @Test("Flash on by default can be enabled and disabled")
+        func flashOnByDefault() {
+            let configuration = GiniBankConfiguration()
 
-        configuration.flashOnByDefault = true
-        #expect(configuration.flashOnByDefault, "Expected flashOnByDefault to be true after enabling")
+            configuration.flashOnByDefault = true
+            #expect(configuration.flashOnByDefault, "Expected flashOnByDefault to be true after enabling")
 
-        configuration.flashOnByDefault = false
-        #expect(!configuration.flashOnByDefault, "Expected flashOnByDefault to be false after disabling")
-    }
+            configuration.flashOnByDefault = false
+            #expect(!configuration.flashOnByDefault, "Expected flashOnByDefault to be false after disabling")
+        }
 
-    // MARK: - Onboarding
+        // MARK: - Onboarding
 
-    @Test("Onboarding show at launch can be enabled and disabled")
-    func onboardingShowAtLaunch() {
-        let configuration = GiniBankConfiguration()
+        @Test("Onboarding show at launch can be enabled and disabled")
+        func onboardingShowAtLaunch() {
+            let configuration = GiniBankConfiguration()
 
-        configuration.onboardingShowAtLaunch = true
-        #expect(configuration.onboardingShowAtLaunch, "Expected onboardingShowAtLaunch to be true after enabling")
+            configuration.onboardingShowAtLaunch = true
+            #expect(configuration.onboardingShowAtLaunch, "Expected onboardingShowAtLaunch to be true after enabling")
         
-        configuration.onboardingShowAtLaunch = false
-        #expect(!configuration.onboardingShowAtLaunch, "Expected onboardingShowAtLaunch to be false after disabling")
-    }
+            configuration.onboardingShowAtLaunch = false
+            #expect(!configuration.onboardingShowAtLaunch, "Expected onboardingShowAtLaunch to be false after disabling")
+        }
 
-    @Test("Onboarding show at first launch can be enabled and disabled")
-    func onboardingShowAtFirstLaunch() {
-        let configuration = GiniBankConfiguration()
+        @Test("Onboarding show at first launch can be enabled and disabled")
+        func onboardingShowAtFirstLaunch() {
+            let configuration = GiniBankConfiguration()
 
-        configuration.onboardingShowAtFirstLaunch = false
-        #expect(!configuration.onboardingShowAtFirstLaunch, "Expected onboardingShowAtFirstLaunch to be false after disabling")
+            configuration.onboardingShowAtFirstLaunch = false
+            #expect(!configuration.onboardingShowAtFirstLaunch, "Expected onboardingShowAtFirstLaunch to be false after disabling")
 
-        configuration.onboardingShowAtFirstLaunch = true
-        #expect(configuration.onboardingShowAtFirstLaunch, "Expected onboardingShowAtFirstLaunch to be true after enabling")
-    }
+            configuration.onboardingShowAtFirstLaunch = true
+            #expect(configuration.onboardingShowAtFirstLaunch, "Expected onboardingShowAtFirstLaunch to be true after enabling")
+        }
 
-    // MARK: - Open With Feature
+        // MARK: - Open With Feature
 
-    @Test("Open with feature can be enabled and disabled")
-    func openWithEnabled() {
-        let configuration = GiniBankConfiguration()
+        @Test("Open with feature can be enabled and disabled")
+        func openWithEnabled() {
+            let configuration = GiniBankConfiguration()
         
-        configuration.openWithEnabled = true
-        #expect(configuration.openWithEnabled, "Expected openWithEnabled to be true after enabling")
+            configuration.openWithEnabled = true
+            #expect(configuration.openWithEnabled, "Expected openWithEnabled to be true after enabling")
 
-        configuration.openWithEnabled = false
-        #expect(!configuration.openWithEnabled, "Expected openWithEnabled to be false after disabling")
-    }
+            configuration.openWithEnabled = false
+            #expect(!configuration.openWithEnabled, "Expected openWithEnabled to be false after disabling")
+        }
 
-    // MARK: - Return Assistant
+        // MARK: - Return Assistant
 
-    @Test("Return assistant can be enabled and disabled")
-    func returnAssistantEnabled() {
-        let configuration = GiniBankConfiguration()
+        @Test("Return assistant can be enabled and disabled")
+        func returnAssistantEnabled() {
+            let configuration = GiniBankConfiguration()
         
-        configuration.returnAssistantEnabled = false
-        #expect(!configuration.returnAssistantEnabled, "Expected returnAssistantEnabled to be false after disabling")
+            configuration.returnAssistantEnabled = false
+            #expect(!configuration.returnAssistantEnabled, "Expected returnAssistantEnabled to be false after disabling")
 
-        configuration.returnAssistantEnabled = true
-        #expect(configuration.returnAssistantEnabled, "Expected returnAssistantEnabled to be true after enabling")
-    }
+            configuration.returnAssistantEnabled = true
+            #expect(configuration.returnAssistantEnabled, "Expected returnAssistantEnabled to be true after enabling")
+        }
 
-    // MARK: - Skonto Feature
+        // MARK: - Skonto Feature
 
-    @Test("Skonto feature can be enabled and disabled")
-    func skontoEnabled() {
-        let configuration = GiniBankConfiguration()
+        @Test("Skonto feature can be enabled and disabled")
+        func skontoEnabled() {
+            let configuration = GiniBankConfiguration()
 
-        configuration.skontoEnabled = false
-        #expect(!configuration.skontoEnabled, "Expected skontoEnabled to be false after disabling")
+            configuration.skontoEnabled = false
+            #expect(!configuration.skontoEnabled, "Expected skontoEnabled to be false after disabling")
         
-        configuration.skontoEnabled = true
-        #expect(configuration.skontoEnabled, "Expected skontoEnabled to be true after enabling")
-    }
+            configuration.skontoEnabled = true
+            #expect(configuration.skontoEnabled, "Expected skontoEnabled to be true after enabling")
+        }
 
-    // MARK: - Transaction Docs
+        // MARK: - Transaction Docs
 
-    @Test("Transaction docs can be enabled and disabled")
-    func transactionDocsEnabled() {
-        let configuration = GiniBankConfiguration()
+        @Test("Transaction docs can be enabled and disabled")
+        func transactionDocsEnabled() {
+            let configuration = GiniBankConfiguration()
 
-        configuration.transactionDocsEnabled = false
-        #expect(!configuration.transactionDocsEnabled, "Expected transactionDocsEnabled to be false after disabling")
+            configuration.transactionDocsEnabled = false
+            #expect(!configuration.transactionDocsEnabled, "Expected transactionDocsEnabled to be false after disabling")
         
-        configuration.transactionDocsEnabled = true
-        #expect(configuration.transactionDocsEnabled, "Expected transactionDocsEnabled to be true after enabling")
-    }
+            configuration.transactionDocsEnabled = true
+            #expect(configuration.transactionDocsEnabled, "Expected transactionDocsEnabled to be true after enabling")
+        }
 
-    // MARK: - Payment Hints
+        // MARK: - Payment Hints
 
-    @Test("Payment hints can be enabled and disabled")
-    func alreadyPaidHintEnabled() {
-        let configuration = GiniBankConfiguration()
+        @Test("Payment hints can be enabled and disabled")
+        func alreadyPaidHintEnabled() {
+            let configuration = GiniBankConfiguration()
 
-        configuration.alreadyPaidHintEnabled = false
-        #expect(!configuration.alreadyPaidHintEnabled, "Expected alreadyPaidHintEnabled to be false after disabling")
+            configuration.alreadyPaidHintEnabled = false
+            #expect(!configuration.alreadyPaidHintEnabled, "Expected alreadyPaidHintEnabled to be false after disabling")
         
-        configuration.alreadyPaidHintEnabled = true
-        #expect(configuration.alreadyPaidHintEnabled, "Expected alreadyPaidHintEnabled to be true after enabling")
-    }
+            configuration.alreadyPaidHintEnabled = true
+            #expect(configuration.alreadyPaidHintEnabled, "Expected alreadyPaidHintEnabled to be true after enabling")
+        }
 
-    // MARK: - Save Photos Locally
+        // MARK: - Save Photos Locally
 
-    @Test("Save photos locally can be enabled and disabled")
-    func savePhotosLocallyEnabled() {
-        let configuration = GiniBankConfiguration()
+        @Test("Save photos locally can be enabled and disabled")
+        func savePhotosLocallyEnabled() {
+            let configuration = GiniBankConfiguration()
 
-        configuration.savePhotosLocallyEnabled = false
-        #expect(!configuration.savePhotosLocallyEnabled, "Expected savePhotosLocallyEnabled to be false after disabling")
+            configuration.savePhotosLocallyEnabled = false
+            #expect(!configuration.savePhotosLocallyEnabled, "Expected savePhotosLocallyEnabled to be false after disabling")
 
-        configuration.savePhotosLocallyEnabled = true
-        #expect(configuration.savePhotosLocallyEnabled, "Expected savePhotosLocallyEnabled to be true after enabling")
-    }
+            configuration.savePhotosLocallyEnabled = true
+            #expect(configuration.savePhotosLocallyEnabled, "Expected savePhotosLocallyEnabled to be true after enabling")
+        }
 
-    // MARK: - Payment Due Hint
+        // MARK: - Payment Due Hint
 
-    @Test("Payment due hint can be enabled and disabled")
-    func paymentDueHintEnabled() {
-        let configuration = GiniBankConfiguration()
+        @Test("Payment due hint can be enabled and disabled")
+        func paymentDueHintEnabled() {
+            let configuration = GiniBankConfiguration()
 
-        configuration.paymentDueHintEnabled = false
-        #expect(!configuration.paymentDueHintEnabled,
-                "Expected paymentDueHintEnabled to be false after disabling")
+            configuration.paymentDueHintEnabled = false
+            #expect(!configuration.paymentDueHintEnabled,
+                    "Expected paymentDueHintEnabled to be false after disabling")
 
-        configuration.paymentDueHintEnabled = true
-        #expect(configuration.paymentDueHintEnabled,
-                "Expected paymentDueHintEnabled to be true after enabling")
-    }
+            configuration.paymentDueHintEnabled = true
+            #expect(configuration.paymentDueHintEnabled,
+                    "Expected paymentDueHintEnabled to be true after enabling")
+        }
 
-    @Test("Payment due hint threshold can be customized")
-    func paymentDueHintThresholdDays() {
-        let configuration = GiniBankConfiguration()
+        @Test("Payment due hint threshold can be customized")
+        func paymentDueHintThresholdDays() {
+            let configuration = GiniBankConfiguration()
 
-        #expect(configuration.paymentDueHintThresholdDays == 5,
-                "Expected paymentDueHintThresholdDays to be 5 by default")
+            #expect(configuration.paymentDueHintThresholdDays == 5,
+                    "Expected paymentDueHintThresholdDays to be 5 by default")
 
-        configuration.paymentDueHintThresholdDays = 10
-        #expect(configuration.paymentDueHintThresholdDays == 10,
-                "Expected paymentDueHintThresholdDays to be updated to 10")
-    }
+            configuration.paymentDueHintThresholdDays = 10
+            #expect(configuration.paymentDueHintThresholdDays == 10,
+                    "Expected paymentDueHintThresholdDays to be updated to 10")
+        }
 
-    // MARK: - Credit Note Hint
+        // MARK: - Credit Note Hint
 
-    @Test("Credit note hint can be enabled and disabled")
-    func creditNoteHintEnabled() {
-        let configuration = GiniBankConfiguration()
+        @Test("Credit note hint can be enabled and disabled")
+        func creditNoteHintEnabled() {
+            let configuration = GiniBankConfiguration()
 
-        configuration.creditNoteHintEnabled = false
-        #expect(!configuration.creditNoteHintEnabled,
-                "Expected creditNoteHintEnabled to be false after disabling")
+            configuration.creditNoteHintEnabled = false
+            #expect(!configuration.creditNoteHintEnabled,
+                    "Expected creditNoteHintEnabled to be false after disabling")
 
-        configuration.creditNoteHintEnabled = true
-        #expect(configuration.creditNoteHintEnabled,
-                "Expected creditNoteHintEnabled to be true after enabling")
-    }
+            configuration.creditNoteHintEnabled = true
+            #expect(configuration.creditNoteHintEnabled,
+                    "Expected creditNoteHintEnabled to be true after enabling")
+        }
 
 
-    // MARK: - Help Screens
+        // MARK: - Help Screens
 
-    @Test("Supported formats screen visibility can be toggled")
-    func shouldShowSupportedFormatsScreen() {
-        let configuration = GiniBankConfiguration()
+        @Test("Supported formats screen visibility can be toggled")
+        func shouldShowSupportedFormatsScreen() {
+            let configuration = GiniBankConfiguration()
 
-        configuration.shouldShowSupportedFormatsScreen = false
-        #expect(!configuration.shouldShowSupportedFormatsScreen, "Expected shouldShowSupportedFormatsScreen to be false after disabling")
+            configuration.shouldShowSupportedFormatsScreen = false
+            #expect(!configuration.shouldShowSupportedFormatsScreen, "Expected shouldShowSupportedFormatsScreen to be false after disabling")
 
-        configuration.shouldShowSupportedFormatsScreen = true
-        #expect(configuration.shouldShowSupportedFormatsScreen, "Expected shouldShowSupportedFormatsScreen to be true after enabling")
-    }
+            configuration.shouldShowSupportedFormatsScreen = true
+            #expect(configuration.shouldShowSupportedFormatsScreen, "Expected shouldShowSupportedFormatsScreen to be true after enabling")
+        }
 
-    @Test("Drag and drop tutorial visibility can be toggled")
-    func shouldShowDragAndDropTutorial() {
-        let configuration = GiniBankConfiguration()
+        @Test("Drag and drop tutorial visibility can be toggled")
+        func shouldShowDragAndDropTutorial() {
+            let configuration = GiniBankConfiguration()
 
-        configuration.shouldShowDragAndDropTutorial = false
-        #expect(!configuration.shouldShowDragAndDropTutorial, "Expected shouldShowDragAndDropTutorial to be false after disabling")
+            configuration.shouldShowDragAndDropTutorial = false
+            #expect(!configuration.shouldShowDragAndDropTutorial, "Expected shouldShowDragAndDropTutorial to be false after disabling")
         
-        configuration.shouldShowDragAndDropTutorial = true
-        #expect(configuration.shouldShowDragAndDropTutorial, "Expected shouldShowDragAndDropTutorial to be true after enabling")
-    }
+            configuration.shouldShowDragAndDropTutorial = true
+            #expect(configuration.shouldShowDragAndDropTutorial, "Expected shouldShowDragAndDropTutorial to be true after enabling")
+        }
 
-    // MARK: - Error Logging
+        // MARK: - Error Logging
 
-    @Test("Error logger can be enabled and disabled")
-    func giniErrorLoggerIsOn() {
-        let configuration = GiniBankConfiguration()
+        @Test("Error logger can be enabled and disabled")
+        func giniErrorLoggerIsOn() {
+            let configuration = GiniBankConfiguration()
 
-        configuration.giniErrorLoggerIsOn = false
-        #expect(!configuration.giniErrorLoggerIsOn, "Expected giniErrorLoggerIsOn to be false after disabling")
+            configuration.giniErrorLoggerIsOn = false
+            #expect(!configuration.giniErrorLoggerIsOn, "Expected giniErrorLoggerIsOn to be false after disabling")
 
-        configuration.giniErrorLoggerIsOn = true
-        #expect(configuration.giniErrorLoggerIsOn, "Expected giniErrorLoggerIsOn to be true after enabling")
-    }
+            configuration.giniErrorLoggerIsOn = true
+            #expect(configuration.giniErrorLoggerIsOn, "Expected giniErrorLoggerIsOn to be true after enabling")
+        }
 
-    // MARK: - Debug Mode
+        // MARK: - Debug Mode
 
-    @Test("Debug mode can be enabled and disabled")
-    func debugModeOn() {
-        let configuration = GiniBankConfiguration()
+        @Test("Debug mode can be enabled and disabled")
+        func debugModeOn() {
+            let configuration = GiniBankConfiguration()
 
-        configuration.debugModeOn = true
-        #expect(configuration.debugModeOn, "Expected debugModeOn to be true after enabling")
+            configuration.debugModeOn = true
+            #expect(configuration.debugModeOn, "Expected debugModeOn to be true after enabling")
 
-        configuration.debugModeOn = false
-        #expect(!configuration.debugModeOn, "Expected debugModeOn to be false after disabling")
-    }
+            configuration.debugModeOn = false
+            #expect(!configuration.debugModeOn, "Expected debugModeOn to be false after disabling")
+        }
 
-    // MARK: - Flag Transfer to CaptureConfiguration
+        // MARK: - Flag Transfer to CaptureConfiguration
 
-    @Test("Capture configuration transfers all flags correctly")
-    func captureConfigurationTransfersAllFlags() {
-        let configuration = GiniBankConfiguration()
+        @Test("Capture configuration transfers all flags correctly")
+        func captureConfigurationTransfersAllFlags() {
+            let configuration = GiniBankConfiguration()
 
-        configuration.multipageEnabled = true
-        configuration.qrCodeScanningEnabled = true
-        configuration.onlyQRCodeScanningEnabled = true
-        configuration.flashToggleEnabled = true
-        configuration.flashOnByDefault = true
-        configuration.onboardingShowAtLaunch = true
-        configuration.onboardingShowAtFirstLaunch = false
-        configuration.openWithEnabled = true
-        configuration.savePhotosLocallyEnabled = true
-        configuration.shouldShowSupportedFormatsScreen = false
-        configuration.shouldShowDragAndDropTutorial = false
-        configuration.transactionDocsEnabled = false
-        configuration.giniErrorLoggerIsOn = false
-        configuration.debugModeOn = true
+            configuration.multipageEnabled = true
+            configuration.qrCodeScanningEnabled = true
+            configuration.onlyQRCodeScanningEnabled = true
+            configuration.flashToggleEnabled = true
+            configuration.flashOnByDefault = true
+            configuration.onboardingShowAtLaunch = true
+            configuration.onboardingShowAtFirstLaunch = false
+            configuration.openWithEnabled = true
+            configuration.savePhotosLocallyEnabled = true
+            configuration.shouldShowSupportedFormatsScreen = false
+            configuration.shouldShowDragAndDropTutorial = false
+            configuration.transactionDocsEnabled = false
+            configuration.giniErrorLoggerIsOn = false
+            configuration.debugModeOn = true
 
-        let config = configuration.captureConfiguration()
+            let config = configuration.captureConfiguration()
 
-        #expect(config.multipageEnabled, "Expected multipageEnabled to be transferred as true")
-        #expect(config.qrCodeScanningEnabled, "Expected qrCodeScanningEnabled to be transferred as true")
-        #expect(config.onlyQRCodeScanningEnabled, "Expected onlyQRCodeScanningEnabled to be transferred as true")
-        #expect(config.flashToggleEnabled, "Expected flashToggleEnabled to be transferred as true")
-        #expect(config.flashOnByDefault, "Expected flashOnByDefault to be transferred as true")
-        #expect(config.onboardingShowAtLaunch, "Expected onboardingShowAtLaunch to be transferred as true")
-        #expect(!config.onboardingShowAtFirstLaunch, "Expected onboardingShowAtFirstLaunch to be transferred as false")
-        #expect(config.openWithEnabled, "Expected openWithEnabled to be transferred as true")
-        #expect(config.savePhotosLocallyEnabled, "Expected savePhotosLocallyEnabled to be transferred as true")
-        #expect(!config.shouldShowSupportedFormatsScreen, "Expected shouldShowSupportedFormatsScreen to be transferred as false")
-        #expect(!config.shouldShowDragAndDropTutorial, "Expected shouldShowDragAndDropTutorial to be transferred as false")
-        #expect(!config.transactionDocsEnabled, "Expected transactionDocsEnabled to be transferred as false")
-        #expect(!config.giniErrorLoggerIsOn, "Expected giniErrorLoggerIsOn to be transferred as false")
-        #expect(config.debugModeOn, "Expected debugModeOn to be transferred as true")
+            #expect(config.multipageEnabled, "Expected multipageEnabled to be transferred as true")
+            #expect(config.qrCodeScanningEnabled, "Expected qrCodeScanningEnabled to be transferred as true")
+            #expect(config.onlyQRCodeScanningEnabled, "Expected onlyQRCodeScanningEnabled to be transferred as true")
+            #expect(config.flashToggleEnabled, "Expected flashToggleEnabled to be transferred as true")
+            #expect(config.flashOnByDefault, "Expected flashOnByDefault to be transferred as true")
+            #expect(config.onboardingShowAtLaunch, "Expected onboardingShowAtLaunch to be transferred as true")
+            #expect(!config.onboardingShowAtFirstLaunch, "Expected onboardingShowAtFirstLaunch to be transferred as false")
+            #expect(config.openWithEnabled, "Expected openWithEnabled to be transferred as true")
+            #expect(config.savePhotosLocallyEnabled, "Expected savePhotosLocallyEnabled to be transferred as true")
+            #expect(!config.shouldShowSupportedFormatsScreen, "Expected shouldShowSupportedFormatsScreen to be transferred as false")
+            #expect(!config.shouldShowDragAndDropTutorial, "Expected shouldShowDragAndDropTutorial to be transferred as false")
+            #expect(!config.transactionDocsEnabled, "Expected transactionDocsEnabled to be transferred as false")
+            #expect(!config.giniErrorLoggerIsOn, "Expected giniErrorLoggerIsOn to be transferred as false")
+            #expect(config.debugModeOn, "Expected debugModeOn to be transferred as true")
+        }
     }
 }

--- a/BankSDK/GiniBankSDK/Tests/GiniBankSDKTests/GiniConfigurationSharedStateSuite.swift
+++ b/BankSDK/GiniBankSDK/Tests/GiniBankSDKTests/GiniConfigurationSharedStateSuite.swift
@@ -1,0 +1,23 @@
+//
+//  GiniConfigurationSharedStateSuite.swift
+//
+//  Copyright © 2026 Gini GmbH. All rights reserved.
+//
+
+import Testing
+
+/**
+ Parent suite for all tests that read or mutate the `GiniConfiguration.shared` singleton.
+
+ `GiniBankConfiguration.captureConfiguration()` writes into `GiniConfiguration.shared`
+ and returns it, and `GiniBankNetworkingScreenApiCoordinator.startSDK` mutates the same
+ singleton (partly via async main-queue dispatches). Swift Testing runs suites in
+ parallel by default, so two suites touching that singleton can overwrite each other's
+ state mid-assertion and fail flakily.
+
+ The `.serialized` trait applies recursively, so every suite nested in this enum runs
+ serially relative to the others. Nest any new suite that touches
+ `GiniConfiguration.shared` inside this type.
+ */
+@Suite("GiniConfiguration shared-state tests", .serialized)
+enum GiniConfigurationSharedStateSuite {}

--- a/BankSDK/GiniBankSDK/Tests/GiniBankSDKTests/NetworkingScreenApiCoordinatorTests+Helpers.swift
+++ b/BankSDK/GiniBankSDK/Tests/GiniBankSDKTests/NetworkingScreenApiCoordinatorTests+Helpers.swift
@@ -79,7 +79,9 @@ extension NetworkingScreenApiCoordinatorTests {
                                 businessDocType: String? = nil,
                                 lineItems: [[Extraction]]? = nil,
                                 skontoDiscounts: [[Extraction]]? = nil,
-                                crossBorderPayment: [[Extraction]]? = nil) -> ExtractionResult {
+                                crossBorderPayment: [[Extraction]]? = nil,
+                                returnReasons: [ReturnReason] = [],
+                                candidates: [String: [Extraction.Candidate]] = [:]) -> ExtractionResult {
         var extractions: [Extraction] = []
 
         if let amountToPay = amountToPay {
@@ -120,10 +122,21 @@ extension NetworkingScreenApiCoordinatorTests {
 
         return ExtractionResult(extractions: extractions,
                                 lineItems: lineItems,
-                                returnReasons: [],
+                                returnReasons: returnReasons,
                                 skontoDiscounts: skontoDiscounts,
                                 crossBorderPayment: crossBorderPayment,
-                                candidates: [:])
+                                candidates: candidates)
+    }
+
+    func createMockReturnReasons() -> [ReturnReason] {
+        return [ReturnReason(id: "r1", localizedLabels: ["de": "Beschädigt"])]
+    }
+
+    func createMockCandidates() -> [String: [Extraction.Candidate]] {
+        let candidate = Extraction.Candidate(box: nil,
+                                             entity: "amount",
+                                             value: "100.00:EUR")
+        return ["amounts": [candidate]]
     }
 
     func createMockLineItems() -> [[Extraction]] {

--- a/BankSDK/GiniBankSDK/Tests/GiniBankSDKTests/NetworkingScreenApiCoordinatorTests.swift
+++ b/BankSDK/GiniBankSDK/Tests/GiniBankSDKTests/NetworkingScreenApiCoordinatorTests.swift
@@ -553,6 +553,47 @@ final class NetworkingScreenApiCoordinatorTests: XCTestCase {
         XCTAssertTrue(coordinator.shouldShowSkonto(for: extractionResult),
                       "A non-credit-note document should keep its Skonto eligibility")
     }
+
+    // MARK: - creditNoteDeliveryResult Tests
+
+    func testCreditNoteDeliveryResultStripsCompoundExtractionsAndAmountToPay() throws {
+        let (coordinator, _) = try makeCoordinatorAndService()
+
+        let extractionResult = createExtractionResult(amountToPay: "100.00",
+                                                      businessDocType: "creditnote",
+                                                      lineItems: createMockLineItems(),
+                                                      skontoDiscounts: createMockSkontoDiscounts(),
+                                                      returnReasons: createMockReturnReasons())
+
+        let delivered = coordinator.creditNoteDeliveryResult(from: extractionResult)
+
+        XCTAssertNil(delivered.lineItems, "lineItems should be removed from the delivered credit-note result")
+        XCTAssertNil(delivered.skontoDiscounts, "skontoDiscounts should be removed from the delivered credit-note result")
+        XCTAssertNil(delivered.returnReasons, "returnReasons should be removed from the delivered credit-note result")
+        XCTAssertFalse(delivered.extractions.contains { $0.name == "amountToPay" },
+                       "amountToPay should be removed from the delivered credit-note result")
+    }
+
+    func testCreditNoteDeliveryResultKeepsRemainingFlatExtractionsAndCandidates() throws {
+        let (coordinator, _) = try makeCoordinatorAndService()
+
+        let extractionResult = createExtractionResult(amountToPay: "100.00",
+                                                      businessDocType: "creditnote",
+                                                      lineItems: createMockLineItems(),
+                                                      candidates: createMockCandidates())
+
+        let delivered = coordinator.creditNoteDeliveryResult(from: extractionResult)
+
+        XCTAssertEqual(delivered.extractions.first(where: { $0.name == "businessDocType" })?.value,
+                       "creditnote",
+                       "businessDocType should still be delivered for a credit note")
+        XCTAssertEqual(delivered.extractions.count,
+                       extractionResult.extractions.count - 1,
+                       "Only amountToPay should be filtered from the flat extractions")
+        XCTAssertEqual(delivered.candidates["amounts"]?.first?.value,
+                       "100.00:EUR",
+                       "Candidates should be carried over unchanged")
+    }
 }
 
 // MARK: - ClientConfiguration Extension

--- a/BankSDK/GiniBankSDK/Tests/GiniBankSDKTests/NetworkingScreenApiCoordinatorTests.swift
+++ b/BankSDK/GiniBankSDK/Tests/GiniBankSDKTests/NetworkingScreenApiCoordinatorTests.swift
@@ -435,6 +435,124 @@ final class NetworkingScreenApiCoordinatorTests: XCTestCase {
 
         XCTAssertFalse(result)
     }
+
+    // MARK: - excludingCompoundExtractions Tests (PP-2263)
+
+    func testExcludingCompoundExtractionsRemovesLineItemsSkontoDiscountsAndReturnReasons() throws {
+        let (coordinator, _) = try makeCoordinatorAndService()
+
+        let extractionResult = createExtractionResult(amountToPay: "100.00",
+                                                      businessDocType: "creditnote",
+                                                      lineItems: createMockLineItems(),
+                                                      skontoDiscounts: createMockSkontoDiscounts(),
+                                                      returnReasons: createMockReturnReasons())
+
+        let result = coordinator.excludingCompoundExtractions(from: extractionResult)
+
+        XCTAssertNil(result.lineItems, "lineItems should be removed for credit-note documents")
+        XCTAssertNil(result.skontoDiscounts, "skontoDiscounts should be removed for credit-note documents")
+        XCTAssertNil(result.returnReasons, "returnReasons should be removed for credit-note documents")
+    }
+
+    func testExcludingCompoundExtractionsKeepsExtractionsAndCandidates() throws {
+        let (coordinator, _) = try makeCoordinatorAndService()
+
+        let extractionResult = createExtractionResult(amountToPay: "100.00",
+                                                      businessDocType: "creditnote",
+                                                      lineItems: createMockLineItems(),
+                                                      skontoDiscounts: createMockSkontoDiscounts(),
+                                                      candidates: createMockCandidates())
+
+        let result = coordinator.excludingCompoundExtractions(from: extractionResult)
+
+        XCTAssertEqual(result.extractions.count,
+                       extractionResult.extractions.count,
+                       "Flat extractions should not be filtered")
+        XCTAssertEqual(result.extractions.first(where: { $0.name == "amountToPay" })?.value,
+                       "100.00",
+                       "amountToPay should survive compound stripping")
+        XCTAssertEqual(result.extractions.first(where: { $0.name == "businessDocType" })?.value,
+                       "creditnote",
+                       "businessDocType should survive compound stripping")
+        XCTAssertEqual(result.candidates["amounts"]?.first?.value,
+                       "100.00:EUR",
+                       "Candidates should be carried over unchanged")
+    }
+
+    func testShouldShowReturnAssistantFalseAfterExcludingCompoundExtractions() throws {
+        let (coordinator, _) = try makeCoordinatorAndService()
+
+        coordinator.giniBankConfiguration.productTag = .sepaExtractions
+        coordinator.giniBankConfiguration.returnAssistantEnabled = true
+        let extractionResult = createExtractionResult(businessDocType: "creditnote",
+                                                      lineItems: createMockLineItems())
+
+        XCTAssertTrue(coordinator.shouldShowReturnAssistant(for: extractionResult),
+                      "Precondition: RA gate should be true before stripping")
+
+        let stripped = coordinator.excludingCompoundExtractions(from: extractionResult)
+
+        XCTAssertFalse(coordinator.shouldShowReturnAssistant(for: stripped),
+                       "RA gate should be false on a stripped credit-note result")
+    }
+
+    func testShouldShowSkontoFalseAfterExcludingCompoundExtractions() throws {
+        let (coordinator, _) = try makeCoordinatorAndService()
+
+        coordinator.giniBankConfiguration.productTag = .sepaExtractions
+        coordinator.giniBankConfiguration.skontoEnabled = true
+        let extractionResult = createExtractionResult(businessDocType: "creditnote",
+                                                      skontoDiscounts: createMockSkontoDiscounts())
+
+        XCTAssertTrue(coordinator.shouldShowSkonto(for: extractionResult),
+                      "Precondition: Skonto gate should be true before stripping")
+
+        let stripped = coordinator.excludingCompoundExtractions(from: extractionResult)
+
+        XCTAssertFalse(coordinator.shouldShowSkonto(for: stripped),
+                       "Skonto gate should be false on a stripped credit-note result")
+    }
+
+    func testExcludingAmountToPayOnStrippedResultRemovesAmountToPay() throws {
+        let (coordinator, _) = try makeCoordinatorAndService()
+
+        let extractionResult = createExtractionResult(amountToPay: "100.00",
+                                                      businessDocType: "creditnote",
+                                                      lineItems: createMockLineItems(),
+                                                      skontoDiscounts: createMockSkontoDiscounts(),
+                                                      returnReasons: createMockReturnReasons())
+
+        let stripped = coordinator.excludingCompoundExtractions(from: extractionResult)
+        let filtered = coordinator.excludingAmountToPay(from: stripped)
+
+        XCTAssertFalse(filtered.extractions.contains { $0.name == "amountToPay" },
+                       "amountToPay should be excluded after chaining both helpers")
+        XCTAssertEqual(filtered.extractions.first(where: { $0.name == "businessDocType" })?.value,
+                       "creditnote",
+                       "businessDocType should still be delivered")
+        XCTAssertNil(filtered.lineItems, "lineItems should stay removed after amountToPay filtering")
+        XCTAssertNil(filtered.skontoDiscounts, "skontoDiscounts should stay removed after amountToPay filtering")
+        XCTAssertNil(filtered.returnReasons, "returnReasons should stay removed after amountToPay filtering")
+    }
+
+    func testNonCreditNoteResultKeepsCompoundExtractions() throws {
+        let (coordinator, _) = try makeCoordinatorAndService()
+
+        coordinator.giniBankConfiguration.productTag = .sepaExtractions
+        coordinator.giniBankConfiguration.returnAssistantEnabled = true
+        coordinator.giniBankConfiguration.skontoEnabled = true
+        let extractionResult = createExtractionResult(amountToPay: "100.00",
+                                                      businessDocType: "invoice",
+                                                      lineItems: createMockLineItems(),
+                                                      skontoDiscounts: createMockSkontoDiscounts())
+
+        XCTAssertFalse(coordinator.isDocumentMarkedAsCreditNote(from: extractionResult),
+                       "An invoice must not be detected as a credit note, so the flow never strips it")
+        XCTAssertTrue(coordinator.shouldShowReturnAssistant(for: extractionResult),
+                      "A non-credit-note document should keep its Return Assistant eligibility")
+        XCTAssertTrue(coordinator.shouldShowSkonto(for: extractionResult),
+                      "A non-credit-note document should keep its Skonto eligibility")
+    }
 }
 
 // MARK: - ClientConfiguration Extension

--- a/BankSDK/GiniBankSDK/Tests/GiniBankSDKTests/NetworkingScreenApiCoordinatorTests.swift
+++ b/BankSDK/GiniBankSDK/Tests/GiniBankSDKTests/NetworkingScreenApiCoordinatorTests.swift
@@ -436,7 +436,7 @@ final class NetworkingScreenApiCoordinatorTests: XCTestCase {
         XCTAssertFalse(result)
     }
 
-    // MARK: - excludingCompoundExtractions Tests (PP-2263)
+    // MARK: - excludingCompoundExtractions Tests
 
     func testExcludingCompoundExtractionsRemovesLineItemsSkontoDiscountsAndReturnReasons() throws {
         let (coordinator, _) = try makeCoordinatorAndService()

--- a/BankSDK/GiniBankSDK/Tests/GiniBankSDKTests/RemoteConfigPropagationTests.swift
+++ b/BankSDK/GiniBankSDK/Tests/GiniBankSDKTests/RemoteConfigPropagationTests.swift
@@ -10,69 +10,71 @@ import Testing
 @testable import GiniBankSDK
 @testable import GiniCaptureSDK
 
-@Suite("Remote client-configuration propagation to GiniCaptureUserDefaultsStorage", .serialized)
-@MainActor
-struct RemoteConfigPropagationTests {
+extension GiniConfigurationSharedStateSuite {
+    @Suite("Remote client-configuration propagation to GiniCaptureUserDefaultsStorage", .serialized)
+    @MainActor
+    struct RemoteConfigPropagationTests {
 
-    init() {
-        _GINIBANKAPILIBRARY_DISABLE_KEYCHAIN_PRECONDITION_FAILURE = true
-    }
-
-    @Test("unsupportedQRCodeWarningEnabled=true from remote config is written to storage")
-    func propagatesUnsupportedQRCodeWarningTrue() async {
-        await runStartSDK(withUnsupportedQRCodeWarningEnabled: true)
-
-        #expect(GiniCaptureUserDefaultsStorage.unsupportedQRCodeWarningEnabled == true)
-    }
-
-    @Test("unsupportedQRCodeWarningEnabled=false from remote config is written to storage")
-    func propagatesUnsupportedQRCodeWarningFalse() async {
-        await runStartSDK(withUnsupportedQRCodeWarningEnabled: false)
-
-        #expect(GiniCaptureUserDefaultsStorage.unsupportedQRCodeWarningEnabled == false)
-    }
-
-    // MARK: - Helpers
-
-    private func runStartSDK(withUnsupportedQRCodeWarningEnabled flag: Bool) async {
-        GiniCaptureUserDefaultsStorage.unsupportedQRCodeWarningEnabled = nil
-
-        let configuration = makeClientConfiguration(unsupportedQRCodeWarningEnabled: flag)
-        let configService = MockClientConfigurationService(result: .success(configuration))
-
-        let coordinator = GiniBankNetworkingScreenApiCoordinator(
-            resultsDelegate: MockCaptureResultsDelegate(),
-            configuration: GiniBankConfiguration(),
-            documentMetadata: nil,
-            trackingDelegate: nil,
-            captureNetworkService: MockCaptureNetworkService(),
-            configurationService: configService
-        )
-
-        _ = coordinator.startSDK(withDocuments: nil, animated: false)
-
-        // startSDK dispatches the assignments to main asynchronously; hop once to
-        // let the queued block drain before asserting.
-        await withCheckedContinuation { continuation in
-            DispatchQueue.main.async { continuation.resume() }
+        init() {
+            _GINIBANKAPILIBRARY_DISABLE_KEYCHAIN_PRECONDITION_FAILURE = true
         }
 
-        GiniBank.closeCurrentSDK()
-    }
+        @Test("unsupportedQRCodeWarningEnabled=true from remote config is written to storage")
+        func propagatesUnsupportedQRCodeWarningTrue() async {
+            await runStartSDK(withUnsupportedQRCodeWarningEnabled: true)
 
-    private func makeClientConfiguration(unsupportedQRCodeWarningEnabled: Bool) -> ClientConfiguration {
-        ClientConfiguration(clientID: "test",
-                            userJourneyAnalyticsEnabled: false,
-                            skontoEnabled: false,
-                            returnAssistantEnabled: false,
-                            transactionDocsEnabled: false,
-                            instantPaymentEnabled: false,
-                            qrCodeEducationEnabled: false,
-                            eInvoiceEnabled: false,
-                            savePhotosLocallyEnabled: false,
-                            alreadyPaidHintEnabled: false,
-                            paymentDueHintEnabled: false,
-                            creditNoteHintEnabled: false,
-                            unsupportedQRCodeWarningEnabled: unsupportedQRCodeWarningEnabled)
+            #expect(GiniCaptureUserDefaultsStorage.unsupportedQRCodeWarningEnabled == true)
+        }
+
+        @Test("unsupportedQRCodeWarningEnabled=false from remote config is written to storage")
+        func propagatesUnsupportedQRCodeWarningFalse() async {
+            await runStartSDK(withUnsupportedQRCodeWarningEnabled: false)
+
+            #expect(GiniCaptureUserDefaultsStorage.unsupportedQRCodeWarningEnabled == false)
+        }
+
+        // MARK: - Helpers
+
+        private func runStartSDK(withUnsupportedQRCodeWarningEnabled flag: Bool) async {
+            GiniCaptureUserDefaultsStorage.unsupportedQRCodeWarningEnabled = nil
+
+            let configuration = makeClientConfiguration(unsupportedQRCodeWarningEnabled: flag)
+            let configService = MockClientConfigurationService(result: .success(configuration))
+
+            let coordinator = GiniBankNetworkingScreenApiCoordinator(
+                resultsDelegate: MockCaptureResultsDelegate(),
+                configuration: GiniBankConfiguration(),
+                documentMetadata: nil,
+                trackingDelegate: nil,
+                captureNetworkService: MockCaptureNetworkService(),
+                configurationService: configService
+            )
+
+            _ = coordinator.startSDK(withDocuments: nil, animated: false)
+
+            // startSDK dispatches the assignments to main asynchronously; hop once to
+            // let the queued block drain before asserting.
+            await withCheckedContinuation { continuation in
+                DispatchQueue.main.async { continuation.resume() }
+            }
+
+            GiniBank.closeCurrentSDK()
+        }
+
+        private func makeClientConfiguration(unsupportedQRCodeWarningEnabled: Bool) -> ClientConfiguration {
+            ClientConfiguration(clientID: "test",
+                                userJourneyAnalyticsEnabled: false,
+                                skontoEnabled: false,
+                                returnAssistantEnabled: false,
+                                transactionDocsEnabled: false,
+                                instantPaymentEnabled: false,
+                                qrCodeEducationEnabled: false,
+                                eInvoiceEnabled: false,
+                                savePhotosLocallyEnabled: false,
+                                alreadyPaidHintEnabled: false,
+                                paymentDueHintEnabled: false,
+                                creditNoteHintEnabled: false,
+                                unsupportedQRCodeWarningEnabled: unsupportedQRCodeWarningEnabled)
+        }
     }
 }

--- a/BankSDK/GiniBankSDK/Tests/GiniBankSDKTests/RemoteConfigPropagationTests.swift
+++ b/BankSDK/GiniBankSDK/Tests/GiniBankSDKTests/RemoteConfigPropagationTests.swift
@@ -72,6 +72,7 @@ struct RemoteConfigPropagationTests {
                             savePhotosLocallyEnabled: false,
                             alreadyPaidHintEnabled: false,
                             paymentDueHintEnabled: false,
+                            creditNoteHintEnabled: false,
                             unsupportedQRCodeWarningEnabled: unsupportedQRCodeWarningEnabled)
     }
 }

--- a/BankSDK/GiniBankSDKExample/GiniBankSDKExample/AppCoordinator.swift
+++ b/BankSDK/GiniBankSDKExample/GiniBankSDKExample/AppCoordinator.swift
@@ -83,7 +83,9 @@ final class AppCoordinator: Coordinator {
        return configuration
     }()
     
-    private lazy var client: Client = CredentialsManager.fetchClientFromBundle()
+    private lazy var client: Client = apiEnvironment == .stage
+        ? CredentialsManager.fetchStageClientFromBundle()
+        : CredentialsManager.fetchClientFromBundle()
     private var documentMetadata: Document.Metadata?
     private let documentMetadataBranchId = "GVLExampleIOS"
     private let documentMetadataAppFlowKey = "AppFlow"
@@ -91,7 +93,7 @@ final class AppCoordinator: Coordinator {
     private let imageDataKey = "imageData"
 	private var settingsButtonStates: SettingsButtonStates?
 	private var documentValidationsState: DocumentValidationsState?
-    private var apiEnvironment: APIEnvironment = .production
+    private var apiEnvironment: APIEnvironment = ExampleAppUserDefaultsStorage.currentAPIEnvironment
     private var enablePinningSDK: Bool = ExampleAppUserDefaultsStorage.enablePinningSDK
 
     init(window: UIWindow) {

--- a/BankSDK/GiniBankSDKExample/GiniBankSDKExample/Credentials.plist
+++ b/BankSDK/GiniBankSDKExample/GiniBankSDKExample/Credentials.plist
@@ -12,5 +12,9 @@
 	<string>***</string>
 	<key>cx_client_password</key>
 	<string>***</string>
+	<key>stage_client_id</key>
+	<string>***</string>
+	<key>stage_client_password</key>
+	<string>***</string>
 </dict>
 </plist>

--- a/BankSDK/GiniBankSDKExample/GiniBankSDKExample/CredentialsManager.swift
+++ b/BankSDK/GiniBankSDKExample/GiniBankSDKExample/CredentialsManager.swift
@@ -17,6 +17,10 @@ final class CredentialsManager {
         return fetchClient(idKey: "cx_client_id", passwordKey: "cx_client_password")
     }
 
+    class func fetchStageClientFromBundle() -> Client {
+        return fetchClient(idKey: "stage_client_id", passwordKey: "stage_client_password")
+    }
+
     private class func fetchClient(idKey: String, passwordKey: String) -> Client {
         let clientEmailDomain = "client_domain"
         let credentialsPlistPath = Bundle.main.path(forResource: "Credentials", ofType: "plist")

--- a/BankSDK/GiniBankSDKExample/GiniBankSDKExample/SettingsViewController/CredentialsSet.swift
+++ b/BankSDK/GiniBankSDKExample/GiniBankSDKExample/SettingsViewController/CredentialsSet.swift
@@ -16,7 +16,15 @@ struct CredentialsSet {
         return (clientId: client.id, clientSecret: client.secret)
     }
 
-    static func credentials(for index: Int) -> (clientId: String, clientSecret: String) {
-        return index == 0 ? setA : setB
+    /// Staging counterpart of set A; set B (CX) has no staging variant.
+    static var stageSetA: (clientId: String, clientSecret: String) {
+        let client = CredentialsManager.fetchStageClientFromBundle()
+        return (clientId: client.id, clientSecret: client.secret)
+    }
+
+    static func credentials(for index: Int,
+                            environment: APIEnvironment) -> (clientId: String, clientSecret: String) {
+        guard index == 0 else { return setB }
+        return environment == .stage ? stageSetA : setA
     }
 }

--- a/BankSDK/GiniBankSDKExample/GiniBankSDKExample/SettingsViewController/CredentialsSet.swift
+++ b/BankSDK/GiniBankSDKExample/GiniBankSDKExample/SettingsViewController/CredentialsSet.swift
@@ -16,7 +16,9 @@ struct CredentialsSet {
         return (clientId: client.id, clientSecret: client.secret)
     }
 
-    /// Staging counterpart of set A; set B (CX) has no staging variant.
+    /**
+     Provides the staging counterpart of `setA`; `setB` (CX) has no staging variant.
+     */
     static var stageSetA: (clientId: String, clientSecret: String) {
         let client = CredentialsManager.fetchStageClientFromBundle()
         return (clientId: client.id, clientSecret: client.secret)

--- a/BankSDK/GiniBankSDKExample/GiniBankSDKExample/SettingsViewController/SettingsViewController.swift
+++ b/BankSDK/GiniBankSDKExample/GiniBankSDKExample/SettingsViewController/SettingsViewController.swift
@@ -227,11 +227,17 @@ extension SettingsViewController: SegmentedOptionTableViewCellDelegate {
         let environment: APIEnvironment = environmentIndex == 0 ? .production : .stage
         viewModel.handleAPIEnvironmentSelection(environment: environment)
         delegate?.didSelectAPIEnvironment(apiEnvironment: environment)
+        applyCredentialsForSelectedSet()
     }
 
     func handleCredentialsSetSelection(credentialsIndex: Int) {
         viewModel.handleCredentialsSetSelection(credentialsIndex: credentialsIndex)
-        let credentials = CredentialsSet.credentials(for: credentialsIndex)
+        applyCredentialsForSelectedSet()
+    }
+
+    /// Pushes the credentials resolved for the selected set and environment to the delegate.
+    private func applyCredentialsForSelectedSet() {
+        let credentials = viewModel.credentialsForSelectedSet()
         delegate?.didTapSaveCredentialsButton(clientId: credentials.clientId,
                                               clientSecret: credentials.clientSecret)
         showCredentialsSavedAlert(setName: "client_id \(credentials.clientId)")

--- a/BankSDK/GiniBankSDKExample/GiniBankSDKExample/SettingsViewController/SettingsViewController.swift
+++ b/BankSDK/GiniBankSDKExample/GiniBankSDKExample/SettingsViewController/SettingsViewController.swift
@@ -235,7 +235,9 @@ extension SettingsViewController: SegmentedOptionTableViewCellDelegate {
         applyCredentialsForSelectedSet()
     }
 
-    /// Pushes the credentials resolved for the selected set and environment to the delegate.
+    /**
+     Pushes the credentials resolved for the selected set and environment to the delegate.
+     */
     private func applyCredentialsForSelectedSet() {
         let credentials = viewModel.credentialsForSelectedSet()
         delegate?.didTapSaveCredentialsButton(clientId: credentials.clientId,

--- a/BankSDK/GiniBankSDKExample/GiniBankSDKExample/SettingsViewController/SettingsViewModel.swift
+++ b/BankSDK/GiniBankSDKExample/GiniBankSDKExample/SettingsViewController/SettingsViewModel.swift
@@ -86,7 +86,7 @@ final class SettingsViewModel {
         credentialsSection.items.append(.segmentedOption(data: CredentialsSetSegmentedOptionModel(selectedIndex: selectedCredentialsSetIndex)))
 
         // Credentials input fields
-        let currentCredentials = CredentialsSet.credentials(for: selectedCredentialsSetIndex)
+        let currentCredentials = credentialsForSelectedSet()
         credentialsSection.items.append(.credentials(data: .init(clientId: currentCredentials.clientId,
                                                                  secretId: currentCredentials.clientSecret)))
 
@@ -117,6 +117,15 @@ final class SettingsViewModel {
 
         setupContentData()
         delegate?.contentDataUpdated()
+    }
+
+    /**
+     Returns the credentials matching the selected credentials set and the
+     current API environment (set A resolves to its staging variant on stage).
+     */
+    func credentialsForSelectedSet() -> (clientId: String, clientSecret: String) {
+        return CredentialsSet.credentials(for: selectedCredentialsSetIndex,
+                                          environment: currentAPIEnvironment)
     }
 
     private func setupSDKTypeSection(enablePinningSDK: Bool) -> SettingsSection {

--- a/BankSDK/GiniBankSDKExample/Tests/IntegrationTests/Base/BaseIntegrationTest.swift
+++ b/BankSDK/GiniBankSDKExample/Tests/IntegrationTests/Base/BaseIntegrationTest.swift
@@ -13,8 +13,27 @@ class BaseIntegrationTest: XCTestCase {
     lazy var giniHelper = GiniSetupHelper()
     var analysisExtractionResult: ExtractionResult?
 
+    /**
+     Set on the main queue when the test finishes (including timeouts).
+
+     Async callbacks from a timed-out test would otherwise keep running into the
+     following tests and send transfer summary feedback through the shared
+     `GiniBankConfiguration` — which by then points at the *next* test's document,
+     overwriting its extractions server-side. Every async continuation must check
+     this flag on the main queue and bail out when it is `true`.
+     */
+    private(set) var isTestFinished = false
+
     override func setUp() {
         giniHelper.setup()
+    }
+
+    override func tearDown() {
+        isTestFinished = true
+        /// Reset the shared configuration so a late callback of this test can never
+        /// reach the document service of the test that runs next.
+        GiniBankConfiguration.shared.cleanup()
+        super.tearDown()
     }
     /**
      * This method reproduces the document upload and analysis done by the Bank SDK.
@@ -45,12 +64,17 @@ class BaseIntegrationTest: XCTestCase {
 
         // Upload and analyze the document
         giniHelper.giniCaptureSDKDocumentService.upload(document: captureDocument) { result in
-            switch result {
-                case .success(_):
-                    self.handleUploadSuccess(captureDocument: captureDocument,
-                                             delegate: delegate)
-                case let .failure(error):
-                    XCTFail(String(describing: error))
+            /// Hop to the main queue so `isTestFinished` is read race-free and all
+            /// follow-up test logic runs serially with the test's run loop.
+            DispatchQueue.main.async {
+                guard !self.isTestFinished else { return }
+                switch result {
+                    case .success(_):
+                        self.handleUploadSuccess(captureDocument: captureDocument,
+                                                 delegate: delegate)
+                    case let .failure(error):
+                        XCTFail(String(describing: error))
+                }
             }
         }
     }
@@ -66,12 +90,15 @@ class BaseIntegrationTest: XCTestCase {
     func handleUploadSuccess(captureDocument: GiniCaptureDocument,
                              delegate: GiniCaptureResultsDelegate) {
         giniHelper.giniCaptureSDKDocumentService?.startAnalysis { result in
-            switch result {
-                case let .success(extractionResult):
-                    self.handleAnalysisSuccess(extractionResult: extractionResult,
-                                               delegate: delegate)
-                case let .failure(error):
-                    XCTFail(String(describing: error))
+            DispatchQueue.main.async {
+                guard !self.isTestFinished else { return }
+                switch result {
+                    case let .success(extractionResult):
+                        self.handleAnalysisSuccess(extractionResult: extractionResult,
+                                                   delegate: delegate)
+                    case let .failure(error):
+                        XCTFail(String(describing: error))
+                }
             }
         }
     }

--- a/BankSDK/GiniBankSDKExample/Tests/IntegrationTests/SSLPinningTests/TransferSummaryIntegrationPinningTests.swift
+++ b/BankSDK/GiniBankSDKExample/Tests/IntegrationTests/SSLPinningTests/TransferSummaryIntegrationPinningTests.swift
@@ -45,11 +45,16 @@ class TransferSummaryIntegrationPinningTests: BaseIntegrationTest {
         }
 
         func giniCaptureAnalysisDidFinishWith(result: AnalysisResult) {
+            /// A callback surviving a timed-out test must not run into the next test.
+            guard !testCase.isTestFinished else { return }
             var extractions = result.extractions.reduce(into: [String: String]()) { dict, pair in
                 dict[pair.key] = pair.value.value
             }
             /// Override `amountToPay` with the confirmed test value to guarantee the "value:currency" format.
             extractions["amountToPay"] = ExtractionAmount(value: 950.00, currency: .EUR).formattedString()
+            /// Re-pin the shared document service to this test's own service so the
+            /// feedback can never target another test's document.
+            GiniBankConfiguration.shared.documentService = testCase.giniHelper.giniCaptureSDKDocumentService
             GiniBankConfiguration.shared.sendTransferSummary(extractions: extractions)
 
             let mockedInvoice = mockedInvoiceResultName

--- a/BankSDK/GiniBankSDKExample/Tests/IntegrationTests/TransferSummary/BaseIntegrationTest+CXTransferSummary.swift
+++ b/BankSDK/GiniBankSDKExample/Tests/IntegrationTests/TransferSummary/BaseIntegrationTest+CXTransferSummary.swift
@@ -82,15 +82,19 @@ extension BaseIntegrationTest {
         }
 
         DispatchQueue.main.asyncAfter(deadline: .now() + 10) {
+            guard !self.isTestFinished else { return }
             self.getUpdatedExtractionsFromGiniBankSDK(for: document) { updatedResult in
-                switch updatedResult {
-                case .success:
-                    /// Backend accepted the `crossBorderPayment` feedback — document is still accessible.
-                    GiniBankConfiguration.shared.cleanup()
-                    XCTAssertNil(GiniBankConfiguration.shared.documentService)
-                    expect.fulfill()
-                case let .failure(error):
-                    XCTFail("CX transfer summary feedback was rejected by the backend: \(error)")
+                DispatchQueue.main.async {
+                    guard !self.isTestFinished else { return }
+                    switch updatedResult {
+                    case .success:
+                        /// Backend accepted the `crossBorderPayment` feedback — document is still accessible.
+                        GiniBankConfiguration.shared.cleanup()
+                        XCTAssertNil(GiniBankConfiguration.shared.documentService)
+                        expect.fulfill()
+                    case let .failure(error):
+                        XCTFail("CX transfer summary feedback was rejected by the backend: \(error)")
+                    }
                 }
             }
         }

--- a/BankSDK/GiniBankSDKExample/Tests/IntegrationTests/TransferSummary/BaseIntegrationTest+TransferSummary.swift
+++ b/BankSDK/GiniBankSDKExample/Tests/IntegrationTests/TransferSummary/BaseIntegrationTest+TransferSummary.swift
@@ -10,6 +10,14 @@ import XCTest
 @testable import GiniCaptureSDK
 @testable import GiniBankSDK
 
+/**
+ Polling cadence for waiting on the backend to process transfer summary feedback.
+ */
+private enum Constants {
+    static let pollInterval: TimeInterval = 2
+    static let maxPollAttempts = 30
+}
+
 extension BaseIntegrationTest {
 
     // Method to handle updating and verifying feedback
@@ -20,21 +28,57 @@ extension BaseIntegrationTest {
         // Assuming the user updated the amountToPay to "950.00:EUR"
         result.extractions["amountToPay"]?.value = "950.00:EUR"
 
-        if result.extractions["amountToPay"] != nil {
-            // Delay to simulate feedback update process
-            DispatchQueue.main.asyncAfter(deadline: .now() + 10) {
-                // 5. Verify that the extractions were updated after feedback
-                self.getUpdatedExtractionsFromGiniBankSDK(for: result.document!) { updatedResult in
-                    switch updatedResult {
-                        case let .success(extractionResult):
-                            self.handleSuccessfulTransferSummaryUpdate(extractionResult: extractionResult,
-                                                                       mockedInvoiceUpdatedResultName: mockedInvoiceUpdatedResultName,
-                                                                       expect: expect,
-                                                                       result: result,
-                                                                       verifyInstantPayment: verifyInstantPayment)
-                        case let .failure(error):
-                            XCTFail("Error updating transfer summary: \(error)")
-                    }
+        guard result.extractions["amountToPay"] != nil else { return }
+        guard let document = result.document else {
+            XCTFail("Analysis result has no document to verify the transfer summary against")
+            return
+        }
+
+        /// The fed-back `amountToPay` appearing in the fetched extractions signals
+        /// that the backend has processed the transfer summary.
+        pollUpdatedExtractions(for: document,
+                               expectedAmountToPay: "950.00:EUR") { extractionResult in
+            self.handleSuccessfulTransferSummaryUpdate(extractionResult: extractionResult,
+                                                       mockedInvoiceUpdatedResultName: mockedInvoiceUpdatedResultName,
+                                                       expect: expect,
+                                                       result: result,
+                                                       verifyInstantPayment: verifyInstantPayment)
+        }
+    }
+
+    /**
+     Polls the updated extractions for `document` until the fed-back `amountToPay`
+     value becomes visible or the attempts are exhausted, then calls `completion`
+     on the main queue with the last fetched result.
+
+     Replaces the previous fixed 10-second delay: on a slow backend the delay
+     expired before the feedback was processed and the assertions compared stale
+     values. Exhausting the attempts still calls `completion` so the assertions
+     produce a readable failure instead of a bare timeout.
+     */
+    func pollUpdatedExtractions(for document: Document,
+                                expectedAmountToPay: String,
+                                attemptsLeft: Int = Constants.maxPollAttempts,
+                                completion: @escaping (ExtractionResult) -> Void) {
+        getUpdatedExtractionsFromGiniBankSDK(for: document) { updatedResult in
+            DispatchQueue.main.async {
+                guard !self.isTestFinished else { return }
+                switch updatedResult {
+                    case let .success(extractionResult):
+                        let amountToPay = extractionResult.extractions.first(where: { $0.name == "amountToPay" })?.value
+                        if amountToPay == expectedAmountToPay || attemptsLeft <= 1 {
+                            completion(extractionResult)
+                        } else {
+                            DispatchQueue.main.asyncAfter(deadline: .now() + Constants.pollInterval) {
+                                guard !self.isTestFinished else { return }
+                                self.pollUpdatedExtractions(for: document,
+                                                            expectedAmountToPay: expectedAmountToPay,
+                                                            attemptsLeft: attemptsLeft - 1,
+                                                            completion: completion)
+                            }
+                        }
+                    case let .failure(error):
+                        XCTFail("Error updating transfer summary: \(error)")
                 }
             }
         }

--- a/BankSDK/GiniBankSDKExample/Tests/IntegrationTests/TransferSummary/CXTransferSummaryIntegrationTest.swift
+++ b/BankSDK/GiniBankSDKExample/Tests/IntegrationTests/TransferSummary/CXTransferSummaryIntegrationTest.swift
@@ -96,6 +96,8 @@ class CXTransferSummaryIntegrationTest: BaseIntegrationTest {
         }
 
         func giniCaptureAnalysisDidFinishWith(result: AnalysisResult) {
+            /// A callback surviving a timed-out test must not run into the next test.
+            guard !testCase.isTestFinished else { return }
             guard let fixtureContainer = testCase.loadFixtureExtractionsContainer(from: fixtureResultName) else {
                 return
             }
@@ -112,6 +114,9 @@ class CXTransferSummaryIntegrationTest: BaseIntegrationTest {
                     }
                 } ?? [:]
 
+                /// Re-pin the shared document service to this test's own service so the
+                /// feedback can never target another test's document.
+                GiniBankConfiguration.shared.documentService = testCase.giniHelper.giniCaptureSDKDocumentService
                 GiniBankConfiguration.shared.sendTransferSummary(extractions: cxFields)
                 testCase.updateAndVerifyCXTransferSummary(result: result, expect: expect)
             } else {

--- a/BankSDK/GiniBankSDKExample/Tests/IntegrationTests/TransferSummary/SkontoTransferSummaryIntegrationTest.swift
+++ b/BankSDK/GiniBankSDKExample/Tests/IntegrationTests/TransferSummary/SkontoTransferSummaryIntegrationTest.swift
@@ -63,6 +63,8 @@ class BaseSkontoTransferSummaryHandler<TestCase: BaseIntegrationTest>: GiniCaptu
     }
 
     func giniCaptureAnalysisDidFinishWith(result: AnalysisResult) {
+        /// A callback surviving a timed-out test must not run into the next test.
+        guard !testCase.isTestFinished else { return }
         guard let fixtureExtractionsContainer = testCase.loadFixtureExtractionsContainer(from: mockedInvoiceResultName) else {
             return
         }
@@ -94,6 +96,9 @@ class BaseSkontoTransferSummaryHandler<TestCase: BaseIntegrationTest>: GiniCaptu
     func sendTransferSummary(result: AnalysisResult) {
         guard let amountToPayString = result.extractions["amountToPay"]?.value else { return }
         let amountExtraction = createAmountExtraction(value: amountToPayString)
+        /// Re-pin the shared document service to this test's own service so the
+        /// feedback can never target another test's document.
+        GiniBankConfiguration.shared.documentService = testCase.giniHelper.giniCaptureSDKDocumentService
         GiniBankConfiguration.shared.sendTransferSummaryWithSkonto(amountToPayExtraction: amountExtraction,
                                                                    amountToPayString: amountToPayString)
     }
@@ -103,19 +108,24 @@ class BaseSkontoTransferSummaryHandler<TestCase: BaseIntegrationTest>: GiniCaptu
     func updateAndVerifyTransferSummary(result: AnalysisResult,
                                         mockedInvoiceUpdatedResultName: String,
                                         expect: XCTestExpectation) {
-        DispatchQueue.main.asyncAfter(deadline: .now() + 10) { [weak self] in
+        guard let document = result.document else {
+            XCTFail("Analysis result has no document to verify the transfer summary against")
+            return
+        }
+        guard let expectedAmountToPay = result.extractions["amountToPay"]?.value else {
+            XCTFail("Analysis result has no amountToPay to poll the transfer summary with")
+            return
+        }
+
+        /// Poll until the fed-back `amountToPay` is visible instead of sleeping a
+        /// fixed 10 seconds — a slow backend made the fixed delay assert stale values.
+        testCase.pollUpdatedExtractions(for: document,
+                                        expectedAmountToPay: expectedAmountToPay) { [weak self] extractionResult in
             guard let self = self else { return }
-            self.testCase.getUpdatedExtractionsFromGiniBankSDK(for: result.document!) { updatedResult in
-                switch updatedResult {
-                case let .success(extractionResult):
-                    self.handleSuccessfulTransferSummary(extractionResult: extractionResult,
-                                                         mockedInvoiceUpdatedResultName: mockedInvoiceUpdatedResultName,
-                                                         expect: expect,
-                                                         result: result)
-                case let .failure(error):
-                    XCTFail("Error updating transfer summary: \(error)")
-                }
-            }
+            self.handleSuccessfulTransferSummary(extractionResult: extractionResult,
+                                                 mockedInvoiceUpdatedResultName: mockedInvoiceUpdatedResultName,
+                                                 expect: expect,
+                                                 result: result)
         }
     }
 

--- a/BankSDK/GiniBankSDKExample/Tests/IntegrationTests/TransferSummary/TransferSummaryIntegrationTest.swift
+++ b/BankSDK/GiniBankSDKExample/Tests/IntegrationTests/TransferSummary/TransferSummaryIntegrationTest.swift
@@ -60,6 +60,8 @@ class TransferSummaryIntegrationTest: BaseIntegrationTest {
         }
 
         func giniCaptureAnalysisDidFinishWith(result: AnalysisResult) {
+            /// A callback surviving a timed-out test must not run into the next test.
+            guard !testCase.isTestFinished else { return }
             sentTransferSummary(result: result)
             let mockedInvoice = mockedInvoiceResultName
             // Use the helper method to load the fixture extractions container
@@ -85,6 +87,9 @@ class TransferSummaryIntegrationTest: BaseIntegrationTest {
             }
             /// Override `amountToPay` with the confirmed test value to guarantee the "value:currency" format.
             extractions["amountToPay"] = ExtractionAmount(value: 950.00, currency: .EUR).formattedString()
+            /// Re-pin the shared document service to this test's own service so the
+            /// feedback can never target another test's document.
+            GiniBankConfiguration.shared.documentService = testCase.giniHelper.giniCaptureSDKDocumentService
             GiniBankConfiguration.shared.sendTransferSummary(extractions: extractions)
         }
         func giniCaptureDidCancelAnalysis() {

--- a/specs/PP-2263-feature.md
+++ b/specs/PP-2263-feature.md
@@ -1,0 +1,264 @@
+# PP-2263: [iOS] Remove compound extractions for Credit Note feature
+
+Status: implemented
+Ticket: https://ginis.atlassian.net/browse/PP-2263
+
+## Problem
+
+When the Gini Bank API marks an analyzed document as a credit note
+(`businessDocType == "creditnote"`), the iOS SDK already suppresses the
+Return Assistant and Skonto screens *when the credit-note warning sheet is
+shown*, and removes `amountToPay` from the delivered extractions. However,
+the compound extractions (`lineItems`, `skontoDiscounts`) and
+`returnReasons` are still delivered to the host app via `AnalysisResult`,
+still stored on `giniBankConfiguration.lineItems` / `.skontoDiscounts`, and
+a Skonto transfer summary is still sent. (When the credit-note hint is
+disabled — globally or by client configuration — the document flows through
+the normal path; that path is deliberately out of scope here.)
+
+Per the decision in PP-2257 (comment by Demis, 2026-01-09), compound
+extractions must be removed for credit notes on iOS, matching the Android
+implementation where removing the compound extractions is what prevents the
+RA/Skonto screens from showing.
+
+Decision from clarifying questions (this session, revised): stripping
+applies only when the document is a credit note **and** the credit-note
+hint is enabled (global `creditNoteHintEnabled` AND client configuration
+`creditNoteHintEnabled` both true) — i.e. exactly when the credit-note
+warning sheet is shown, matching the PP-2257 option "remove the compound
+extractions if we show the credit note warning". With the hint disabled,
+the flow is unchanged (compound extractions delivered, RA/Skonto screens
+can show). `amountToPay` removal keeps its current trigger (only on
+"Proceed" from the warning sheet) — that behavior is explicitly unchanged.
+
+## Requirements
+
+- R1 (MUST, entry): Given the SDK analyzes a document, the extraction
+  result contains an extraction named `businessDocType` with value
+  `creditnote` (case-insensitive), and the credit-note hint is enabled
+  (global `creditNoteHintEnabled` AND client configuration
+  `creditNoteHintEnabled` both true), when
+  `GiniBankNetworkingScreenApiCoordinator.presentNextScreen(extractionResult:delegate:)`
+  runs, then the credit-note warning sheet is shown and the extraction
+  result used for subsequent delivery has `lineItems == nil`,
+  `skontoDiscounts == nil`, and `returnReasons == nil`, while `extractions`
+  and `candidates` are unchanged.
+- R2 (MUST, happy): Given a credit-note extraction result (hint enabled)
+  that also contains non-empty `lineItems` and `skontoDiscounts`, and
+  `returnAssistantEnabled` and `skontoEnabled` are both true, when the user
+  taps "Proceed" on the warning sheet, then neither the Return Assistant
+  (digital invoice) screen nor the Skonto screen is presented, and the
+  `AnalysisResult` passed to
+  `GiniCaptureResultsDelegate.giniCaptureAnalysisDidFinishWith(result:)` has
+  `lineItems == nil` and `skontoDiscounts == nil`.
+- R3 (MUST, happy): Given a credit-note document with the credit-note hint
+  enabled, when the user taps "Proceed" on the credit-note warning sheet,
+  then the delivered extractions additionally exclude `amountToPay`
+  (existing behavior, must not regress).
+- R4 (MUST, error/negative): Given a credit-note document with the
+  credit-note hint disabled (either flag false), when analysis completes,
+  then no warning sheet is shown and the flow is byte-for-byte today's
+  behavior: `amountToPay`, `lineItems`, `skontoDiscounts`, and
+  `returnReasons` are all delivered unmodified, and the Return Assistant /
+  Skonto screens can show per their own gates.
+- R5 (MUST, happy): Given a credit-note extraction result (hint enabled)
+  with `skontoDiscounts` present, when the result is delivered after
+  "Proceed", then `giniBankConfiguration.skontoDiscounts` and
+  `giniBankConfiguration.lineItems` are not populated with the stripped
+  values and no Skonto transfer summary
+  (`sendTransferSummaryWithSkonto`) is sent (follows from R1: the delivery
+  code reads these fields off the already-stripped result).
+- R6 (MUST, error/negative): Given an extraction result whose
+  `businessDocType` is absent, empty, or any value other than `creditnote`
+  (case-insensitive), when `presentNextScreen` runs, then `lineItems`,
+  `skontoDiscounts`, and `returnReasons` pass through unmodified and the
+  Return Assistant / Skonto flows behave exactly as today.
+- R7 (SHOULD, happy): Given a cross-border payment flow
+  (`productTag == .cxExtractions`), when the extraction result arrives, then
+  the existing cross-border early-return in `presentNextScreen` keeps
+  precedence over credit-note handling (order of checks unchanged).
+
+## Affected modules
+
+- **GiniBankSDK** (iOS 15+) — only module with code changes:
+  `BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/GiniBankNetworkingScreenApiCoordinator.swift`
+  and its test file.
+- **GiniBankAPILibrary**, **GiniCaptureSDK** — read-only dependencies
+  (`ExtractionResult`, `CreditNoteWarningViewController`); no changes.
+
+## Public API impact
+
+None. All touched declarations are `internal`/`private` members of
+`GiniBankNetworkingScreenApiCoordinator`
+(`presentNextScreen`, `shouldProceedWithCreditNote`, `excludingAmountToPay`,
+new helper). No `public`/`open` declaration changes, no signature changes to
+`ExtractionResult` or `AnalysisResult`. Behavior change only in what data
+those existing types carry for credit-note documents (documented in the
+changelog, not an API break).
+
+## Technical conventions
+
+1. **Language/access**: Swift; new helper is `internal` (placed in the
+   existing `internal extension GiniBankNetworkingScreenApiCoordinator`
+   alongside `excludingAmountToPay`, `GiniBankNetworkingScreenApiCoordinator.swift:715-826`,
+   so tests can call it via `@testable import`). Doc comments `/** ... */`
+   on the new helper declaration, `///` for inline notes, per AGENTS.md.
+2. **UI**: none — no new views, no color/font/spacing/localization work.
+   `CreditNoteWarningViewController` (CaptureSDK) is reused untouched.
+3. **Architecture**: no new coordinator/view model — this is flow logic
+   inside the existing `GiniBankNetworkingScreenApiCoordinator` (matches the
+   precedent of `excludingAmountToPay` and the `shouldShow*` helpers living
+   there). MVVM+Coordinator unaffected.
+4. **Wiring**: no DI changes; no new async — the touched methods are the
+   existing `@MainActor` `presentNextScreen` path and pure synchronous
+   helpers, matching neighboring code.
+5. **Localization**: no new strings.
+6. **Quality gates**: `make lint scheme=GiniBankSDK` clean; multi-parameter
+   calls/inits use one-parameter-per-line per CLAUDE.md. Tests follow the
+   module's dominant framework — **XCTest** (the file being extended,
+   `NetworkingScreenApiCoordinatorTests.swift`, is XCTest).
+
+## Design
+
+All changes in
+`BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/GiniBankNetworkingScreenApiCoordinator.swift`.
+
+1. **New helper** in the `internal extension` (next to
+   `excludingAmountToPay(from:)`, currently lines 800-807):
+
+   ```swift
+   /**
+    Returns a copy of the extraction result with the compound extractions
+    removed (`lineItems`, `skontoDiscounts`) together with `returnReasons`.
+    Used for credit-note documents (PP-2263): without compound extractions
+    the Return Assistant and Skonto flows are never triggered and the host
+    app never receives them.
+    */
+   func excludingCompoundExtractions(from extractionResult: ExtractionResult) -> ExtractionResult {
+       ExtractionResult(extractions: extractionResult.extractions,
+                        lineItems: nil,
+                        returnReasons: nil,
+                        skontoDiscounts: nil,
+                        candidates: extractionResult.candidates)
+   }
+   ```
+
+   Mirrors the `excludingAmountToPay` precedent (pure function, new
+   instance). Like that precedent, `crossBorderPayment` is not carried over;
+   that is safe because the cross-border flow returns before this point
+   (R7). `ExtractionResult` init is
+   `BankAPILibrary/.../Documents/ExtractionResult.swift:44-58`.
+
+2. **Strip inside the credit-note branch of `presentNextScreen`**
+   (currently lines 547-556). The branch condition stays
+   `shouldProceedWithCreditNote(extractionResult)` (credit note detected
+   AND hint enabled, line 577-579) — the gate is unchanged. Only the
+   "Proceed" completion changes: chain the new helper with the existing
+   `amountToPay` filter before delivery:
+
+   ```swift
+   if shouldProceedWithCreditNote(extractionResult) {
+       presentDocumentMarkedAsCreditNoteBottomSheet(extractionResult) { [weak self] in
+           guard let self else { return }
+           let strippedResult = self.excludingCompoundExtractions(from: extractionResult)
+           let filteredResult = self.excludingAmountToPay(from: strippedResult)
+           self.presentTransactionDocsAlert(extractionResult: filteredResult,
+                                            delegate: delegate)
+       }
+       return
+   }
+   ```
+
+   Warn-and-proceed delivers extractions minus `amountToPay` minus
+   compounds (R2, R3). Every other path — hint disabled, non-credit-note —
+   is untouched code (R4, R6). With compounds nil,
+   `shouldShowReturnAssistant` (line 788) and `shouldShowSkonto` (line 794)
+   stay false for the delivered result; the credit-note branch already
+   bypasses those screens by going straight to
+   `presentTransactionDocsAlert`.
+
+4. **Delivery**: no changes needed. `deliverWithReturnAssistant`
+   (lines 627-664) reads `result.lineItems`/`result.skontoDiscounts` —
+   nil after stripping, so `AnalysisResult` carries nil,
+   `giniBankConfiguration.lineItems/skontoDiscounts` get nil, and
+   `sendSkontoTransferSummary` (guarded by `if let skontoDiscounts`) is not
+   called (R5).
+
+## Test plan
+
+Extend the existing
+`BankSDK/GiniBankSDK/Tests/GiniBankSDKTests/NetworkingScreenApiCoordinatorTests.swift`
+(XCTest — matches the file's framework; it already has
+`makeCoordinatorAndService()`, `createExtractionResult(...)`,
+`createMockLineItems()`, `createMockSkontoDiscounts()` helpers to reuse).
+No new test class. ~6 new tests:
+
+| Test | Proves |
+|---|---|
+| `testExcludingCompoundExtractionsRemovesLineItemsSkontoDiscountsAndReturnReasons` | R1 — all three fields nil after helper |
+| `testExcludingCompoundExtractionsKeepsExtractionsAndCandidates` | R1 — flat extractions (incl. `amountToPay`) and candidates untouched |
+| `testShouldShowReturnAssistantFalseAfterExcludingCompoundExtractions` | R2 — RA gate false on stripped result even with `returnAssistantEnabled = true` and lineItems originally present |
+| `testShouldShowSkontoFalseAfterExcludingCompoundExtractions` | R2 — Skonto gate false on stripped result even with `skontoEnabled = true` |
+| `testExcludingAmountToPayOnStrippedResultRemovesAmountToPay` | R3 — chaining both helpers removes `amountToPay` AND compounds (extends existing `testExcludingAmountToPayExtractionResultCreditNote`) |
+| `testNonCreditNoteResultKeepsCompoundExtractions` | R6 — a result with `businessDocType == "invoice"` is not stripped by the flow decision (`isDocumentMarkedAsCreditNote` false ⇒ no strip) |
+
+Where the outcome is data, assertions compare against the specific fixture
+values fed in via `createExtractionResult` (e.g. the mock line items /
+skonto discounts built by the existing helpers), not just nil/non-nil where
+a hardcoded return could pass.
+
+### Not tested
+
+- `presentNextScreen` end-to-end (sheet presentation, delegate delivery):
+  requires a live navigation stack + capture UI; the class's existing tests
+  also stop at helper level. The branching itself is a one-line ternary
+  exercised indirectly by the helper tests. Left to manual QA: scan a
+  credit-note document with hint enabled/disabled and verify no RA/Skonto
+  screen and no compound extractions in the example app's result screen.
+- `CreditNoteWarningViewController` (unchanged CaptureSDK code).
+- R5 (no transfer summary): follows structurally from nil
+  `skontoDiscounts` (guard in `deliverWithSkonto`/`deliverWithReturnAssistant`);
+  asserting it would need a full delivery harness that doesn't exist today.
+- R7: order of checks is unchanged code, covered by review.
+
+## Out of scope
+
+- Android — already implemented there; this ticket only aligns iOS.
+- Changing WHEN the credit-note warning sheet shows (hint flags logic
+  `determineIfCreditNoteHintEnabled` stays as is).
+- Hint-disabled credit-note documents: they keep today's normal flow,
+  including compound extraction delivery and RA/Skonto screens (decision
+  revised in this session with the assignee).
+- Changing `amountToPay` removal semantics (stays tied to
+  warning-sheet "Proceed").
+- `crossBorderPayment` compound extractions and the cross-border flow.
+- Any `ExtractionResult` / `AnalysisResult` API changes.
+- UI tests / Page Objects.
+- HealthSDK — credit-note handling exists only in GiniBankSDK.
+
+## Open questions
+
+None — strip scope (lineItems + skontoDiscounts + returnReasons), trigger
+(only when the credit-note warning is shown, i.e. `businessDocType ==
+creditnote` AND both hint flags enabled), and test scope (unit only) were
+settled with the assignee in this session.
+
+## Implementation plan
+- [x] 1. Add the 6 tests from the test plan to
+  `BankSDK/GiniBankSDK/Tests/GiniBankSDKTests/NetworkingScreenApiCoordinatorTests.swift`
+  (XCTest, reuse existing helpers) (requirements R1, R2, R3, R6)
+- [x] 2. Add `excludingCompoundExtractions(from:)` helper to the internal
+  extension in `GiniBankNetworkingScreenApiCoordinator.swift` (requirement R1)
+- [x] 3. Chain the helper into the credit-note "Proceed" completion in
+  `presentNextScreen` (requirements R1, R2, R3, R5; R4/R6/R7 by leaving
+  other paths untouched)
+
+Note (verification): fixed two pre-existing test-target failures unrelated
+to this feature, both blocking the `GiniBankSDKTests` run on this branch:
+1. `RemoteConfigPropagationTests.swift` was missing the
+   `creditNoteHintEnabled` argument of the `ClientConfiguration`
+   initializer (compile error).
+2. `GiniBankConfigurationTests.swift` property-count guard was stale
+   (expected 65, actual 67); `creditNoteHintEnabled` — the only stored
+   property added since the guard was written — already has default-value
+   and toggle tests in that suite, so only the count was updated.


### PR DESCRIPTION
## Pull Request Description

Credit-note documents must not trigger the Return Assistant or Skonto flows, and the host app must not receive compound extractions for them. When the credit-note warning sheet is shown and the user proceeds, the extraction result is now stripped of `lineItems`, `skontoDiscounts` and `returnReasons` (in addition to the existing `amountToPay` filtering), matching the Android implementation.

[PP-2263]

How:

- `BankSDK`: new `excludingCompoundExtractions(from:)` helper in `GiniBankNetworkingScreenApiCoordinator`, applied together with the existing `excludingAmountToPay(from:)` in the credit-note proceed flow. Stripping happens only when the credit-note warning sheet is shown; the hint-disabled flow is unchanged.
- `BankAPILibrary`: no production change — added a decoding test with a credit-note fixture (`extractionsContainerCreditNote.json`, no compound extractions) verifying extractions, candidates and nil compound extractions/return reasons.
- `GiniBankSDKExample`: credentials are now resolved per selected credentials set and API environment; the environment choice is persisted and credentials are reapplied when the environment changes (adds `stage_client_id`/`stage_client_password` placeholder keys to `Credentials.plist`).
- `specs/PP-2263-feature.md`: feature spec for the change.

## Notes for Reviewers

- Unit tests added:
  - `ExtractionsContainerTest.testCreditNoteExtractionsDecoding` (BankAPILibrary) — verified passing on iPhone 17 Pro simulator, iOS 26.2.
  - `NetworkingScreenApiCoordinatorTests` (BankSDK) — coverage for the stripping helper, its interaction with the `amountToPay` filter and the credit-note feature gates.
- Test scenario: analyze a document whose extractions contain `businessDocType = CreditNote` with the credit-note hint enabled (SDK config + client config). Proceed from the warning sheet — the delivered extraction result must contain no `lineItems`, `skontoDiscounts` or `returnReasons`, and no `amountToPay`. With the hint disabled, the result is unchanged.


[PP-2263]: https://ginis.atlassian.net/browse/PP-2263?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ