### PR TITLE
ci: Inject real credentials in TestFlight example app builds

### DIFF
--- a/.github/workflows/bank-sdk.publish.example.app.testflight.yml
+++ b/.github/workflows/bank-sdk.publish.example.app.testflight.yml
@@ -41,6 +41,8 @@ jobs:
       bundle_identifier: 'net.gini.banksdk.example'
       bundle_identifier_extension: 'net.gini.banksdk.example.ShareExtension'
       ipa_name: 'GiniBankSDKExample'
+      credentials_plist_path: 'BankSDK/GiniBankSDKExample/GiniBankSDKExample/Credentials.plist'
+      google_services_plist_path: 'BankSDK/GiniBankSDKExample/GoogleService-Info.plist'
     secrets:
       MATCH_GIT_URL: ${{ secrets.MATCH_GIT_URL }}
       MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
@@ -48,3 +50,6 @@ jobs:
       APP_STORE_CONNECT_API_KEY: ${{ secrets.APP_STORE_CONNECT_API_KEY_BASE64}}
       APP_STORE_API_KEY_ID: ${{ secrets.APP_STORE_API_KEY_ID }}
       APP_STORE_API_KEY_ISSUER_ID: ${{ secrets.APP_STORE_API_KEY_ISSUER_ID }}
+      FIREBASE_API_KEY: ${{ secrets.FIREBASE_API_KEY }}
+      GINI_MOBILE_CI_USERNAME: ${{ secrets.GINI_MOBILE_CI_USERNAME }}
+      GINI_MOBILE_CI_PASSWORD: ${{ secrets.GINI_MOBILE_CI_PASSWORD }}

--- a/.github/workflows/health-sdk.publish.example.app.testflight.yml
+++ b/.github/workflows/health-sdk.publish.example.app.testflight.yml
@@ -40,6 +40,8 @@ jobs:
       scheme: 'GiniHealthSDKExample'
       bundle_identifier: 'net.gini.healthsdk.example'
       ipa_name: 'GiniHealthSDKExample'
+      credentials_manager_path: 'HealthSDK/GiniHealthSDKExample/GiniHealthSDKExample/CredentialsManager.swift'
+      google_services_plist_path: 'HealthSDK/GiniHealthSDKExample/GoogleService-Info.plist'
     secrets:
       MATCH_GIT_URL: ${{ secrets.MATCH_GIT_URL }}
       MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
@@ -47,3 +49,6 @@ jobs:
       APP_STORE_CONNECT_API_KEY: ${{ secrets.APP_STORE_CONNECT_API_KEY_BASE64}}
       APP_STORE_API_KEY_ID: ${{ secrets.APP_STORE_API_KEY_ID }}
       APP_STORE_API_KEY_ISSUER_ID: ${{ secrets.APP_STORE_API_KEY_ISSUER_ID }}
+      FIREBASE_API_KEY: ${{ secrets.FIREBASE_API_KEY }}
+      GINI_MOBILE_CI_USERNAME: ${{ secrets.GINI_MOBILE_CI_USERNAME }}
+      GINI_MOBILE_CI_PASSWORD: ${{ secrets.GINI_MOBILE_CI_PASSWORD }}

--- a/.github/workflows/publish.example.app.testflight.yml
+++ b/.github/workflows/publish.example.app.testflight.yml
@@ -50,6 +50,21 @@ on:
         required: false
         default: 'JA825X8F7Z'
         type: string
+      credentials_plist_path:
+        description: 'Relative path to a Credentials.plist to inject Gini client credentials into (plutil style, e.g. BankSDK example)'
+        required: false
+        default: ''
+        type: string
+      credentials_manager_path:
+        description: 'Relative path to a CredentialsManager.swift to inject Gini client credentials into (sed style, e.g. HealthSDK example)'
+        required: false
+        default: ''
+        type: string
+      google_services_plist_path:
+        description: 'Relative path to the GoogleService-Info.plist whose placeholder API_KEY must be replaced before archiving'
+        required: false
+        default: ''
+        type: string
     secrets:
       MATCH_GIT_URL:
         required: true
@@ -63,6 +78,12 @@ on:
         required: true
       APP_STORE_API_KEY_ISSUER_ID:
         required: true
+      FIREBASE_API_KEY:
+        required: false
+      GINI_MOBILE_CI_USERNAME:
+        required: false
+      GINI_MOBILE_CI_PASSWORD:
+        required: false
 
 jobs:
   upload-testflight:
@@ -100,6 +121,45 @@ jobs:
           # step then re-signs with the AppStore profiles above). Extension targets sign
           # with AppStore profiles in Release, so they are excluded here on purpose.
           DISTRIBUTION_TYPE=adhoc APP_IDENTIFIER=${{ inputs.bundle_identifier }} bundle exec fastlane download_profiles
