### PR TITLE
refactor(GiniBankSDK): Fix SonarQube issues

### DIFF
--- a/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/GiniBankUtils.swift
+++ b/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/GiniBankUtils.swift
@@ -40,6 +40,35 @@ func NSLocalizedStringPreferredGiniBankFormat(_ key: String,
     return giniLocalizedString(key, fallbackKey: fallbackKey, comment: comment)
 }
 
+/**
+ Returns a localized string resource preferably from the client's bundle.
+
+ This is a convenience wrapper around `NSLocalizedStringPreferredGiniBankFormat`
+ to simplify localization calls throughout the app.
+
+ - parameter key:          The key to search for in the strings file.
+ - parameter fallback:     An optional fallback key to use if the primary key is not found. Default is empty string.
+ - parameter comment:      The corresponding comment describing the usage context.
+ - parameter customizable: Whether to check client bundles for custom localizations. Default is true.
+
+ - returns: Localized string resource for the given key.
+
+ ## Example Usage:
+ ```swift
+ let text = localized("ginibank.digitalinvoice.onboarding.text1",
+ comment: "RA onboarding screen first label")
+ ```
+ */
+internal func giniLocalized(_ key: String,
+                            fallback: String = "",
+                            comment: String = "",
+                            customizable: Bool = true) -> String {
+    return NSLocalizedStringPreferredGiniBankFormat(key,
+                                                    fallbackKey: fallback,
+                                                    comment: comment,
+                                                    isCustomizable: customizable)
+}
+
 private func clientLocalizedString(_ key: String,
                                    fallbackKey: String,
                                    comment: String,

--- a/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/GiniBankUtils.swift
+++ b/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/GiniBankUtils.swift
@@ -55,8 +55,8 @@ func NSLocalizedStringPreferredGiniBankFormat(_ key: String,
 
  ## Example Usage:
  ```swift
- let text = localized("ginibank.digitalinvoice.onboarding.text1",
- comment: "RA onboarding screen first label")
+ let text = giniLocalized("ginibank.digitalinvoice.onboarding.text1",
+                          comment: "RA onboarding screen first label")
  ```
  */
 internal func giniLocalized(_ key: String,

--- a/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/GiniBankUtils.swift
+++ b/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/GiniBankUtils.swift
@@ -59,10 +59,10 @@ func NSLocalizedStringPreferredGiniBankFormat(_ key: String,
                           comment: "RA onboarding screen first label")
  ```
  */
-internal func giniLocalized(_ key: String,
-                            fallback: String = "",
-                            comment: String = "",
-                            customizable: Bool = true) -> String {
+func giniLocalized(_ key: String,
+                   fallback: String = "",
+                   comment: String = "",
+                   customizable: Bool = true) -> String {
     return NSLocalizedStringPreferredGiniBankFormat(key,
                                                     fallbackKey: fallback,
                                                     comment: comment,

--- a/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/ReturnAssistant/DigitalInvoice/Components/DigitalInvoiceSkontoTableViewCell.swift
+++ b/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/ReturnAssistant/DigitalInvoice/Components/DigitalInvoiceSkontoTableViewCell.swift
@@ -13,6 +13,8 @@ protocol DigitalInvoiceSkontoTableViewCellDelegate: AnyObject {
 }
 
 class DigitalInvoiceSkontoTableViewCell: UITableViewCell {
+    static let reuseIdentifier = "DigitalInvoiceSkontoTableViewCell"
+
     private var viewModel: SkontoViewModel?
 
     weak var delegate: DigitalInvoiceSkontoTableViewCellDelegate?

--- a/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/ReturnAssistant/DigitalInvoice/DigitalInvoiceViewController.swift
+++ b/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/ReturnAssistant/DigitalInvoice/DigitalInvoiceViewController.swift
@@ -333,67 +333,98 @@ extension DigitalInvoiceViewController: UITableViewDelegate, UITableViewDataSour
     // MARK: - UITableViewDataSource
 
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        switch Section(rawValue: section) {
-        case .titleCell: return 1
-        case .lineItems: return viewModel.invoice?.lineItems.count ?? 0
-        case .addOns: return 1
-        case .skonto: return viewModel.hasSkonto ? 1 : 0
-        default: fatalError()
+        guard let sectionType = Section(rawValue: section) else {
+            assertionFailure("Unexpected section index \(section)")
+            return 0
+        }
+        switch sectionType {
+        case .titleCell, .addOns:
+            return 1
+        case .lineItems:
+            return viewModel.invoice?.lineItems.count ?? 0
+        case .skonto:
+            return viewModel.hasSkonto ? 1 : 0
         }
     }
 
     func tableView(_ tableView: UITableView,
                    cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        switch Section(rawValue: indexPath.section) {
-        case .titleCell:
-            let cellIdentifier = DigitalInvoiceTableViewTitleCell.reuseIdentifier
-            if let cell = tableView.dequeueReusableCell(withIdentifier: cellIdentifier,
-                                                        for: indexPath) as? DigitalInvoiceTableViewTitleCell {
-                return cell
-            }
+        guard let sectionType = Section(rawValue: indexPath.section) else {
+            assertionFailure("Unexpected section index \(indexPath.section)")
             return UITableViewCell()
-        case .lineItems:
+        }
 
-            if let cell = tableView.dequeueReusableCell(withIdentifier: DigitalLineItemTableViewCell.reuseIdentifier,
-                                                        for: indexPath) as? DigitalLineItemTableViewCell {
-                if let invoice = viewModel.invoice {
-                    let maxCharactersCount = Constants.nameMaxCharactersCount
-                    cell.viewModel = DigitalLineItemTableViewCellViewModel(lineItem: invoice.lineItems[indexPath.row],
-                                                                           indexPath: indexPath,
-                                                                           invoiceNumTotal: invoice.numTotal,
-                                                                           invoiceLineItemsCount:
-                                                                           invoice.lineItems.count,
-                                                                           nameMaxCharactersCount: maxCharactersCount)
-                }
-                cell.delegate = self
-                return cell
-            }
+        switch sectionType {
+        case .titleCell:
+            return configureTitleCell(tableView: tableView, indexPath: indexPath)
+        case .lineItems:
+            return configureLineItemCell(tableView: tableView, indexPath: indexPath)
+        case .addOns:
+            return configureAddOnCell(tableView: tableView, indexPath: indexPath)
+        case .skonto:
+            return configureSkontoCell(tableView: tableView, indexPath: indexPath)
+        }
+    }
+
+    // MARK: - Cell Configuration Methods
+
+    private func configureTitleCell(tableView: UITableView, indexPath: IndexPath) -> UITableViewCell {
+        let cellIdentifier = DigitalInvoiceTableViewTitleCell.reuseIdentifier
+        guard let cell = tableView.dequeueReusableCell(withIdentifier: cellIdentifier,
+                                                       for: indexPath) as? DigitalInvoiceTableViewTitleCell else {
+            return UITableViewCell()
+        }
+        return cell
+    }
+
+    private func configureLineItemCell(tableView: UITableView, indexPath: IndexPath) -> UITableViewCell {
+        guard let cell = tableView.dequeueReusableCell(withIdentifier: DigitalLineItemTableViewCell.reuseIdentifier,
+                                                       for: indexPath) as? DigitalLineItemTableViewCell else {
             assertionFailure("DigitalLineItemTableViewCell could not been reused")
             return UITableViewCell()
-        case .addOns:
-            if let cell = tableView.dequeueReusableCell(withIdentifier: DigitalInvoiceAddOnListCell.reuseIdentifier,
-                                                        for: indexPath) as? DigitalInvoiceAddOnListCell {
-                cell.addOns = viewModel.invoice?.addons
-                if viewModel.skontoViewModel == nil {
-                    cell.configureAsBottomTableCell()
-                }
-                return cell
-            }
+        }
+
+        if let invoice = viewModel.invoice {
+            let maxCharactersCount = Constants.nameMaxCharactersCount
+            cell.viewModel = DigitalLineItemTableViewCellViewModel(lineItem: invoice.lineItems[indexPath.row],
+                                                                   indexPath: indexPath,
+                                                                   invoiceNumTotal: invoice.numTotal,
+                                                                   invoiceLineItemsCount: invoice.lineItems.count,
+                                                                   nameMaxCharactersCount: maxCharactersCount)
+        }
+        cell.delegate = self
+        return cell
+    }
+
+    private func configureAddOnCell(tableView: UITableView, indexPath: IndexPath) -> UITableViewCell {
+        guard let cell = tableView.dequeueReusableCell(withIdentifier: DigitalInvoiceAddOnListCell.reuseIdentifier,
+                                                       for: indexPath) as? DigitalInvoiceAddOnListCell else {
             assertionFailure("DigitalInvoiceAddOnListCell could not been reused")
             return UITableViewCell()
-        case .skonto:
-            guard let skontoViewModel = viewModel.skontoViewModel else { return UITableViewCell() }
-            let cell = tableView.dequeueReusableCell(withIdentifier: "DigitalInvoiceSkontoTableViewCell",
-                                                     for: indexPath)
-            if let cell = cell as? DigitalInvoiceSkontoTableViewCell {
-                cell.delegate = self
-                cell.configure(with: skontoViewModel)
-                return cell
-            }
+        }
+
+        cell.addOns = viewModel.invoice?.addons
+        if viewModel.skontoViewModel == nil {
+            cell.configureAsBottomTableCell()
+        }
+        return cell
+    }
+
+    private func configureSkontoCell(tableView: UITableView, indexPath: IndexPath) -> UITableViewCell {
+        guard let skontoViewModel = viewModel.skontoViewModel else {
+            return UITableViewCell()
+        }
+
+        let cell = tableView.dequeueReusableCell(withIdentifier: "DigitalInvoiceSkontoTableViewCell",
+                                                 for: indexPath)
+        guard let skontoCell = cell as? DigitalInvoiceSkontoTableViewCell else {
             assertionFailure("SkontoTableViewCell could not been reused")
             return UITableViewCell()
-        default: fatalError()
         }
+
+        skontoCell.delegate = self
+        skontoCell.configure(with: skontoViewModel)
+        return skontoCell
     }
 }
 

--- a/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/ReturnAssistant/DigitalInvoice/DigitalInvoiceViewController.swift
+++ b/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/ReturnAssistant/DigitalInvoice/DigitalInvoiceViewController.swift
@@ -26,7 +26,7 @@ final class DigitalInvoiceViewController: UIViewController {
         tableView.register(DigitalInvoiceAddOnListCell.self,
                            forCellReuseIdentifier: DigitalInvoiceAddOnListCell.reuseIdentifier)
         tableView.register(DigitalInvoiceSkontoTableViewCell.self,
-                           forCellReuseIdentifier: "DigitalInvoiceSkontoTableViewCell")
+                           forCellReuseIdentifier: DigitalInvoiceSkontoTableViewCell.reuseIdentifier)
         tableView.separatorStyle = .none
         tableView.backgroundColor = .clear
         tableView.showsVerticalScrollIndicator = false
@@ -420,7 +420,7 @@ extension DigitalInvoiceViewController: UITableViewDelegate, UITableViewDataSour
             return UITableViewCell()
         }
 
-        let cell = tableView.dequeueReusableCell(withIdentifier: "DigitalInvoiceSkontoTableViewCell",
+        let cell = tableView.dequeueReusableCell(withIdentifier: DigitalInvoiceSkontoTableViewCell.reuseIdentifier,
                                                  for: indexPath)
         guard let skontoCell = cell as? DigitalInvoiceSkontoTableViewCell else {
             assertionFailure("SkontoTableViewCell could not be reused")

--- a/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/ReturnAssistant/DigitalInvoice/DigitalInvoiceViewController.swift
+++ b/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/ReturnAssistant/DigitalInvoice/DigitalInvoiceViewController.swift
@@ -368,19 +368,22 @@ extension DigitalInvoiceViewController: UITableViewDelegate, UITableViewDataSour
 
     // MARK: - Cell Configuration Methods
 
-    private func configureTitleCell(tableView: UITableView, indexPath: IndexPath) -> UITableViewCell {
+    private func configureTitleCell(tableView: UITableView,
+                                    indexPath: IndexPath) -> UITableViewCell {
         let cellIdentifier = DigitalInvoiceTableViewTitleCell.reuseIdentifier
         guard let cell = tableView.dequeueReusableCell(withIdentifier: cellIdentifier,
                                                        for: indexPath) as? DigitalInvoiceTableViewTitleCell else {
+            assertionFailure("DigitalInvoiceTableViewTitleCell could not be reused")
             return UITableViewCell()
         }
         return cell
     }
 
-    private func configureLineItemCell(tableView: UITableView, indexPath: IndexPath) -> UITableViewCell {
+    private func configureLineItemCell(tableView: UITableView,
+                                       indexPath: IndexPath) -> UITableViewCell {
         guard let cell = tableView.dequeueReusableCell(withIdentifier: DigitalLineItemTableViewCell.reuseIdentifier,
                                                        for: indexPath) as? DigitalLineItemTableViewCell else {
-            assertionFailure("DigitalLineItemTableViewCell could not been reused")
+            assertionFailure("DigitalLineItemTableViewCell could not be reused")
             return UITableViewCell()
         }
 
@@ -396,10 +399,11 @@ extension DigitalInvoiceViewController: UITableViewDelegate, UITableViewDataSour
         return cell
     }
 
-    private func configureAddOnCell(tableView: UITableView, indexPath: IndexPath) -> UITableViewCell {
+    private func configureAddOnCell(tableView: UITableView,
+                                    indexPath: IndexPath) -> UITableViewCell {
         guard let cell = tableView.dequeueReusableCell(withIdentifier: DigitalInvoiceAddOnListCell.reuseIdentifier,
                                                        for: indexPath) as? DigitalInvoiceAddOnListCell else {
-            assertionFailure("DigitalInvoiceAddOnListCell could not been reused")
+            assertionFailure("DigitalInvoiceAddOnListCell could not be reused")
             return UITableViewCell()
         }
 
@@ -410,7 +414,8 @@ extension DigitalInvoiceViewController: UITableViewDelegate, UITableViewDataSour
         return cell
     }
 
-    private func configureSkontoCell(tableView: UITableView, indexPath: IndexPath) -> UITableViewCell {
+    private func configureSkontoCell(tableView: UITableView,
+                                     indexPath: IndexPath) -> UITableViewCell {
         guard let skontoViewModel = viewModel.skontoViewModel else {
             return UITableViewCell()
         }
@@ -418,7 +423,7 @@ extension DigitalInvoiceViewController: UITableViewDelegate, UITableViewDataSour
         let cell = tableView.dequeueReusableCell(withIdentifier: "DigitalInvoiceSkontoTableViewCell",
                                                  for: indexPath)
         guard let skontoCell = cell as? DigitalInvoiceSkontoTableViewCell else {
-            assertionFailure("SkontoTableViewCell could not been reused")
+            assertionFailure("SkontoTableViewCell could not be reused")
             return UITableViewCell()
         }
 

--- a/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/ReturnAssistant/DigitalInvoice/Models/LineItem.swift
+++ b/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/ReturnAssistant/DigitalInvoice/Models/LineItem.swift
@@ -87,14 +87,9 @@ extension DigitalInvoice {
                 switch key {
                 case .description:
                     extraction.value = name ?? ""
+                    
                 case .quantity:
-
-                    switch selectedState {
-                    case .selected:
-                        extraction.value =  String(quantity)
-                    case .deselected:
-                        extraction.value = "0"
-                    }
+                    extraction.value = (selectedState == .selected ? String(quantity) : "0")
 
                 case .baseGross:
                     extraction.value = price.extractionString

--- a/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/ReturnAssistant/EditLineItem/Components/PriceLabelView.swift
+++ b/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/ReturnAssistant/EditLineItem/Components/PriceLabelView.swift
@@ -161,37 +161,34 @@ extension PriceLabelView: UITextFieldDelegate {
                    shouldChangeCharactersIn range: NSRange,
                    replacementString string: String) -> Bool {
 
-        if let text = textField.text, let textRange = Range(range, in: text) {
-            let updatedText = text.replacingCharacters(in: textRange, with: string)
+        // Ensure the updated string can build
+        guard let text = textField.text,
+              let textRange = Range(range, in: text) else {
+            return true
+        }
 
-            // Limit length to 7 digits
-            let onlyDigits = String(updatedText
-                .trimmingCharacters(in: .whitespaces)
-                .filter { c in c != "," && c != "."}
-                .prefix(7))
+        // Build updated raw text and normalize to (max 7) digits only
+        let updated = text.replacingCharacters(in: textRange, with: string)
+        let digits = AmountInput.digitsOnlyCapped(updated)
 
-            if let decimal = Decimal(string: onlyDigits) {
-                let decimalWithFraction = decimal / 100
-
-                if let newAmount = Price.stringWithoutSymbol(from: decimalWithFraction)?
-                                        .trimmingCharacters(in: .whitespaces) {
-                    // Save the selected text range to restore the cursor position after replacing the text
-                    let selectedRange = textField.selectedTextRange
-
-                    textField.text = newAmount
-
-                    delegate?.priceLabelViewTextFieldDidChange(on: self)
-                    // Move the cursor position after the inserted character
-                    if let selectedRange = selectedRange {
-                        let countDelta = newAmount.count - text.count
-                        let offset = countDelta == 0 ? 1 : countDelta
-                        textField.moveSelectedTextRange(from: selectedRange.start, to: offset)
-                    }
-                }
-            }
+        // Format as price (xx -> 0.xx, 12345 -> 123.45)
+        guard let formatted = AmountInput.format(digits) else {
+            // Block the change if it can't format
             return false
         }
-        return true
+
+        // Preserve cursor relative position after replacing text
+        let priorSelection = textField.selectedTextRange
+        textField.text = formatted
+        delegate?.priceLabelViewTextFieldDidChange(on: self)
+
+        if let priorSelection = priorSelection {
+            let delta = formatted.count - text.count
+            let offset = (delta == 0) ? 1 : delta
+            textField.moveSelectedTextRange(from: priorSelection.start, to: offset)
+        }
+
+        return false
     }
 
     func textFieldDidBeginEditing(_ textField: UITextField) {
@@ -200,9 +197,24 @@ extension PriceLabelView: UITextFieldDelegate {
 }
 
 private extension PriceLabelView {
-    enum Constants {
+    struct Constants {
         static let cornerRadius: CGFloat = 8
         static let padding: CGFloat = 12
         static let textFieldTopPadding: CGFloat = 0
+    }
+
+    struct AmountInput {
+        static let maxDigits = 7
+
+        static func digitsOnlyCapped(_ s: String) -> String {
+            let digits = s.unicodeScalars.filter(CharacterSet.decimalDigits.contains)
+            return String(digits.prefix(maxDigits))
+        }
+
+        static func format(_ centsDigits: String) -> String? {
+            guard let cents = Decimal(string: centsDigits) else { return nil }
+            let amount = cents / 100
+            return Price.stringWithoutSymbol(from: amount)?.trimmingCharacters(in: .whitespaces)
+        }
     }
 }

--- a/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/ReturnAssistant/EditLineItem/Components/PriceLabelView.swift
+++ b/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/ReturnAssistant/EditLineItem/Components/PriceLabelView.swift
@@ -161,23 +161,23 @@ extension PriceLabelView: UITextFieldDelegate {
                    shouldChangeCharactersIn range: NSRange,
                    replacementString string: String) -> Bool {
 
-        // Ensure the updated string can build
+        /// Ensure the updated string can build
         guard let text = textField.text,
               let textRange = Range(range, in: text) else {
             return true
         }
 
-        // Build updated raw text and normalize to (max 7) digits only
+        /// Build updated raw text and normalize to (max 7) digits only
         let updated = text.replacingCharacters(in: textRange, with: string)
         let digits = AmountInput.digitsOnlyCapped(updated)
 
-        // Format as price (xx -> 0.xx, 12345 -> 123.45)
+        /// Format as price (xx -> 0.xx, 12345 -> 123.45)
         guard let formatted = AmountInput.format(digits) else {
-            // Block the change if it can't format
+            /// Block the change if it can't format
             return false
         }
 
-        // Preserve cursor relative position after replacing text
+        /// Preserve cursor relative position after replacing text
         let priorSelection = textField.selectedTextRange
         textField.text = formatted
         delegate?.priceLabelViewTextFieldDidChange(on: self)

--- a/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/ReturnAssistant/Help/DigitalInvoiceHelpViewModel.swift
+++ b/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/ReturnAssistant/Help/DigitalInvoiceHelpViewModel.swift
@@ -17,27 +17,35 @@ struct DigitalInvoiceHelpViewModel {
     let helpSections: [DigitalInvoiceHelpSection]
 
     init() {
-        let firstHelpSection = DigitalInvoiceHelpSection(
-            icon: prefferedImage(named: "help_icon_1"),
-            title: NSLocalizedStringPreferredGiniBankFormat("ginibank.digitalinvoice.help.title1",
-                                                            comment: "help title"),
-            description: NSLocalizedStringPreferredGiniBankFormat("ginibank.digitalinvoice.help.description1",
-                                                                  comment: "help description"))
+        let firstHelpSection = DigitalInvoiceHelpSection(icon: prefferedImage(named: "help_icon_1"),
+                                                         title: Strings.firstHelpSectionTitle,
+                                                         description: Strings.firstHelpSectionDescription)
 
-        let secondHelpSection = DigitalInvoiceHelpSection(
-            icon: prefferedImage(named: "help_icon_2"),
-            title: NSLocalizedStringPreferredGiniBankFormat("ginibank.digitalinvoice.help.title2",
-                                                            comment: "help title"),
-            description: NSLocalizedStringPreferredGiniBankFormat("ginibank.digitalinvoice.help.description2",
-                                                                  comment: "help description"))
+        let secondHelpSection = DigitalInvoiceHelpSection(icon: prefferedImage(named: "help_icon_2"),
+                                                          title: Strings.secondHelpSectionTitle,
+                                                          description: Strings.secondHelpSectionDescription)
 
-        let thirdHelpSection = DigitalInvoiceHelpSection(
-            icon: prefferedImage(named: "help_icon_3"),
-            title: NSLocalizedStringPreferredGiniBankFormat("ginibank.digitalinvoice.help.title3",
-                                                            comment: "help title"),
-            description: NSLocalizedStringPreferredGiniBankFormat("ginibank.digitalinvoice.help.description3",
-                                                                  comment: "help description"))
+        let thirdHelpSection = DigitalInvoiceHelpSection(icon: prefferedImage(named: "help_icon_3"),
+                                                         title: Strings.thirdHelpSectionTitle,
+                                                         description: Strings.thirdHelpSectionDescription)
 
-        self.helpSections = [firstHelpSection, secondHelpSection, thirdHelpSection]
+        helpSections = [firstHelpSection, secondHelpSection, thirdHelpSection]
+    }
+
+    private struct Strings {
+        static let titleComment: String = "help title"
+        static let descriptionComment: String = "help description"
+        static let firstHelpSectionTitle = giniLocalized("ginibank.digitalinvoice.help.title1",
+                                                         comment: Strings.titleComment)
+        static let firstHelpSectionDescription = giniLocalized("ginibank.digitalinvoice.help.description1",
+                                                               comment: Strings.descriptionComment)
+        static let secondHelpSectionTitle = giniLocalized("ginibank.digitalinvoice.help.title2",
+                                                          comment: Strings.titleComment)
+        static let secondHelpSectionDescription = giniLocalized("ginibank.digitalinvoice.help.description2",
+                                                                comment: Strings.descriptionComment)
+        static let thirdHelpSectionTitle = giniLocalized("ginibank.digitalinvoice.help.title3",
+                                                         comment: Strings.titleComment)
+        static let thirdHelpSectionDescription = giniLocalized("ginibank.digitalinvoice.help.description3",
+                                                               comment: Strings.descriptionComment)
     }
 }

--- a/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/ReturnAssistant/Onboarding/DigitalInvoiceOnboardingViewController.swift
+++ b/BankSDK/GiniBankSDK/Sources/GiniBankSDK/Core/ReturnAssistant/Onboarding/DigitalInvoiceOnboardingViewController.swift
@@ -40,21 +40,6 @@ final class DigitalInvoiceOnboardingViewController: UIViewController {
         return prefferedImage(named: "digital_invoice_onboarding_icon") ?? UIImage()
     }
 
-    private var firstLabelText: String {
-        return  NSLocalizedStringPreferredGiniBankFormat("ginibank.digitalinvoice.onboarding.text1",
-                                                         comment: "title for digital invoice onboarding screen")
-    }
-
-    private var secondLabelText: String {
-        return NSLocalizedStringPreferredGiniBankFormat("ginibank.digitalinvoice.onboarding.text2",
-                                                        comment: "title for digital invoice onboarding screen")
-    }
-
-    private var doneButtonTitle: String {
-        return NSLocalizedStringPreferredGiniBankFormat("ginibank.digitalinvoice.onboarding.getStartedButton",
-                                                        comment: "title for digital invoice onboarding screen")
-    }
-
     private var doneButtonTapped: Bool = false
 
     override public func viewDidLoad() {
@@ -129,20 +114,20 @@ final class DigitalInvoiceOnboardingViewController: UIViewController {
             topImageView.icon = topImage
         }
         topImageView.isAccessibilityElement = true
-        topImageView.accessibilityValue = firstLabelText
+        topImageView.accessibilityValue = Strings.firstLabelText
         topImageView.accessibilityTraits = .image
         topImageView.setupView()
     }
 
     private func setupFirstLabel(with configuration: GiniBankConfiguration) {
-        firstLabel.text = firstLabelText
+        firstLabel.text = Strings.firstLabelText
         firstLabel.font = configuration.textStyleFonts[.title2Bold]
         firstLabel.textColor = GiniColor(light: .GiniBank.dark1, dark: .GiniBank.light1).uiColor()
         firstLabel.adjustsFontForContentSizeCategory = true
     }
 
     private func setupSecondLabel(with configuration: GiniBankConfiguration) {
-        secondLabel.text = secondLabelText
+        secondLabel.text = Strings.secondLabelText
         secondLabel.font = configuration.textStyleFonts[.subheadline]
         secondLabel.textColor = GiniColor(light: .GiniBank.dark6, dark: .GiniBank.light6).uiColor()
         secondLabel.adjustsFontForContentSizeCategory = true
@@ -150,7 +135,7 @@ final class DigitalInvoiceOnboardingViewController: UIViewController {
 
     private func setupDoneButton(with configuration: GiniBankConfiguration) {
         doneButton.addTarget(self, action: #selector(doneAction(_:)), for: .touchUpInside)
-        doneButton.setTitle(doneButtonTitle, for: .normal)
+        doneButton.setTitle(Strings.doneButtonTitle, for: .normal)
         doneButton.titleLabel?.font = configuration.textStyleFonts[.bodyBold]
         doneButton.titleLabel?.adjustsFontForContentSizeCategory = true
         doneButton.configure(with: configuration.primaryButtonConfiguration)
@@ -276,5 +261,18 @@ extension DigitalInvoiceOnboardingViewController {
 
     func isiPhoneAndLandscape() -> Bool {
         return UIDevice.current.isIphone && view.currentInterfaceOrientation.isLandscape
+    }
+}
+
+private extension DigitalInvoiceOnboardingViewController {
+    struct Strings {
+        static let firstLabelText = giniLocalized("ginibank.digitalinvoice.onboarding.text1",
+                                                  comment: "RA onboarding screen first label")
+
+        static let secondLabelText = giniLocalized("ginibank.digitalinvoice.onboarding.text2",
+                                                   comment: "RA onboarding screen second label")
+
+        static let doneButtonTitle = giniLocalized("ginibank.digitalinvoice.onboarding.getStartedButton",
+                                                   comment: "RA onboarding screen getStartedButton")
     }
 }

--- a/BankSDK/GiniBankSDK/Tests/GiniBankSDKTests/PriceLabelViewInputTests.swift
+++ b/BankSDK/GiniBankSDK/Tests/GiniBankSDKTests/PriceLabelViewInputTests.swift
@@ -1,0 +1,148 @@
+//
+//  PriceLabelViewInputTests.swift
+//
+//  Copyright © 2026 Gini GmbH. All rights reserved.
+//
+
+import Foundation
+import Testing
+import UIKit
+@testable import GiniBankSDK
+
+extension GiniConfigurationSharedStateSuite {
+
+    /**
+     Covers `PriceLabelView`'s `UITextFieldDelegate` amount-input path: digits-only
+     filtering, the seven-digit cap, cents-to-price formatting, the delegate return
+     value, and the `priceLabelViewTextFieldDidChange(on:)` callback delivery.
+
+     Nested in the shared-state suite because `PriceLabelView` reads fonts from
+     `GiniBankConfiguration.shared` during layout.
+     */
+    @Suite("PriceLabelView input")
+    @MainActor
+    struct PriceLabelViewInputTests {
+
+        // MARK: - Insertion
+
+        @Test("A single digit typed into an empty field is formatted as one cent and blocks the system update")
+        func singleDigitInsertsAsCents() {
+            let (view, textField, spy) = makeView(withText: "")
+
+            let handled = view.textField(textField,
+                                         shouldChangeCharactersIn: NSRange(location: 0, length: 0),
+                                         replacementString: "1")
+
+            #expect(handled == false, "The delegate handled the change itself, so it must block the system update")
+            #expect(textField.text == format(Decimal(string: "0.01")!))
+            #expect(spy.changeCount == 1)
+        }
+
+        @Test("Typing five digits builds up as 123.45")
+        func multipleDigitsBuildUpAsCents() {
+            let (view, textField, spy) = makeView(withText: "")
+
+            simulateInput("12345", on: view, into: textField)
+
+            #expect(textField.text == format(Decimal(string: "123.45")!))
+            #expect(spy.changeCount == 5)
+        }
+
+        // MARK: - Seven-digit cap
+
+        @Test("Digits beyond the seven-digit cap are silently dropped")
+        func capsAtSevenDigits() {
+            let (view, textField, spy) = makeView(withText: "")
+
+            simulateInput("99999999", on: view, into: textField)
+
+            #expect(textField.text == format(Decimal(string: "99999.99")!),
+                    "Only the first seven digits should shape the amount")
+            #expect(spy.changeCount == 8,
+                    "Every attempted change still notifies the delegate, even when the formatted value is unchanged")
+        }
+
+        // MARK: - Invalid input
+
+        @Test("Non-digit characters are stripped before formatting")
+        func nonDigitsAreFilteredOut() {
+            let (view, textField, _) = makeView(withText: "")
+
+            simulateInput("1a2b3c", on: view, into: textField)
+
+            #expect(textField.text == format(Decimal(string: "1.23")!))
+        }
+
+        // MARK: - Deletion
+
+        @Test("Deleting the trailing digit shifts the cents one place down")
+        func deletionShiftsCentsDown() throws {
+            let (view, textField, _) = makeView(withText: "")
+            simulateInput("12345", on: view, into: textField)
+
+            let currentText = try #require(textField.text)
+            let range = NSRange(location: currentText.count - 1, length: 1)
+            _ = view.textField(textField,
+                               shouldChangeCharactersIn: range,
+                               replacementString: "")
+
+            #expect(textField.text == format(Decimal(string: "12.34")!))
+        }
+
+        // MARK: - Delegate callback count
+
+        @Test("The delegate is notified exactly once per accepted change")
+        func delegateFiresOncePerAcceptedChange() {
+            let (view, textField, spy) = makeView(withText: format(Decimal(string: "0.01")!))
+
+            let currentText = textField.text ?? ""
+            _ = view.textField(textField,
+                               shouldChangeCharactersIn: NSRange(location: currentText.count, length: 0),
+                               replacementString: "5")
+
+            #expect(spy.changeCount == 1)
+        }
+
+        // MARK: - Helpers
+
+        private func makeView(withText text: String?) -> (PriceLabelView,
+                                                          UITextField,
+                                                          PriceLabelViewDelegateSpy) {
+            let view = PriceLabelView(frame: .zero)
+            let spy = PriceLabelViewDelegateSpy()
+            view.delegate = spy
+            let textField = UITextField()
+            textField.text = text
+            return (view, textField, spy)
+        }
+
+        private func simulateInput(_ input: String,
+                                   on view: PriceLabelView,
+                                   into textField: UITextField) {
+            for character in input {
+                let currentText = textField.text ?? ""
+                let range = NSRange(location: currentText.count, length: 0)
+                _ = view.textField(textField,
+                                   shouldChangeCharactersIn: range,
+                                   replacementString: String(character))
+            }
+        }
+
+        private func format(_ value: Decimal) -> String {
+            Price.stringWithoutSymbol(from: value) ?? ""
+        }
+    }
+}
+
+private final class PriceLabelViewDelegateSpy: PriceLabelViewDelegate {
+    var changeCount = 0
+    var showCurrencyPickerCount = 0
+
+    func priceLabelViewTextFieldDidChange(on: PriceLabelView) {
+        changeCount += 1
+    }
+
+    func showCurrencyPicker(on view: UIView) {
+        showCurrencyPickerCount += 1
+    }
+}

--- a/BankSDK/GiniBankSDK/Tests/GiniBankSDKTests/PriceLabelViewInputTests.swift
+++ b/BankSDK/GiniBankSDK/Tests/GiniBankSDKTests/PriceLabelViewInputTests.swift
@@ -26,7 +26,7 @@ extension GiniConfigurationSharedStateSuite {
         // MARK: - Insertion
 
         @Test("A single digit typed into an empty field is formatted as one cent and blocks the system update")
-        func singleDigitInsertsAsCents() {
+        func singleDigitInsertsAsCents() throws {
             let (view, textField, spy) = makeView(withText: "")
 
             let handled = view.textField(textField,
@@ -34,29 +34,29 @@ extension GiniConfigurationSharedStateSuite {
                                          replacementString: "1")
 
             #expect(handled == false, "The delegate handled the change itself, so it must block the system update")
-            #expect(textField.text == format(Decimal(string: "0.01")!))
+            #expect(textField.text == (try format("0.01")))
             #expect(spy.changeCount == 1)
         }
 
         @Test("Typing five digits builds up as 123.45")
-        func multipleDigitsBuildUpAsCents() {
+        func multipleDigitsBuildUpAsCents() throws {
             let (view, textField, spy) = makeView(withText: "")
 
             simulateInput("12345", on: view, into: textField)
 
-            #expect(textField.text == format(Decimal(string: "123.45")!))
+            #expect(textField.text == (try format("123.45")))
             #expect(spy.changeCount == 5)
         }
 
         // MARK: - Seven-digit cap
 
         @Test("Digits beyond the seven-digit cap are silently dropped")
-        func capsAtSevenDigits() {
+        func capsAtSevenDigits() throws {
             let (view, textField, spy) = makeView(withText: "")
 
             simulateInput("99999999", on: view, into: textField)
 
-            #expect(textField.text == format(Decimal(string: "99999.99")!),
+            #expect(textField.text == (try format("99999.99")),
                     "Only the first seven digits should shape the amount")
             #expect(spy.changeCount == 8,
                     "Every attempted change still notifies the delegate, even when the formatted value is unchanged")
@@ -65,12 +65,12 @@ extension GiniConfigurationSharedStateSuite {
         // MARK: - Invalid input
 
         @Test("Non-digit characters are stripped before formatting")
-        func nonDigitsAreFilteredOut() {
+        func nonDigitsAreFilteredOut() throws {
             let (view, textField, _) = makeView(withText: "")
 
             simulateInput("1a2b3c", on: view, into: textField)
 
-            #expect(textField.text == format(Decimal(string: "1.23")!))
+            #expect(textField.text == (try format("1.23")))
         }
 
         // MARK: - Deletion
@@ -86,14 +86,14 @@ extension GiniConfigurationSharedStateSuite {
                                shouldChangeCharactersIn: range,
                                replacementString: "")
 
-            #expect(textField.text == format(Decimal(string: "12.34")!))
+            #expect(textField.text == (try format("12.34")))
         }
 
         // MARK: - Delegate callback count
 
         @Test("The delegate is notified exactly once per accepted change")
-        func delegateFiresOncePerAcceptedChange() {
-            let (view, textField, spy) = makeView(withText: format(Decimal(string: "0.01")!))
+        func delegateFiresOncePerAcceptedChange() throws {
+            let (view, textField, spy) = makeView(withText: try format("0.01"))
 
             let currentText = textField.text ?? ""
             _ = view.textField(textField,
@@ -128,8 +128,11 @@ extension GiniConfigurationSharedStateSuite {
             }
         }
 
-        private func format(_ value: Decimal) -> String {
-            Price.stringWithoutSymbol(from: value) ?? ""
+        private func format(_ decimalString: String) throws -> String {
+            let value = try #require(Decimal(string: decimalString),
+                                     "Test fixture '\(decimalString)' is not a valid Decimal")
+            return try #require(Price.stringWithoutSymbol(from: value),
+                                "Price.stringWithoutSymbol should format the fixture")
         }
     }
 }

--- a/BankSDK/GiniBankSDKExample/GiniBankSDKExample/DocumentAnalysisHelper.swift
+++ b/BankSDK/GiniBankSDKExample/GiniBankSDKExample/DocumentAnalysisHelper.swift
@@ -12,7 +12,7 @@ typealias UploadDocumentCompletion = (Result<Document, GiniError>) -> Void
 typealias AnalysisCompletion = (Result<ExtractionResult, GiniError>) -> Void
 
 protocol DocumentAnalysisHelper: AnyObject {
-    
+
     var analysisCancellationToken: CancellationToken? { get set }
     var pay5Parameters: [String] { get }
 
@@ -34,15 +34,19 @@ extension DocumentAnalysisHelper {
             case .success(let extractionResult):
                 print("✅ Finished analysis process with no errors")
                 completion(.success(extractionResult))
+
             case .failure(let error):
-                switch error {
-                case .requestCancelled:
-                    print("❌ Cancelled analysis process")
-                default:
-                    print("❌ Finished analysis process with error: \(error)")
-                }
+                self.handleAnalysisError(error)
             }
         }
-        
     }
+
+    private func handleAnalysisError(_ error: GiniError) {
+           switch error {
+           case .requestCancelled:
+               print("❌ Cancelled analysis process")
+           default:
+               print("❌ Finished analysis process with error: \(error)")
+           }
+       }
 }

--- a/BankSDK/GiniBankSDKExample/GiniBankSDKExample/DocumentAnalysisHelper.swift
+++ b/BankSDK/GiniBankSDKExample/GiniBankSDKExample/DocumentAnalysisHelper.swift
@@ -42,11 +42,11 @@ extension DocumentAnalysisHelper {
     }
 
     private func handleAnalysisError(_ error: GiniError) {
-           switch error {
-           case .requestCancelled:
-               print("❌ Cancelled analysis process")
-           default:
-               print("❌ Finished analysis process with error: \(error)")
-           }
-       }
+        switch error {
+        case .requestCancelled:
+            print("❌ Cancelled analysis process")
+        default:
+            print("❌ Finished analysis process with error: \(error)")
+        }
+    }
 }

--- a/BankSDK/GiniBankSDKExample/GiniBankSDKExample/SettingsViewController/SettingsViewController+SwitchOptionModel.swift
+++ b/BankSDK/GiniBankSDKExample/GiniBankSDKExample/SettingsViewController/SettingsViewController+SwitchOptionModel.swift
@@ -177,15 +177,11 @@ struct SwitchOptionModel {
 				return "Show drag and drop tutorial step in Help menu > How to import option."
 			case .onboardingShowAtFirstLaunch:
 				return "Overwrites `Onboarding screens at every launch` for the first launch."
-			case .customOnboardingPages:
-				return "This will work if the `Onboarding show at every launch` switch is also enabled."
-			case .onboardingAlignCornersIllustrationAdapter:
-				return "This will work if the `Onboarding show at every launch` switch is also enabled."
-			case .onboardingLightingIllustrationAdapter:
-				return "This will work if the `Onboarding show at every launch` switch is also enabled."
-			case .onboardingQRCodeIllustrationAdapter:
-				return "This will work if the `Onboarding show at every launch` switch is also enabled."
-			case .onboardingMultiPageIllustrationAdapter:
+            case .customOnboardingPages,
+                    .onboardingAlignCornersIllustrationAdapter,
+                    .onboardingLightingIllustrationAdapter,
+                    .onboardingQRCodeIllustrationAdapter,
+                    .onboardingMultiPageIllustrationAdapter :
 				return "This will work if the `Onboarding show at every launch` switch is also enabled."
 			case .primaryButtonConfiguration:
 				return "Primary button used on different screens, e.g: `Onboarding`, `Digital Invoice Onboarding`, `Error`, etc."

--- a/BankSDK/GiniBankSDKExample/GiniBankSDKExample/SettingsViewController/SettingsViewController+SwitchOptionModel.swift
+++ b/BankSDK/GiniBankSDKExample/GiniBankSDKExample/SettingsViewController/SettingsViewController+SwitchOptionModel.swift
@@ -177,11 +177,11 @@ struct SwitchOptionModel {
 				return "Show drag and drop tutorial step in Help menu > How to import option."
 			case .onboardingShowAtFirstLaunch:
 				return "Overwrites `Onboarding screens at every launch` for the first launch."
-            case .customOnboardingPages,
-                    .onboardingAlignCornersIllustrationAdapter,
-                    .onboardingLightingIllustrationAdapter,
-                    .onboardingQRCodeIllustrationAdapter,
-                    .onboardingMultiPageIllustrationAdapter :
+			case .customOnboardingPages,
+					.onboardingAlignCornersIllustrationAdapter,
+					.onboardingLightingIllustrationAdapter,
+					.onboardingQRCodeIllustrationAdapter,
+					.onboardingMultiPageIllustrationAdapter:
 				return "This will work if the `Onboarding show at every launch` switch is also enabled."
 			case .primaryButtonConfiguration:
 				return "Primary button used on different screens, e.g: `Onboarding`, `Digital Invoice Onboarding`, `Error`, etc."

--- a/BankSDK/GiniBankSDKExample/GiniBankSDKExample/SettingsViewController/SettingsViewController+SwitchOptionModel.swift
+++ b/BankSDK/GiniBankSDKExample/GiniBankSDKExample/SettingsViewController/SettingsViewController+SwitchOptionModel.swift
@@ -178,10 +178,10 @@ struct SwitchOptionModel {
 			case .onboardingShowAtFirstLaunch:
 				return "Overwrites `Onboarding screens at every launch` for the first launch."
 			case .customOnboardingPages,
-					.onboardingAlignCornersIllustrationAdapter,
-					.onboardingLightingIllustrationAdapter,
-					.onboardingQRCodeIllustrationAdapter,
-					.onboardingMultiPageIllustrationAdapter:
+				 .onboardingAlignCornersIllustrationAdapter,
+				 .onboardingLightingIllustrationAdapter,
+				 .onboardingQRCodeIllustrationAdapter,
+				 .onboardingMultiPageIllustrationAdapter:
 				return "This will work if the `Onboarding show at every launch` switch is also enabled."
 			case .primaryButtonConfiguration:
 				return "Primary button used on different screens, e.g: `Onboarding`, `Digital Invoice Onboarding`, `Error`, etc."

--- a/BankSDK/GiniBankSDKExample/GiniBankSDKExampleBank/PaymentViewController.swift
+++ b/BankSDK/GiniBankSDKExample/GiniBankSDKExampleBank/PaymentViewController.swift
@@ -223,38 +223,48 @@ extension PaymentViewController: UITextFieldDelegate {
     }
     
     public func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
-        if TextFieldType(rawValue: textField.tag) == .amountFieldTag,
-           let text = textField.text,
-           let textRange = Range(range, in: text) {
-            let updatedText = text.replacingCharacters(in: textRange, with: string)
-            
-            // Limit length to 7 digits
-            let onlyDigits = String(updatedText
-                                        .trimmingCharacters(in: .whitespaces)
-                                        .filter { c in c != "," && c != "."}
-                                        .prefix(7))
-            
-            if let decimal = Decimal(string: onlyDigits) {
-                let decimalWithFraction = decimal / 100
-                
-                if let newAmount = amountToPay?.stringWithoutSymbol(from: decimalWithFraction)?.trimmingCharacters(in: .whitespaces) {
-                    // Save the selected text range to restore the cursor position after replacing the text
-                    let selectedRange = textField.selectedTextRange
-                    
-                    textField.text = newAmount
-                    amountToPay?.value = decimalWithFraction
-                    
-                    // Move the cursor position after the inserted character
-                    if let selectedRange = selectedRange {
-                        let countDelta = newAmount.count - text.count
-                        let offset = countDelta == 0 ? 1 : countDelta
-                        textField.moveSelectedTextRange(from: selectedRange.start, to: offset)
-                    }
-                }
-            }
-            return false
-           }
-        return true
+
+        // Only handle the amount field
+        guard TextFieldType(rawValue: textField.tag) == .amountFieldTag else { return true }
+
+        // Ensure we can build the updated string
+        guard let oldText = textField.text,
+              let textRange = Range(range, in: oldText) else { return true }
+
+        // Normalize to (max 7) digits
+        let updated = oldText.replacingCharacters(in: textRange, with: string)
+        let digits = AmountInput.digitsOnlyCapped(updated)
+
+        // Format (xx -> 0.xx, 12345 -> 123.45)
+        guard let amount = AmountInput.amount(fromCentsDigits: digits),
+              let formatted = amountToPay?
+            .stringWithoutSymbol(from: amount)?
+            .trimmingCharacters(in: .whitespaces) else { return false }
+
+        // Update UI + model and keep caret position reasonable
+        let priorSelection = textField.selectedTextRange
+        textField.text = formatted
+        amountToPay?.value = amount
+
+        if let prior = priorSelection {
+            let delta = formatted.count - oldText.count
+            let offset = (delta == 0) ? 1 : delta
+            textField.moveSelectedTextRange(from: prior.start, to: offset)
+        }
+
+        return false
+    }
+
+    private struct AmountInput {
+        static let maxDigits = 7
+
+        static func digitsOnlyCapped(_ s: String) -> String {
+            String(s.unicodeScalars.filter(CharacterSet.decimalDigits.contains).prefix(maxDigits))
+        }
+
+        static func amount(fromCentsDigits s: String) -> Decimal? {
+            Decimal(string: s).map { $0 / 100 }
+        }
     }
 }
 
@@ -280,36 +290,52 @@ extension PaymentViewController {
     }
     
     fileprivate func validateTextField(_ textField: UITextField) {
-        if let fieldIdentifier = TextFieldType(rawValue: textField.tag) {
-            switch fieldIdentifier {
+        guard let field = TextFieldType(rawValue: textField.tag) else { return }
+
+        switch field {
             case .ibanFieldTag:
-                if let ibanText = textField.text, textField.hasText {
-                    if IBANValidator().isValid(iban: ibanText) {
-                        hideErrorLabel(textFieldTag: fieldIdentifier)
-                    } else {
-                        showValidationErrorLabel(textFieldTag: fieldIdentifier)
-                    }
-                } else {
-                    showErrorLabel(textFieldTag: fieldIdentifier)
-                }
+                validateIBAN(textField, field)
+
             case .amountFieldTag:
-                if let amountString = amount?.text, !amount.isReallyEmpty {
-                    if let decimalPart = amountToPay?.value, decimalPart > 0 {
-                        hideErrorLabel(textFieldTag: fieldIdentifier)
-                    } else {
-                        amount.text = ""
-                        showErrorLabel(textFieldTag: fieldIdentifier)
-                    }
-                } else {
-                    showErrorLabel(textFieldTag: fieldIdentifier)
-                }
+                validateAmount(field)
+
             case .recipientFieldTag, .usageFieldTag:
-                if textField.hasText && !textField.isReallyEmpty {
-                    hideErrorLabel(textFieldTag: fieldIdentifier)
-                } else {
-                    showErrorLabel(textFieldTag: fieldIdentifier)
-                }
-            }
+                validateNonEmpty(textField, field)
+        }
+    }
+
+    private func validateIBAN(_ textField: UITextField, _ field: TextFieldType) {
+        guard textField.hasText, let iban = textField.text else {
+            showErrorLabel(textFieldTag: field)
+            return
+        }
+
+        if IBANValidator().isValid(iban: iban) {
+            hideErrorLabel(textFieldTag: field)
+        } else {
+            showValidationErrorLabel(textFieldTag: field)
+        }
+    }
+
+    private func validateAmount(_ field: TextFieldType) {
+        guard !amount.isReallyEmpty else {
+            showErrorLabel(textFieldTag: field)
+            return
+        }
+
+        if let value = amountToPay?.value, value > 0 {
+            hideErrorLabel(textFieldTag: field)
+        } else {
+            amount.text = ""
+            showErrorLabel(textFieldTag: field)
+        }
+    }
+
+    private func validateNonEmpty(_ textField: UITextField, _ field: TextFieldType) {
+        if textField.hasText && !textField.isReallyEmpty {
+            hideErrorLabel(textFieldTag: field)
+        } else {
+            showErrorLabel(textFieldTag: field)
         }
     }
 

--- a/BankSDK/GiniBankSDKExample/GiniBankSDKExampleBank/PaymentViewController.swift
+++ b/BankSDK/GiniBankSDKExample/GiniBankSDKExampleBank/PaymentViewController.swift
@@ -224,24 +224,24 @@ extension PaymentViewController: UITextFieldDelegate {
     
     public func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
 
-        // Only handle the amount field
+        /// Only handle the amount field
         guard TextFieldType(rawValue: textField.tag) == .amountFieldTag else { return true }
 
-        // Ensure we can build the updated string
+        /// Ensure we can build the updated string
         guard let oldText = textField.text,
               let textRange = Range(range, in: oldText) else { return true }
 
-        // Normalize to (max 7) digits
+        /// Normalize to (max 7) digits
         let updated = oldText.replacingCharacters(in: textRange, with: string)
         let digits = AmountInput.digitsOnlyCapped(updated)
 
-        // Format (xx -> 0.xx, 12345 -> 123.45)
+        /// Format (xx -> 0.xx, 12345 -> 123.45)
         guard let amount = AmountInput.amount(fromCentsDigits: digits),
               let formatted = amountToPay?
             .stringWithoutSymbol(from: amount)?
             .trimmingCharacters(in: .whitespaces) else { return false }
 
-        // Update UI + model and keep caret position reasonable
+        /// Update UI + model and keep caret position reasonable
         let priorSelection = textField.selectedTextRange
         textField.text = formatted
         amountToPay?.value = amount
@@ -304,7 +304,8 @@ extension PaymentViewController {
         }
     }
 
-    private func validateIBAN(_ textField: UITextField, _ field: TextFieldType) {
+    private func validateIBAN(_ textField: UITextField,
+                              _ field: TextFieldType) {
         guard textField.hasText, let iban = textField.text else {
             showErrorLabel(textFieldTag: field)
             return
@@ -331,7 +332,8 @@ extension PaymentViewController {
         }
     }
 
-    private func validateNonEmpty(_ textField: UITextField, _ field: TextFieldType) {
+    private func validateNonEmpty(_ textField: UITextField,
+                                  _ field: TextFieldType) {
         if textField.hasText && !textField.isReallyEmpty {
             hideErrorLabel(textFieldTag: field)
         } else {

--- a/BankSDK/GiniBankSDKExample/GiniBankSDKExampleBank/PaymentViewController.swift
+++ b/BankSDK/GiniBankSDKExample/GiniBankSDKExampleBank/PaymentViewController.swift
@@ -258,12 +258,27 @@ extension PaymentViewController: UITextFieldDelegate {
     private struct AmountInput {
         static let maxDigits = 7
 
-        static func digitsOnlyCapped(_ s: String) -> String {
-            String(s.unicodeScalars.filter(CharacterSet.decimalDigits.contains).prefix(maxDigits))
+        /**
+         Returns the first `maxDigits` decimal digits from `input`, dropping every
+         other character (separators, letters, whitespace, punctuation).
+
+         Filtering runs over `unicodeScalars` because `CharacterSet.contains(_:)`
+         is defined on `Unicode.Scalar`; wrapping the filtered scalars back into
+         a `String` yields a plain digit sequence we can hand to `Decimal(string:)`.
+         */
+        static func digitsOnlyCapped(_ input: String) -> String {
+            let digitScalars = input.unicodeScalars.filter { CharacterSet.decimalDigits.contains($0) }
+            let cappedScalars = digitScalars.prefix(maxDigits)
+            return String(String.UnicodeScalarView(cappedScalars))
         }
 
-        static func amount(fromCentsDigits s: String) -> Decimal? {
-            Decimal(string: s).map { $0 / 100 }
+        /**
+         Interprets `digits` as a cents value and returns the corresponding decimal
+         amount (e.g. `"5"` → `0.05`, `"12345"` → `123.45`). Returns `nil` when
+         `digits` is empty or otherwise not parseable as a `Decimal`.
+         */
+        static func amount(fromCentsDigits digits: String) -> Decimal? {
+            Decimal(string: digits).map { $0 / 100 }
         }
     }
 }


### PR DESCRIPTION
SonarQube fixes for GiniBankSDK: ReturnAssistant refactors (DigitalInvoiceViewController, PriceLabelView, onboarding, help view model), giniLocalized helper in GiniBankUtils, example app cleanups. Orphaned pinning-example files were intentionally excluded (that app was removed on main).

Part of the SonarQube cleanup split from `release/SonarQube-issues` — one PR per SDK for easier review. No public API changes; independent of the sibling SonarQube PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)