### PR TITLE
refactor: XPL-130 – Drop dead iOS <15 SSLPinningManager fallbacks

### DIFF
--- a/HealthAPILibrary/GiniHealthAPILibrary/Sources/GiniHealthAPILibrary/Documents/Core/SSLPinning/SSLPinningManager.swift
+++ b/HealthAPILibrary/GiniHealthAPILibrary/Sources/GiniHealthAPILibrary/Documents/Core/SSLPinning/SSLPinningManager.swift
@@ -7,7 +7,6 @@
 
 import CryptoKit
 import Foundation
-import CommonCrypto
 
 struct SSLPinningManager {
     // Custom error types for SSL pinning
@@ -105,37 +104,16 @@ private extension SSLPinningManager {
     }
 }
 
-//MARK: - private methods for capability with old ios versions
-
 private extension SSLPinningManager {
     func trustCopyPublicKey(_ trust: SecTrust) -> SecKey? {
-        if #available(iOS 14, *) {
-            return SecTrustCopyKey(trust)
-        } else {
-            return SecTrustCopyPublicKey(trust)
-        }
+        SecTrustCopyKey(trust)
     }
-    
+
     func trustCopyCertificateChain(_ trust: SecTrust) -> [SecCertificate]? {
-        if #available(iOS 15, *) {
-            return (SecTrustCopyCertificateChain(trust) as? [SecCertificate])
-        } else {
-            return (0..<SecTrustGetCertificateCount(trust)).compactMap { index in
-                SecTrustGetCertificateAtIndex(trust, index)
-            }
-        }
+        SecTrustCopyCertificateChain(trust) as? [SecCertificate]
     }
 
     func sha256(data: Data) -> Data {
-        if #available(iOS 13.0, *) {
-            return Data(SHA256.hash(data: data))
-        } else {
-            //code to support ios < 13, import CommonCrypto should be removed with this code
-            var hash = [UInt8](repeating: 0,  count: Int(CC_SHA256_DIGEST_LENGTH))
-            data.withUnsafeBytes { buffer in
-                _ = CC_SHA256(buffer.baseAddress!, CC_LONG(buffer.count), &hash)
-            }
-            return Data(hash)
-        }
+        Data(SHA256.hash(data: data))
     }
 }

--- a/HealthSDK/GiniHealthSDK/Sources/GiniHealthSDK/Core/SSLPinning/SSLPinningManager.swift
+++ b/HealthSDK/GiniHealthSDK/Sources/GiniHealthSDK/Core/SSLPinning/SSLPinningManager.swift
@@ -7,7 +7,6 @@
 
 import CryptoKit
 import Foundation
-import CommonCrypto
 
 struct SSLPinningManager {
     // Custom error types for SSL pinning
@@ -105,36 +104,16 @@ private extension SSLPinningManager {
     }
 }
 
-//MARK: - private methods for capability with old ios versions
-
 private extension SSLPinningManager {
     func trustCopyPublicKey(_ trust: SecTrust) -> SecKey? {
-        if #available(iOS 14, macOS 11, tvOS 14, watchOS 7, visionOS 1, *) {
-            return SecTrustCopyKey(trust)
-        } else {
-            return SecTrustCopyPublicKey(trust)
-        }
+        SecTrustCopyKey(trust)
     }
 
     func trustCopyCertificateChain(_ trust: SecTrust) -> [SecCertificate]? {
-        if #available(iOS 15, macOS 11, tvOS 14, watchOS 7, visionOS 1, *) {
-            return (SecTrustCopyCertificateChain(trust) as? [SecCertificate])
-        } else {
-            return (0..<SecTrustGetCertificateCount(trust)).compactMap { index in
-                SecTrustGetCertificateAtIndex(trust, index)
-            }
-        }
+        SecTrustCopyCertificateChain(trust) as? [SecCertificate]
     }
 
     func sha256(data: Data) -> Data {
-        if #available(iOS 13.0, macOS 10.15, watchOS 6.0, tvOS 13.0, *) {
-            return Data(SHA256.hash(data: data))
-        } else {
-            var hash = [UInt8](repeating: 0,  count: Int(CC_SHA256_DIGEST_LENGTH))
-            data.withUnsafeBytes { buffer in
-                _ = CC_SHA256(buffer.baseAddress!, CC_LONG(buffer.count), &hash)
-            }
-            return Data(hash)
-        }
+        Data(SHA256.hash(data: data))
     }
 }