+
+      - name: Setup Credentials (plist)
+        if: inputs.credentials_plist_path != ''
+        env:
+          TEST_CLIENT_ID: ${{ secrets.GINI_MOBILE_CI_USERNAME }}
+          TEST_CLIENT_SECRET: ${{ secrets.GINI_MOBILE_CI_PASSWORD }}
+        run: |
+          if [ -z "$TEST_CLIENT_ID" ] || [ -z "$TEST_CLIENT_SECRET" ]; then
+            echo "GINI_MOBILE_CI_USERNAME/GINI_MOBILE_CI_PASSWORD secrets are empty — refusing to ship placeholder credentials" >&2
+            exit 1
+          fi
+          plutil -replace client_id -string "$TEST_CLIENT_ID" "${{ inputs.credentials_plist_path }}"
+          plutil -replace client_password -string "$TEST_CLIENT_SECRET" "${{ inputs.credentials_plist_path }}"
+
+      - name: Setup Credentials (CredentialsManager.swift)
+        if: inputs.credentials_manager_path != ''
+        env:
+          TEST_CLIENT_ID: ${{ secrets.GINI_MOBILE_CI_USERNAME }}
+          TEST_CLIENT_SECRET: ${{ secrets.GINI_MOBILE_CI_PASSWORD }}
+        run: |
+          if [ -z "$TEST_CLIENT_ID" ] || [ -z "$TEST_CLIENT_SECRET" ]; then
+            echo "GINI_MOBILE_CI_USERNAME/GINI_MOBILE_CI_PASSWORD secrets are empty — refusing to ship placeholder credentials" >&2
+            exit 1
+          fi
+          sed -i '' \
+          -e "s/clientID = \"client_id\"/clientID = \"$TEST_CLIENT_ID\"/" \
+          -e "s/clientPassword = \"client_password\"/clientPassword = \"$TEST_CLIENT_SECRET\"/" \
+          "${{ inputs.credentials_manager_path }}"
+
+      - name: Setup Firebase API Key
+        if: inputs.google_services_plist_path != ''
+        env:
+          FIREBASE_API_KEY: ${{ secrets.FIREBASE_API_KEY }}
+        run: |
+          if [ -z "$FIREBASE_API_KEY" ]; then
+            echo "FIREBASE_API_KEY secret is empty — refusing to ship placeholder API key (app would crash at launch)" >&2
+            exit 1
+          fi
+          plutil -replace API_KEY -string "$FIREBASE_API_KEY" "${{ inputs.google_services_plist_path }}"
 
       - name: Archive Xcode Project
         run: |