### PR DESCRIPTION
## Pull Request Description

<!-- Briefly explain **what** this PR does and **why**. Mention the motivation, feature, or issue it's addressing. -->

Removes unreachable pre-iOS-15 fallbacks from `SSLPinningManager.swift` in `GiniHealthAPILibrary` and `GiniHealthSDK`. Minimum deployment targets are iOS 15 (BankAPILibrary) / iOS 17 (HealthSDK & HealthAPILibrary), so the guards for iOS 13 (`CommonCrypto` SHA-256), iOS 14 (`SecTrustCopyPublicKey`), and iOS 15 (per-index certificate-chain enumeration) can never execute. The `import CommonCrypto` goes away with the last fallback. BankAPILibrary already shipped this shape — the two Health copies now match it.

[XPL-130](https://ginis.atlassian.net/browse/XPL-130)<!-- Closes ticket number PP-####; Replace with JIRA ticket if relevant -->

<!--

Some description of HOW you achieved it. Perhaps give a high level description of the chnages you did. Did you need to refactor something? What tradeoffs did you take?

-->

Context on the underlying [CodeQL alert #237](https://github.com/gini/gini-mobile-ios/security/code-scanning/237) (`swift/weak-password-hashing`): the alert is a **false positive**. CodeQL's dataflow taints `SecKeyCopyExternalRepresentation` as a password source and flags the SHA-256 hash on the returned data, but the hashed data is the server's SubjectPublicKeyInfo used for TLS certificate pinning (RFC 7469 `pin-sha256`) — no credential ever flows into `sha256(data:)`. SHA-256 is the correct algorithm for SPKI pinning; a password-hashing KDF (bcrypt/scrypt/Argon2) would be wrong here. Alert #237 will be dismissed as *false positive* out-of-band with that justification.

## Notes for Reviewers

<!--

Explain how you verified the changes.
A clear testing scenario helps colleagues who may not be familiar with this part of the code quickly understand and verify the changes. Include steps they can follow to see the impact in action.

You can include: 
- Simulators/Devices you used (e.g. iPhone 13, iPad Pro) 
- iOS versions tested (e.g. 16.0, 17.5) 
- Manual checks (e.g. flow tested: onboarding, permissions, error states) 
- Unit tests added or updated 
 
 Include screenshots, screen recordings, or simulator gifs for UI changes. 
 
 - Optional: Anything that needs extra attention in review? Are there TODOs, known limitations, or follow-up work? 
 
 -->

- Behaviour-preserving: on iOS 15+ the removed branches were already unreachable — the retained code paths are byte-for-byte what was already executing at runtime.
- Diff is confined to `HealthAPILibrary/.../SSLPinningManager.swift` and `HealthSDK/.../SSLPinningManager.swift`; no public API touched.
- `BankAPILibrary/GiniBankAPILibrary/Sources/GiniBankAPILibrary/SSLPinning/SSLPinningManager.swift` already had this shape — this PR aligns the other two copies with it.
- Verification: SPM builds for `GiniHealthAPILibrary`, `GiniHealthSDK`, and the `GiniHealthSDKExample` scheme; existing SSL-pinning tests continue to pass.
- Follow-up: dismiss CodeQL alert #237 as *false positive* with the SPKI-pinning justification above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[XPL-130]: https://ginis.atlassian.net/browse/XPL-130?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