--- a/BankSDK/GiniBankSDKExample/GiniBankSDKExample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/BankSDK/GiniBankSDKExample/GiniBankSDKExample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -2,12 +2,138 @@
   "object": {
     "pins": [
       {
+        "package": "abseil",
+        "repositoryURL": "https://github.com/google/abseil-cpp-binary.git",
+        "state": {
+          "branch": null,
+          "revision": "bbe8b69694d7873315fd3a4ad41efe043e1c07c5",
+          "version": "1.2024072200.0"
+        }
+      },
+      {
+        "package": "AppCheck",
+        "repositoryURL": "https://github.com/google/app-check.git",
+        "state": {
+          "branch": null,
+          "revision": "bb4002485ff867768dec13bf904a2ddb050bd1b1",
+          "version": "11.3.0"
+        }
+      },
+      {
+        "package": "Firebase",
+        "repositoryURL": "https://github.com/firebase/firebase-ios-sdk.git",
+        "state": {
+          "branch": null,
+          "revision": "b9bf3adac18e6e3059167194aeb632f15a5ba4b2",
+          "version": "12.1.0"
+        }
+      },
+      {
+        "package": "GoogleAdsOnDeviceConversion",
+        "repositoryURL": "https://github.com/googleads/google-ads-on-device-conversion-ios-sdk",
+        "state": {
+          "branch": null,
+          "revision": "e15f979c3eaf477d24e5bfec9d87f1d76fbac297",
+          "version": "2.2.0"
+        }
+      },
+      {
+        "package": "GoogleAppMeasurement",
+        "repositoryURL": "https://github.com/google/GoogleAppMeasurement.git",
+        "state": {
+          "branch": null,
+          "revision": "883305109ead4599e4ca59591754ee72e81e6b5e",
+          "version": "12.1.0"
+        }
+      },
+      {
+        "package": "GoogleDataTransport",
+        "repositoryURL": "https://github.com/google/GoogleDataTransport.git",
+        "state": {
+          "branch": null,
+          "revision": "617af071af9aa1d6a091d59a202910ac482128f9",
+          "version": "10.1.0"
+        }
+      },
+      {
+        "package": "GoogleUtilities",
+        "repositoryURL": "https://github.com/google/GoogleUtilities.git",
+        "state": {
+          "branch": null,
+          "revision": "9f183ae842be978784f2963a343682e0c46d8fb3",
+          "version": "8.1.2"
+        }
+      },
+      {
+        "package": "gRPC",
+        "repositoryURL": "https://github.com/google/grpc-binary.git",
+        "state": {
+          "branch": null,
+          "revision": "75b31c842f664a0f46a2e590a570e370249fd8f6",
+          "version": "1.69.1"
+        }
+      },
+      {
+        "package": "GTMSessionFetcher",
+        "repositoryURL": "https://github.com/google/gtm-session-fetcher.git",
+        "state": {
+          "branch": null,
+          "revision": "c0ac7575d70050c2973ba2318bd5af47f8e8153a",
+          "version": "5.3.0"
+        }
+      },
+      {
+        "package": "InteropForGoogle",
+        "repositoryURL": "https://github.com/google/interop-ios-for-google-sdks.git",
+        "state": {
+          "branch": null,
+          "revision": "040d087ac2267d2ddd4cca36c757d1c6a05fdbfe",
+          "version": "101.0.0"
+        }
+      },
+      {
+        "package": "leveldb",
+        "repositoryURL": "https://github.com/firebase/leveldb.git",
+        "state": {
+          "branch": null,
+          "revision": "a0bc79961d7be727d258d33d5a6b2f1023270ba1",
+          "version": "1.22.5"
+        }
+      },
+      {
         "package": "Lottie",
         "repositoryURL": "https://github.com/airbnb/lottie-ios.git",
         "state": {
           "branch": null,
-          "revision": "b4bd0604ded9574807f41b4004b57dd1226a30a4",
-          "version": "3.5.0"
+          "revision": "d6feea26a370019b4d3a85f5984cb95a2734776f",
+          "version": "4.2.0"
+        }
+      },
+      {
+        "package": "nanopb",
+        "repositoryURL": "https://github.com/firebase/nanopb.git",
+        "state": {
+          "branch": null,
+          "revision": "3851d94a41890dea16dc3db34caf60e585cb4163",
+          "version": "2.30910.1"
+        }
+      },
+      {
+        "package": "Promises",
+        "repositoryURL": "https://github.com/google/promises.git",
+        "state": {
+          "branch": null,
+          "revision": "f4a19a3c313dc2616c70bb49d29a799fb16be837",
+          "version": "2.4.1"
+        }
+      },
+      {
+        "package": "SwiftProtobuf",
+        "repositoryURL": "https://github.com/apple/swift-protobuf.git",
+        "state": {
+          "branch": null,
+          "revision": "55d7a1cc5666b85c13464aea1c4b4a90feccb4c8",
+          "version": "1.38.1"
         }
       }
     ]


### PR DESCRIPTION
## Pull Request Description

TestFlight builds of the example apps crashed at launch: the committed `GoogleService-Info.plist` ships a placeholder `API_KEY` (`&quot;&quot;`), and `FirebaseApp.configure()` in the AppDelegate raises an `NSException` when the key fails format validation. The Firebase App Distribution workflows replace the placeholder before archiving, but the TestFlight workflow never did — the IPA shipped with the placeholder. The Gini client credentials had the same gap, so document upload would have failed after launch.

This PR mirrors the Firebase workflows' injection steps into the reusable TestFlight workflow:

- `publish.example.app.testflight.yml` gains three optional inputs — `credentials_plist_path` (plutil style, Bank), `credentials_manager_path` (sed style, Health), and `google_services_plist_path` — plus the `FIREBASE_API_KEY` / `GINI_MOBILE_CI_USERNAME` / `GINI_MOBILE_CI_PASSWORD` secrets. Each injection step runs before archiving and fails fast if its secret is empty, so a misconfigured pipeline can no longer silently ship a crashing build.
- The Bank and Health callers pass their respective paths and secrets. CX credentials are intentionally not injected in TestFlight builds.
- Also updates the workspace `Package.resolved`.

## Notes for Reviewers

- Injection commands, paths, and placeholder patterns are copied from the working Firebase workflows (`bank-sdk.publish.example.app.firebase.yml`, `health-sdk.publish.example.apps.firebase.yml`) and verified against the committed placeholder files.
- All secrets referenced already exist in the repo (used by the Firebase workflows), so no new secret setup is needed.
- To verify end-to-end: trigger the Bank or Health TestFlight workflow via `workflow_dispatch` and confirm the resulting build launches without the Firebase `NSException`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)