### PR TITLE
refactor(GiniHealthAPILibrary): Fix SonarQube issues

### DIFF
--- a/HealthAPILibrary/GiniHealthAPILibrary/Sources/GiniHealthAPILibrary/Documents/Core/Auth/SessionManager+Auth.swift
+++ b/HealthAPILibrary/GiniHealthAPILibrary/Sources/GiniHealthAPILibrary/Documents/Core/Auth/SessionManager+Auth.swift
@@ -26,61 +26,22 @@ extension SessionManager: SessionAuthenticationProtocol {
         
         return User(email: email, password: password)
     }
-    
+
     func logIn(completion: @escaping CompletionResult<Token>) {
-        
-        let saveTokenAndComplete: (Result<Token, GiniError>) -> Void = { result in
-            
-            switch result {
-            case .failure:
-                self.removeUserAccessToken()
-            case .success(let token):
-                self.userAccessToken = token.accessToken
-            }
-            
-            completion(result)
-        }
-        
+        let saveTokenAndComplete = createTokenCompletionHandler(completion: completion)
+
         if let alternativeTokenSource = alternativeTokenSource {
             alternativeTokenSource.fetchToken(completion: saveTokenAndComplete)
-        } else {
-            
-            if let user = user {
-                
-                fetchUserAccessToken(for: user) { result in
-                    switch result {
-                        case .success:
-                            saveTokenAndComplete(result)
-                        case .failure(let error):
-                            if case .unauthorized = error {
-                                self.removeCurrentUserInfo()
-                                self.createUser { result in
-                                    switch result {
-                                        case .success(let user):
-                                            self.fetchUserAccessToken(for: user, completion: saveTokenAndComplete)
-                                        case .failure(let error):
-                                            completion(.failure(error))
-                                    }
-                                }
-                            } else {
-                                completion(.failure(error))
-                            }
-                    }
-                }
+            return
+        }
 
-            } else {
-                createUser { result in
-                    switch result {
-                    case .success(let user):
-                        self.fetchUserAccessToken(for: user, completion: saveTokenAndComplete)
-                    case .failure(let error):
-                        completion(.failure(error))
-                    }
-                }
-            }
+        if let user = user {
+            handleExistingUser(user: user, completion: completion, saveTokenAndComplete: saveTokenAndComplete)
+        } else {
+            createUserAndFetchToken(completion: completion, saveTokenAndComplete: saveTokenAndComplete)
         }
     }
-    
+
     func logOut() {       
         // Remove current user info from SessionManager
         userAccessToken = nil
@@ -130,6 +91,50 @@ extension SessionManager: SessionAuthenticationProtocol {
 // MARK: - Fileprivate
 
 fileprivate extension SessionManager {
+
+   func createTokenCompletionHandler(completion: @escaping CompletionResult<Token>) -> (Result<Token, GiniError>) -> Void {
+        return { [weak self] result in
+            switch result {
+                case .failure:
+                    self?.removeUserAccessToken()
+                case .success(let token):
+                    self?.userAccessToken = token.accessToken
+            }
+            completion(result)
+        }
+    }
+
+    func handleExistingUser(user: User,
+                                    completion: @escaping CompletionResult<Token>,
+                                    saveTokenAndComplete: @escaping (Result<Token, GiniError>) -> Void) {
+        fetchUserAccessToken(for: user) { [weak self] result in
+            switch result {
+                case .success:
+                    saveTokenAndComplete(result)
+                case .failure(let error):
+                    if case .unauthorized = error {
+                        self?.removeCurrentUserInfo()
+                        self?.createUserAndFetchToken(completion: completion,
+                                                      saveTokenAndComplete: saveTokenAndComplete)
+                    } else {
+                        completion(.failure(error))
+                    }
+            }
+        }
+    }
+
+    func createUserAndFetchToken(completion: @escaping CompletionResult<Token>,
+                                         saveTokenAndComplete: @escaping (Result<Token, GiniError>) -> Void) {
+        createUser { [weak self] result in
+            switch result {
+                case .success(let user):
+                    self?.fetchUserAccessToken(for: user, completion: saveTokenAndComplete)
+                case .failure(let error):
+                    completion(.failure(error))
+            }
+        }
+    }
+
     func createUser(completion: @escaping CompletionResult<User>) {
         fetchClientAccessToken { result in
             switch result {
@@ -137,27 +142,33 @@ fileprivate extension SessionManager {
                 self.clientAccessToken = token.accessToken
                 let domain = self.keyStore.fetch(service: .auth, key: .clientDomain) ?? "no-domain-specified"
                 let user = AuthHelper.generateUser(with: domain)
-                
+
                 let resource = UserResource<String>(method: .users,
                                                     userDomain: self.userDomain,
                                                     httpMethod: .post,
                                                     body: try? JSONEncoder().encode(user))
 
-                self.data(resource: resource) { result in
-                    switch result {
-                    case .success:
-                        self.storeUserCredentials(for: user,
-                                                  completion: completion)
-                    case .failure(let error):
-                        completion(.failure(error))
-                    }
-                }
+                self.handleDataResource(resource, for: user, completion: completion)
+
             case .failure(let error):
                 completion(.failure(error))
             }
         }
     }
-    
+
+    private func handleDataResource(_ resource: UserResource<String>,
+                                    for user: User,
+                                    completion: @escaping CompletionResult<User>) {
+        self.data(resource: resource) { result in
+            switch result {
+            case .success:
+                self.storeUserCredentials(for: user,
+                                          completion: completion)
+            case .failure(let error):
+                completion(.failure(error))
+            }
+        }
+    }
     func fetchUserAccessToken(for user: User,
                               completion: @escaping CompletionResult<Token>) {
         let body = "username=\(user.email)&password=\(user.password)"
@@ -179,8 +190,8 @@ fileprivate extension SessionManager {
         data(resource: resource, completion: completion)
     }
 
-    private func storeUserCredentials(for user: User,
-                                      completion: @escaping CompletionResult<User>) {
+    func storeUserCredentials(for user: User,
+                              completion: @escaping CompletionResult<User>) {
         do {
             try self.keyStore.save(item: KeychainManagerItem(key: .userEmail,
                                                              value: user.email,

--- a/HealthAPILibrary/GiniHealthAPILibrary/Sources/GiniHealthAPILibrary/Documents/Core/Auth/SessionManager+Auth.swift
+++ b/HealthAPILibrary/GiniHealthAPILibrary/Sources/GiniHealthAPILibrary/Documents/Core/Auth/SessionManager+Auth.swift
@@ -96,12 +96,12 @@ extension SessionManager: SessionAuthenticationProtocol {
 fileprivate extension SessionManager {
 
     func createTokenCompletionHandler(completion: @escaping CompletionResult<Token>) -> (Result<Token, GiniError>) -> Void {
-        return { [weak self] result in
+        return { result in
             switch result {
                 case .failure:
-                    self?.removeUserAccessToken()
+                    self.removeUserAccessToken()
                 case .success(let token):
-                    self?.userAccessToken = token.accessToken
+                    self.userAccessToken = token.accessToken
             }
             completion(result)
         }

--- a/HealthAPILibrary/GiniHealthAPILibrary/Sources/GiniHealthAPILibrary/Documents/Core/Auth/SessionManager+Auth.swift
+++ b/HealthAPILibrary/GiniHealthAPILibrary/Sources/GiniHealthAPILibrary/Documents/Core/Auth/SessionManager+Auth.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 extension SessionManager: SessionAuthenticationProtocol {
-    
+
     var client: Client {
         if let id = self.keyStore.fetch(service: .auth, key: .clientId),
            let secret = self.keyStore.fetch(service: .auth, key: .clientSecret),
@@ -19,11 +19,11 @@ extension SessionManager: SessionAuthenticationProtocol {
             return Client(id: "", secret: "", domain: "")
         }
     }
-    
+
     var user: User? {
         guard let email = self.keyStore.fetch(service: .auth, key: .userEmail),
             let password = self.keyStore.fetch(service: .auth, key: .userPassword) else { return nil }
-        
+
         return User(email: email, password: password)
     }
 
@@ -36,40 +36,43 @@ extension SessionManager: SessionAuthenticationProtocol {
         }
 
         if let user = user {
-            handleExistingUser(user: user, completion: completion, saveTokenAndComplete: saveTokenAndComplete)
+            handleExistingUser(user: user,
+                               completion: completion,
+                               saveTokenAndComplete: saveTokenAndComplete)
         } else {
-            createUserAndFetchToken(completion: completion, saveTokenAndComplete: saveTokenAndComplete)
+            createUserAndFetchToken(completion: completion,
+                                    saveTokenAndComplete: saveTokenAndComplete)
         }
     }
 
-    func logOut() {       
-        // Remove current user info from SessionManager
+    func logOut() {
+        /// Remove current user info from SessionManager
         userAccessToken = nil
         clientAccessToken = nil
 
-        // Remove current user info from Keychain
+        /// Remove current user info from Keychain
         keyStore.removeAll()
     }
 
     private func removeUserAccessToken() {
-        // Remove current userAccessToken from SessionManager
+        /// Remove current userAccessToken from SessionManager
         userAccessToken = nil
 
-        // removing `userAccessToken` from Keychain is part of the old implementation where it was saved in Keychain
+        /// removing `userAccessToken` from Keychain is part of the old implementation where it was saved in Keychain
         do {
-            try KeychainStore().remove(service: .auth, key: .userAccessToken)
+            try self.keyStore.remove(service: .auth, key: .userAccessToken)
         } catch {
             preconditionFailure("Gini couldn't remove the `userAccessToken` from Keychain.")
         }
     }
 
     private func removeClientAccessToken() {
-        // Remove current clientAccessToken from SessionManager
+        /// Remove current clientAccessToken from SessionManager
         clientAccessToken = nil
 
-        // removing  `clientAccessToken` from Keychain is part of the old implementation where it was saved in Keychain
+        /// removing  `clientAccessToken` from Keychain is part of the old implementation where it was saved in Keychain
         do {
-            try KeychainStore().remove(service: .auth, key: .clientAccessToken)
+            try self.keyStore.remove(service: .auth, key: .clientAccessToken)
         } catch {
             preconditionFailure("Gini couldn't remove the `clientAccessToken` from Keychain.")
         }
@@ -92,7 +95,7 @@ extension SessionManager: SessionAuthenticationProtocol {
 
 fileprivate extension SessionManager {
 
-   func createTokenCompletionHandler(completion: @escaping CompletionResult<Token>) -> (Result<Token, GiniError>) -> Void {
+    func createTokenCompletionHandler(completion: @escaping CompletionResult<Token>) -> (Result<Token, GiniError>) -> Void {
         return { [weak self] result in
             switch result {
                 case .failure:
@@ -105,17 +108,17 @@ fileprivate extension SessionManager {
     }
 
     func handleExistingUser(user: User,
-                                    completion: @escaping CompletionResult<Token>,
-                                    saveTokenAndComplete: @escaping (Result<Token, GiniError>) -> Void) {
-        fetchUserAccessToken(for: user) { [weak self] result in
+                            completion: @escaping CompletionResult<Token>,
+                            saveTokenAndComplete: @escaping (Result<Token, GiniError>) -> Void) {
+        fetchUserAccessToken(for: user) { result in
             switch result {
                 case .success:
                     saveTokenAndComplete(result)
                 case .failure(let error):
                     if case .unauthorized = error {
-                        self?.removeCurrentUserInfo()
-                        self?.createUserAndFetchToken(completion: completion,
-                                                      saveTokenAndComplete: saveTokenAndComplete)
+                        self.removeCurrentUserInfo()
+                        self.createUserAndFetchToken(completion: completion,
+                                                     saveTokenAndComplete: saveTokenAndComplete)
                     } else {
                         completion(.failure(error))
                     }
@@ -124,11 +127,11 @@ fileprivate extension SessionManager {
     }
 
     func createUserAndFetchToken(completion: @escaping CompletionResult<Token>,
-                                         saveTokenAndComplete: @escaping (Result<Token, GiniError>) -> Void) {
-        createUser { [weak self] result in
+                                 saveTokenAndComplete: @escaping (Result<Token, GiniError>) -> Void) {
+        createUser { result in
             switch result {
                 case .success(let user):
-                    self?.fetchUserAccessToken(for: user, completion: saveTokenAndComplete)
+                    self.fetchUserAccessToken(for: user, completion: saveTokenAndComplete)
                 case .failure(let error):
                     completion(.failure(error))
             }
@@ -169,20 +172,21 @@ fileprivate extension SessionManager {
             }
         }
     }
+
     func fetchUserAccessToken(for user: User,
                               completion: @escaping CompletionResult<Token>) {
         let body = "username=\(user.email)&password=\(user.password)"
             .addingPercentEncoding(withAllowedCharacters: .urlHostAllowed)?
             .data(using: .utf8)
-        
+
         let resource = UserResource<Token>(method: .token(grantType: .password),
                                            userDomain: self.userDomain,
                                            httpMethod: .post,
                                            body: body)
-        
+
         data(resource: resource, completion: completion)
     }
-    
+
     func fetchClientAccessToken(completion: @escaping CompletionResult<Token>) {
         let resource = UserResource<Token>(method: .token(grantType: .clientCredentials),
                                            userDomain: self.userDomain,

--- a/HealthAPILibrary/GiniHealthAPILibrary/Sources/GiniHealthAPILibrary/Documents/DefaultDocumentService.swift
+++ b/HealthAPILibrary/GiniHealthAPILibrary/Sources/GiniHealthAPILibrary/Documents/DefaultDocumentService.swift
@@ -124,34 +124,38 @@ public final class DefaultDocumentService: DefaultDocumentServiceProtocol {
         default:
             fetchDocument(with: document.id) { [weak self] result in
                 guard let self = self else { return }
-                switch result {
-                case .success(let document):
-                    // Before removing the partial document, all its composite documents must be deleted
-                    let dispatchGroup = DispatchGroup()
-                    document.compositeDocuments?.forEach { compositeDocument in
-                        guard let id = compositeDocument.id else { return }
-                        dispatchGroup.enter()
-                        
-                        self.deleteDocument(resourceHandler: self.sessionManager.data,
-                                            with: id) { _ in
-                            dispatchGroup.leave()
-                        }
-                    }
-                    
-                    // Once all composite documents are deleted, it proceeds with the partial document
-                    dispatchGroup.notify(queue: DispatchQueue.global()) {
-                        self.deleteDocument(resourceHandler: self.sessionManager.data,
-                                            with: document.id,
-                                            completion: completion)
-                    }
-                case .failure(let error):
-                    completion(.failure(error))
-                }
+                handleFetchedDocument(result, completion: completion)
             }
-            
         }
     }
-    
+
+    private func handleFetchedDocument(_ result: Result<Document, GiniError>, completion: @escaping CompletionResult<String>) {
+
+        switch result {
+        case .success(let document):
+            // Before removing the partial document, all its composite documents must be deleted
+            let dispatchGroup = DispatchGroup()
+            document.compositeDocuments?.forEach { compositeDocument in
+                guard let id = compositeDocument.id else { return }
+                dispatchGroup.enter()
+
+                self.deleteDocument(resourceHandler: self.sessionManager.data,
+                                    with: id) { _ in
+                    dispatchGroup.leave()
+                }
+            }
+
+            // Once all composite documents are deleted, it proceeds with the partial document
+            dispatchGroup.notify(queue: DispatchQueue.global()) {
+                self.deleteDocument(resourceHandler: self.sessionManager.data,
+                                    with: document.id,
+                                    completion: completion)
+            }
+        case .failure(let error):
+            completion(.failure(error))
+        }
+    }
+
     /**
      *  Fetches the user documents, with the possibility to retrieve them paginated
      *

--- a/HealthAPILibrary/GiniHealthAPILibrary/Sources/GiniHealthAPILibrary/Documents/DefaultDocumentService.swift
+++ b/HealthAPILibrary/GiniHealthAPILibrary/Sources/GiniHealthAPILibrary/Documents/DefaultDocumentService.swift
@@ -129,8 +129,8 @@ public final class DefaultDocumentService: DefaultDocumentServiceProtocol {
         }
     }
 
-    private func handleFetchedDocument(_ result: Result<Document, GiniError>, completion: @escaping CompletionResult<String>) {
-
+    private func handleFetchedDocument(_ result: Result<Document, GiniError>,
+                                       completion: @escaping CompletionResult<String>) {
         switch result {
         case .success(let document):
             // Before removing the partial document, all its composite documents must be deleted

--- a/HealthAPILibrary/GiniHealthAPILibrary/Sources/GiniHealthAPILibrary/Documents/DefaultDocumentService.swift
+++ b/HealthAPILibrary/GiniHealthAPILibrary/Sources/GiniHealthAPILibrary/Documents/DefaultDocumentService.swift
@@ -133,7 +133,7 @@ public final class DefaultDocumentService: DefaultDocumentServiceProtocol {
                                        completion: @escaping CompletionResult<String>) {
         switch result {
         case .success(let document):
-            // Before removing the partial document, all its composite documents must be deleted
+            /// Before removing the partial document, all its composite documents must be deleted
             let dispatchGroup = DispatchGroup()
             document.compositeDocuments?.forEach { compositeDocument in
                 guard let id = compositeDocument.id else { return }
@@ -145,7 +145,7 @@ public final class DefaultDocumentService: DefaultDocumentServiceProtocol {
                 }
             }
 
-            // Once all composite documents are deleted, it proceeds with the partial document
+            /// Once all composite documents are deleted, it proceeds with the partial document
             dispatchGroup.notify(queue: DispatchQueue.global()) {
                 self.deleteDocument(resourceHandler: self.sessionManager.data,
                                     with: document.id,

--- a/HealthAPILibrary/GiniHealthAPILibrary/Sources/GiniHealthAPILibrary/Documents/DocumentService.swift
+++ b/HealthAPILibrary/GiniHealthAPILibrary/Sources/GiniHealthAPILibrary/Documents/DocumentService.swift
@@ -192,8 +192,11 @@ extension DocumentService {
         poll(resourceHandler: documentResourceHandler,
              document: document,
              cancellationToken: cancellationToken) { result in
-            self.handlePollResult(result, document: document, resourceHandler: resourceHandler, cancellationToken: cancellationToken, completion: completion)
-            
+            self.handlePollResult(result,
+                                  document: document,
+                                  resourceHandler: resourceHandler,
+                                  cancellationToken: cancellationToken,
+                                  completion: completion)
         }
     }
 
@@ -315,10 +318,16 @@ extension DocumentService {
         resourceHandler(resource) { result in
             switch result {
             case let .success(pages):
-                self.handlePreviewPages(pages, pageNumber: pageNumber, completion: completion)
-            
+                self.handlePreviewPages(pages,
+                                        pageNumber: pageNumber,
+                                        completion: completion)
+
             case let .failure(error):
-                self.retryPreviewIfNeeded(error: error, resourceHandler: resourceHandler, documentId: documentId, pageNumber: pageNumber, completion: completion)
+                self.retryPreviewIfNeeded(error: error,
+                                          resourceHandler: resourceHandler,
+                                          documentId: documentId,
+                                          pageNumber: pageNumber,
+                                          completion: completion)
             }
         }
     }
@@ -346,7 +355,6 @@ extension DocumentService {
                                       documentId: String,
                                       pageNumber: Int,
                                       completion: @escaping CompletionResult<Data>) {
-        
         if case .notFound = error {
             DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
                 self.preview(resourceHandler: resourceHandler,
@@ -354,6 +362,9 @@ extension DocumentService {
                              pageNumber: pageNumber,
                              completion: completion)
             }
+        } else {
+            /// Non-`.notFound` errors must be forwarded so callers don't wait indefinitely.
+            completion(.failure(error))
         }
     }
 

--- a/HealthAPILibrary/GiniHealthAPILibrary/Sources/GiniHealthAPILibrary/Documents/DocumentService.swift
+++ b/HealthAPILibrary/GiniHealthAPILibrary/Sources/GiniHealthAPILibrary/Documents/DocumentService.swift
@@ -218,8 +218,8 @@ extension DocumentService {
         case .failure(let error):
             completion(.failure(error))
         }
-        
     }
+
     private func handleExtractionsResult(_ result: Result<ExtractionsContainer, GiniError>,
                                          completion: @escaping CompletionResult<ExtractionResult>) {
         switch result {

--- a/HealthAPILibrary/GiniHealthAPILibrary/Tests/GiniHealthAPILibraryTests/DocumentServiceHelperTests.swift
+++ b/HealthAPILibrary/GiniHealthAPILibrary/Tests/GiniHealthAPILibraryTests/DocumentServiceHelperTests.swift
@@ -1,0 +1,224 @@
+//
+//  DocumentServiceHelperTests.swift
+//  GiniHealthAPILibraryTests
+//
+//  Copyright © 2026 Gini. All rights reserved.
+//
+
+import Testing
+import Foundation
+@testable import GiniHealthAPILibrary
+
+/**
+ Focused unit tests for the private helpers extracted from
+ `DocumentService.extractions(...)` and `DocumentService.preview(...)` during
+ the SonarQube cleanup. Each test drives the internal `resourceHandler`
+ seams so the helpers execute end-to-end without a live network.
+ */
+@Suite("DocumentService helpers")
+struct DocumentServiceHelperTests {
+
+    // MARK: - Doubles
+
+    private static func makeService() -> DefaultDocumentService {
+        DefaultDocumentService(sessionManager: SessionManagerMock(),
+                               apiVersion: 5)
+    }
+
+    private static func loadCompletedDocument() -> Document {
+        let document: Document = load(fromFile: "document", type: "json")
+        return document
+    }
+
+    private static func loadPages() -> [Document.Page] {
+        load(fromFile: "pages", type: "json")
+    }
+
+    private static func loadExtractionsContainer() -> ExtractionsContainer {
+        load(fromFile: "extractionsContainer", type: "json")
+    }
+
+    // MARK: - extractions helpers (handlePollResult / handleExtractionsResult)
+
+    @Test("extractions: poll success → extractions success → .success(ExtractionResult)")
+    func extractionsFullSuccess() async {
+        let service = Self.makeService()
+        let document = Self.loadCompletedDocument()
+        let extractionsContainer = Self.loadExtractionsContainer()
+
+        let docHandler: CancellableResourceDataHandler<APIResource<Document>> = { _, _, completion in
+            completion(.success(document))
+        }
+        let extractionsHandler: CancellableResourceDataHandler<APIResource<ExtractionsContainer>> = { _, _, completion in
+            completion(.success(extractionsContainer))
+        }
+
+        let result: Result<ExtractionResult, GiniError> = await withCheckedContinuation { continuation in
+            service.extractions(resourceHandler: extractionsHandler,
+                                documentResourceHandler: docHandler,
+                                for: document,
+                                cancellationToken: nil) { continuation.resume(returning: $0) }
+        }
+
+        switch result {
+        case .success(let extractionResult):
+            #expect(extractionResult.extractions.count == extractionsContainer.extractions.count)
+        case .failure(let error):
+            Issue.record("Expected .success, got .failure(\(error))")
+        }
+    }
+
+    @Test("extractions: poll success → extractions failure → .failure propagates")
+    func extractionsFetchFailurePropagates() async {
+        let service = Self.makeService()
+        let document = Self.loadCompletedDocument()
+
+        let docHandler: CancellableResourceDataHandler<APIResource<Document>> = { _, _, completion in
+            completion(.success(document))
+        }
+        let extractionsHandler: CancellableResourceDataHandler<APIResource<ExtractionsContainer>> = { _, _, completion in
+            completion(.failure(.notFound()))
+        }
+
+        let result: Result<ExtractionResult, GiniError> = await withCheckedContinuation { continuation in
+            service.extractions(resourceHandler: extractionsHandler,
+                                documentResourceHandler: docHandler,
+                                for: document,
+                                cancellationToken: nil) { continuation.resume(returning: $0) }
+        }
+
+        switch result {
+        case .success:
+            Issue.record("Expected .failure, got .success")
+        case .failure(let error):
+            if case .notFound = error {
+                break
+            } else {
+                Issue.record("Expected .notFound, got \(error)")
+            }
+        }
+    }
+
+    @Test("extractions: poll failure → .failure propagates and extractions handler is never called")
+    func extractionsPollFailurePropagates() async {
+        let service = Self.makeService()
+        let document = Self.loadCompletedDocument()
+
+        let docHandler: CancellableResourceDataHandler<APIResource<Document>> = { _, _, completion in
+            completion(.failure(.badRequest()))
+        }
+        let extractionsCalled = ExtractionsCalledFlag()
+        let extractionsHandler: CancellableResourceDataHandler<APIResource<ExtractionsContainer>> = { _, _, _ in
+            extractionsCalled.wasCalled = true
+        }
+
+        let result: Result<ExtractionResult, GiniError> = await withCheckedContinuation { continuation in
+            service.extractions(resourceHandler: extractionsHandler,
+                                documentResourceHandler: docHandler,
+                                for: document,
+                                cancellationToken: nil) { continuation.resume(returning: $0) }
+        }
+
+        #expect(extractionsCalled.wasCalled == false,
+                "extractions handler must not run when the poll fails")
+        switch result {
+        case .success:
+            Issue.record("Expected .failure, got .success")
+        case .failure(let error):
+            if case .badRequest = error {
+                break
+            } else {
+                Issue.record("Expected .badRequest, got \(error)")
+            }
+        }
+    }
+
+    /// Reference wrapper so the closure-based mock can flip a flag without needing an actor.
+    private final class ExtractionsCalledFlag { var wasCalled = false }
+
+    // MARK: - preview helpers (handlePreviewPages / retryPreviewIfNeeded / handleFileResult)
+
+    /**
+     End-to-end success uses the real `DefaultDocumentService.preview` entry point so
+     `handlePreviewPages` → `file(urlString:)` → `handleFileResult` all execute, but
+     stubs the underlying `sessionManager.download` via a custom resource handler by
+     routing through the extension's `preview(resourceHandler:...)` overload.
+     */
+    @Test("preview: pages success → handleFileResult forwards the downloaded data")
+    func previewHandlePreviewPagesSuccess() async {
+        let service = Self.makeService()
+        let pages = Self.loadPages()
+
+        let previewHandler: ResourceDataHandler<APIResource<[Document.Page]>> = { _, completion in
+            completion(.success(pages))
+        }
+
+        let result: Result<Data, GiniError> = await withCheckedContinuation { continuation in
+            service.preview(resourceHandler: previewHandler,
+                            with: "dcd0c7a0-8382-11ec-9fb5-a5611818595c",
+                            pageNumber: 1) { continuation.resume(returning: $0) }
+        }
+
+        /// The internal call chain hits `file(urlString:)` → `sessionManager.download`,
+        /// which the mock resolves to a bundled PNG. We only care that data flowed
+        /// through `handleFileResult`.
+        switch result {
+        case .success(let data):
+            #expect(data.isEmpty == false, "handleFileResult should forward the downloaded payload")
+        case .failure(let error):
+            Issue.record("Expected .success, got .failure(\(error))")
+        }
+    }
+
+    @Test("preview: empty pages returns .notFound")
+    func previewEmptyPagesReturnsNotFound() async {
+        let service = Self.makeService()
+
+        let previewHandler: ResourceDataHandler<APIResource<[Document.Page]>> = { _, completion in
+            completion(.success([]))
+        }
+
+        let result: Result<Data, GiniError> = await withCheckedContinuation { continuation in
+            service.preview(resourceHandler: previewHandler,
+                            with: "dcd0c7a0-8382-11ec-9fb5-a5611818595c",
+                            pageNumber: 1) { continuation.resume(returning: $0) }
+        }
+
+        switch result {
+        case .success:
+            Issue.record("Expected .failure, got .success")
+        case .failure(let error):
+            if case .notFound = error {
+                break
+            } else {
+                Issue.record("Expected .notFound, got \(error)")
+            }
+        }
+    }
+
+    @Test("preview: non-.notFound failure is propagated instead of silently retrying")
+    func previewNonNotFoundFailurePropagates() async {
+        let service = Self.makeService()
+
+        let previewHandler: ResourceDataHandler<APIResource<[Document.Page]>> = { _, completion in
+            completion(.failure(.badRequest()))
+        }
+
+        let result: Result<Data, GiniError> = await withCheckedContinuation { continuation in
+            service.preview(resourceHandler: previewHandler,
+                            with: "dcd0c7a0-8382-11ec-9fb5-a5611818595c",
+                            pageNumber: 1) { continuation.resume(returning: $0) }
+        }
+
+        switch result {
+        case .success:
+            Issue.record("Expected .failure, got .success")
+        case .failure(let error):
+            if case .badRequest = error {
+                break
+            } else {
+                Issue.record("Expected .badRequest, got \(error)")
+            }
+        }
+    }
+}

--- a/HealthAPILibrary/GiniHealthAPILibrary/Tests/GiniHealthAPILibraryTests/SessionManagerAuthTests.swift
+++ b/HealthAPILibrary/GiniHealthAPILibrary/Tests/GiniHealthAPILibraryTests/SessionManagerAuthTests.swift
@@ -1,0 +1,400 @@
+//
+//  SessionManagerAuthTests.swift
+//  GiniHealthAPILibraryTests
+//
+//  Copyright © 2026 Gini. All rights reserved.
+//
+
+import Testing
+import Foundation
+@testable import GiniHealthAPILibrary
+
+// MARK: - Alternative token source
+
+@Suite("SessionManager.logIn — alternative token source")
+struct SessionManagerAlternativeTokenTests {
+
+    /**
+     Manual `AlternativeTokenSource` conformance that returns a fixed result.
+     */
+    private final class StubAlternativeTokenSource: AlternativeTokenSource {
+        let result: Result<Token, GiniError>
+
+        init(result: Result<Token, GiniError>) {
+            self.result = result
+        }
+
+        func fetchToken(completion: @escaping (Result<Token, GiniError>) -> Void) {
+            completion(result)
+        }
+    }
+
+    @Test("Failure surfaces as .failure and clears userAccessToken")
+    func failurePropagatesAndClearsToken() async {
+        let stub = StubAlternativeTokenSource(result: .failure(.unauthorized()))
+        let sut = SessionManager(keyStore: KeychainStoreMock(),
+                                 alternativeTokenSource: stub)
+        sut.userAccessToken = "stale-token"
+
+        let result: Result<Token, GiniError> = await withCheckedContinuation { continuation in
+            sut.logIn { continuation.resume(returning: $0) }
+        }
+
+        #expect(sut.userAccessToken == nil,
+                "userAccessToken should be cleared on alt-token failure")
+        switch result {
+        case .success:
+            Issue.record("Expected .failure, got .success")
+        case .failure(let error):
+            if case .unauthorized = error {
+                break
+            } else {
+                Issue.record("Expected .unauthorized, got \(error)")
+            }
+        }
+    }
+
+    @Test("Success stores the returned accessToken and completes with the token")
+    func successStoresAccessToken() async {
+        let token = Token(expiration: Date(timeIntervalSinceNow: 3600),
+                          scope: "read",
+                          type: "bearer",
+                          accessToken: "alt-source-token")
+        let stub = StubAlternativeTokenSource(result: .success(token))
+        let sut = SessionManager(keyStore: KeychainStoreMock(),
+                                 alternativeTokenSource: stub)
+
+        let result: Result<Token, GiniError> = await withCheckedContinuation { continuation in
+            sut.logIn { continuation.resume(returning: $0) }
+        }
+
+        #expect(sut.userAccessToken == "alt-source-token")
+        switch result {
+        case .success(let received):
+            #expect(received.accessToken == "alt-source-token")
+        case .failure(let error):
+            Issue.record("Expected .success, got .failure(\(error))")
+        }
+    }
+}
+
+// MARK: - HTTP-driven paths (login + response handling)
+
+/**
+ Serialized because `URLProtocolMock.handler` is a shared static; every test in
+ this suite mutates it and would otherwise clobber a sibling running in parallel.
+ Both the login-flow tests and the response-shape tests live in the same suite
+ for that reason — tests split across sibling `.serialized` suites are still
+ eligible to run concurrently in Swift Testing.
+ */
+@Suite("SessionManager HTTP interactions", .serialized)
+struct SessionManagerHTTPTests {
+
+    /**
+     Mutable call counter for tests that need to route responses by request order.
+     */
+    private final class CallCounter { var count = 0 }
+
+    // MARK: Fixtures
+
+    private static func tokenResponseData() -> Data {
+        let url = Bundle.module.url(forResource: "accessTokenResponse", withExtension: "json")
+        guard let url, let data = try? Data(contentsOf: url) else {
+            fatalError("accessTokenResponse.json fixture missing")
+        }
+        return data
+    }
+
+    private static let tokenResponseAccessToken = "1eb7ca49-d99f-40cb-b86d-8dd689ca2345"
+
+    private static func okResponse(for request: URLRequest) -> HTTPURLResponse {
+        URLProtocolMock.makeResponse(for: request, statusCode: 200)
+    }
+
+    private static func unauthorizedResponse(for request: URLRequest) -> HTTPURLResponse {
+        URLProtocolMock.makeResponse(for: request, statusCode: 401)
+    }
+
+    // MARK: Doubles
+
+    private static func makeConfiguration() -> URLSessionConfiguration {
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [URLProtocolMock.self]
+        return config
+    }
+
+    private static func seededKeychain(withUser: Bool) -> KeychainStoreMock {
+        let store = KeychainStoreMock()
+        try? store.save(item: KeychainManagerItem(key: .clientId, value: "id", service: .auth))
+        try? store.save(item: KeychainManagerItem(key: .clientSecret, value: "secret", service: .auth))
+        try? store.save(item: KeychainManagerItem(key: .clientDomain, value: "gini.net", service: .auth))
+        if withUser {
+            try? store.save(item: KeychainManagerItem(key: .userEmail, value: "old@user.gini", service: .auth))
+            try? store.save(item: KeychainManagerItem(key: .userPassword, value: "old-password", service: .auth))
+        }
+        return store
+    }
+
+    // MARK: Login-flow tests
+
+    @Test("Existing user with valid credentials receives access token")
+    func existingUserSuccess() async {
+        defer { URLProtocolMock.handler = nil }
+        URLProtocolMock.handler = { request in
+            (Self.okResponse(for: request), Self.tokenResponseData())
+        }
+
+        let sut = SessionManager(keyStore: Self.seededKeychain(withUser: true),
+                                 configuration: Self.makeConfiguration())
+
+        let result: Result<Token, GiniError> = await withCheckedContinuation { continuation in
+            sut.logIn { continuation.resume(returning: $0) }
+        }
+
+        #expect(sut.userAccessToken == Self.tokenResponseAccessToken)
+        switch result {
+        case .success(let token):
+            #expect(token.accessToken == Self.tokenResponseAccessToken)
+        case .failure(let error):
+            Issue.record("Expected .success, got .failure(\(error))")
+        }
+    }
+
+    @Test("Existing user rejected as unauthorized triggers user recreation")
+    func existingUserUnauthorizedRecreates() async {
+        defer { URLProtocolMock.handler = nil }
+        let counter = CallCounter()
+        let keychain = Self.seededKeychain(withUser: true)
+
+        URLProtocolMock.handler = { request in
+            counter.count += 1
+            let query = request.url?.query ?? ""
+            let path = request.url?.path ?? ""
+
+            /// Call 1: fetch token for the old user → unauthorized, triggers recreation
+            if query.contains("grant_type=password") && counter.count == 1 {
+                return (Self.unauthorizedResponse(for: request), nil)
+            }
+            /// Client credentials fetch during user recreation
+            if query.contains("grant_type=client_credentials") {
+                return (Self.okResponse(for: request), Self.tokenResponseData())
+            }
+            /// User creation call — response body is a String; the SDK only checks status
+            if path == "/api/users" {
+                return (Self.okResponse(for: request), "user-created".data(using: .utf8))
+            }
+            /// Subsequent password token call for the freshly-created user → success
+            if query.contains("grant_type=password") {
+                return (Self.okResponse(for: request), Self.tokenResponseData())
+            }
+            fatalError("Unexpected request: \(request.url?.absoluteString ?? "nil")")
+        }
+
+        let sut = SessionManager(keyStore: keychain,
+                                 configuration: Self.makeConfiguration())
+
+        let result: Result<Token, GiniError> = await withCheckedContinuation { continuation in
+            sut.logIn { continuation.resume(returning: $0) }
+        }
+
+        #expect(sut.userAccessToken == Self.tokenResponseAccessToken)
+        #expect(keychain.fetch(service: .auth, key: .userEmail) != "old@user.gini",
+                "user credentials should have been rotated during recreation")
+        switch result {
+        case .success:
+            break
+        case .failure(let error):
+            Issue.record("Expected .success after recreation, got .failure(\(error))")
+        }
+    }
+
+    @Test("No stored user credentials triggers new-user creation and returns token")
+    func newUserCreation() async {
+        defer { URLProtocolMock.handler = nil }
+        let keychain = Self.seededKeychain(withUser: false)
+
+        URLProtocolMock.handler = { request in
+            let query = request.url?.query ?? ""
+            let path = request.url?.path ?? ""
+
+            if query.contains("grant_type=client_credentials") {
+                return (Self.okResponse(for: request), Self.tokenResponseData())
+            }
+            if path == "/api/users" {
+                return (Self.okResponse(for: request), "user-created".data(using: .utf8))
+            }
+            if query.contains("grant_type=password") {
+                return (Self.okResponse(for: request), Self.tokenResponseData())
+            }
+            fatalError("Unexpected request: \(request.url?.absoluteString ?? "nil")")
+        }
+
+        let sut = SessionManager(keyStore: keychain,
+                                 configuration: Self.makeConfiguration())
+
+        let result: Result<Token, GiniError> = await withCheckedContinuation { continuation in
+            sut.logIn { continuation.resume(returning: $0) }
+        }
+
+        #expect(sut.userAccessToken == Self.tokenResponseAccessToken)
+        #expect(keychain.fetch(service: .auth, key: .userEmail) != nil,
+                "new user credentials should be persisted after creation")
+        #expect(keychain.fetch(service: .auth, key: .userPassword) != nil,
+                "new user password should be persisted after creation")
+        switch result {
+        case .success:
+            break
+        case .failure(let error):
+            Issue.record("Expected .success after new-user creation, got .failure(\(error))")
+        }
+    }
+
+    @Test("Existing user rejected as non-.unauthorized error propagates without recreation")
+    func existingUserNonUnauthorizedErrorPropagates() async {
+        defer { URLProtocolMock.handler = nil }
+        let keychain = Self.seededKeychain(withUser: true)
+
+        URLProtocolMock.handler = { request in
+            /// 500 with an empty body → `handleError` falls through to `mapStatusCodeToError`'s
+            /// default arm and produces `.unknown`. `handleExistingUser`'s `if case .unauthorized`
+            /// misses, so the else-branch calls `completion(.failure(error))` without recreating.
+            (URLProtocolMock.makeResponse(for: request, statusCode: 500), Data())
+        }
+
+        let sut = SessionManager(keyStore: keychain,
+                                 configuration: Self.makeConfiguration())
+
+        let result: Result<Token, GiniError> = await withCheckedContinuation { continuation in
+            sut.logIn { continuation.resume(returning: $0) }
+        }
+
+        #expect(keychain.fetch(service: .auth, key: .userEmail) == "old@user.gini",
+                "user credentials should NOT have been rotated when the error is not .unauthorized")
+        switch result {
+        case .success:
+            Issue.record("Expected .failure, got .success")
+        case .failure(let error):
+            if case .unknown = error {
+                break
+            } else {
+                Issue.record("Expected .unknown from a 500 empty-body response, got \(error)")
+            }
+        }
+    }
+
+    // MARK: - Response-handling shape tests
+    //
+    // These drive `SessionManager.data(resource:)` directly (bypassing login) to
+    // exercise the response classification in `taskCompletionHandler` / `handleError`.
+
+    private static func makeResponseSut() -> SessionManager {
+        let sut = SessionManager(keyStore: Self.seededKeychain(withUser: false),
+                                 configuration: Self.makeConfiguration())
+        /// Bypass login for these tests — they only care about response shape.
+        sut.clientAccessToken = "dummy-client-token"
+        sut.userAccessToken = "dummy-user-token"
+        return sut
+    }
+
+    private static func tokenResource() -> UserResource<Token> {
+        UserResource<Token>(method: .token(grantType: .clientCredentials),
+                            userDomain: .default,
+                            httpMethod: .get)
+    }
+
+    @Test("2xx with a decodable body returns .success")
+    func success2xxReturnsDecodedValue() async {
+        defer { URLProtocolMock.handler = nil }
+        URLProtocolMock.handler = { request in
+            (Self.okResponse(for: request), Self.tokenResponseData())
+        }
+
+        let sut = Self.makeResponseSut()
+        let result: Result<Token, GiniError> = await withCheckedContinuation { continuation in
+            sut.data(resource: Self.tokenResource()) { continuation.resume(returning: $0) }
+        }
+
+        switch result {
+        case .success(let token):
+            #expect(token.accessToken == Self.tokenResponseAccessToken)
+        case .failure(let error):
+            Issue.record("Expected .success, got .failure(\(error))")
+        }
+    }
+
+    @Test("401 with empty body maps to .unauthorized")
+    func unauthorized401MapsToGiniError() async {
+        defer { URLProtocolMock.handler = nil }
+        URLProtocolMock.handler = { request in
+            (Self.unauthorizedResponse(for: request), Data())
+        }
+
+        let sut = Self.makeResponseSut()
+        let result: Result<Token, GiniError> = await withCheckedContinuation { continuation in
+            sut.data(resource: Self.tokenResource()) { continuation.resume(returning: $0) }
+        }
+
+        switch result {
+        case .success:
+            Issue.record("Expected .failure, got .success")
+        case .failure(let error):
+            if case .unauthorized = error {
+                break
+            } else {
+                Issue.record("Expected .unauthorized, got \(error)")
+            }
+        }
+    }
+
+    @Test("2xx with an unparseable body surfaces as .parseError")
+    func success2xxWithEmptyBodyReturnsParseError() async {
+        defer { URLProtocolMock.handler = nil }
+        URLProtocolMock.handler = { request in
+            /// Empty Data — URLSession delivers it as empty, not nil; JSONDecoder rejects it.
+            (Self.okResponse(for: request), Data())
+        }
+
+        let sut = Self.makeResponseSut()
+        let result: Result<Token, GiniError> = await withCheckedContinuation { continuation in
+            sut.data(resource: Self.tokenResource()) { continuation.resume(returning: $0) }
+        }
+
+        switch result {
+        case .success:
+            Issue.record("Expected .failure, got .success")
+        case .failure(let error):
+            if case .parseError = error {
+                break
+            } else {
+                Issue.record("Expected .parseError, got \(error)")
+            }
+        }
+    }
+
+    @Test("URLSession no-internet error maps to .noResponse")
+    func noInternetErrorMapsToGiniError() async {
+        defer {
+            URLProtocolMock.handler = nil
+            URLProtocolMock.errorHandler = nil
+        }
+        URLProtocolMock.errorHandler = { _ in
+            URLError(.notConnectedToInternet)
+        }
+
+        let sut = Self.makeResponseSut()
+        let result: Result<Token, GiniError> = await withCheckedContinuation { continuation in
+            sut.data(resource: Self.tokenResource()) { continuation.resume(returning: $0) }
+        }
+
+        switch result {
+        case .success:
+            Issue.record("Expected .failure, got .success")
+        case .failure(let error):
+            if case .noResponse = error {
+                break
+            } else {
+                Issue.record("Expected .noResponse, got \(error)")
+            }
+        }
+    }
+}

--- a/HealthAPILibrary/GiniHealthAPILibrary/Tests/GiniHealthAPILibraryTests/SessionManagerMock.swift
+++ b/HealthAPILibrary/GiniHealthAPILibrary/Tests/GiniHealthAPILibraryTests/SessionManagerMock.swift
@@ -66,30 +66,9 @@ final class SessionManagerMock: SessionManagerProtocol {
                            cancellationToken: CancellationToken?,
                            completion: @escaping (Result<T.ResponseType, GiniError>) -> Void) {
         if let apiMethod = resource.method as? APIMethod {
-            switch apiMethod {                
+            switch apiMethod {
             case .document(let id):
-                switch (id, resource.params.method) {
-                case (SessionManagerMock.v3DocumentId, .get):
-                    let document: Document = load(fromFile: "document", type: "json")
-                    completion(.success(document as! T.ResponseType))
-                case (SessionManagerMock.v3DocumentId, .delete):
-                    documents.removeAll(where: { $0.id == id })
-                    completion(.success("Deleted" as! T.ResponseType))
-                case (SessionManagerMock.partialDocumentId, .get):
-                    let document: Document = load(fromFile: "partialDocument", type: "json")
-                    completion(.success(document as! T.ResponseType))
-                case (SessionManagerMock.partialDocumentId, .delete):
-                    documents.removeAll(where: { $0.id == id })
-                    completion(.success("Deleted" as! T.ResponseType))
-                case (SessionManagerMock.compositeDocumentId, .get):
-                    let document: Document = load(fromFile: "compositeDocument", type: "json")
-                    completion(.success(document as! T.ResponseType))
-                case (SessionManagerMock.compositeDocumentId, .delete):
-                    documents.removeAll(where: { $0.id == id })
-                    completion(.success("Deleted" as! T.ResponseType))
-                default:
-                    fatalError("Document id not found in tests")
-                }
+                handleDocument(id: id, method: resource.params.method, completion: completion)
             case .createDocument(_, _, _, _):
                 completion(.success(SessionManagerMock.compositeDocumentId as! T.ResponseType))
             case .createPaymentRequest:
@@ -124,7 +103,34 @@ final class SessionManagerMock: SessionManagerProtocol {
             }
         }
     }
-    
+
+    private func handleDocument<T>(id: String, method: HTTPMethod,
+                                   completion: @escaping CompletionResult<T>) {
+
+        switch (id, method) {
+        case (SessionManagerMock.v3DocumentId, .get):
+            let document: Document = load(fromFile: "document", type: "json")
+            completion(.success(document as! T))
+        case (SessionManagerMock.v3DocumentId, .delete):
+            documents.removeAll(where: { $0.id == id })
+            completion(.success("Deleted" as! T))
+        case (SessionManagerMock.partialDocumentId, .get):
+            let document: Document = load(fromFile: "partialDocument", type: "json")
+            completion(.success(document as! T))
+        case (SessionManagerMock.partialDocumentId, .delete):
+            documents.removeAll(where: { $0.id == id })
+            completion(.success("Deleted" as! T))
+        case (SessionManagerMock.compositeDocumentId, .get):
+            let document: Document = load(fromFile: "compositeDocument", type: "json")
+            completion(.success(document as! T))
+        case (SessionManagerMock.compositeDocumentId, .delete):
+            documents.removeAll(where: { $0.id == id })
+            completion(.success("Deleted" as! T))
+        default:
+            fatalError("Document id not found in tests")
+        }
+    }
+
     func download<T: Resource>(resource: T,
                                cancellationToken: CancellationToken?,
                                completion: @escaping (Result<T.ResponseType, GiniError>) -> Void) {
@@ -132,30 +138,45 @@ final class SessionManagerMock: SessionManagerProtocol {
             switch apiMethod {
             case .file(_):
                 let imageData = UIImage(named: "Gini-Test-Payment-Provider",
-                                        in: Bundle.module, compatibleWith: nil)?.pngData()
+                                        in: Bundle.module,
+                                        compatibleWith: nil)?.pngData()
                 completion(.success(imageData as! T.ResponseType))
             default:
                 break
             }
         }
     }
-    
+
     func upload<T: Resource>(resource: T,
                              data: Data,
                              cancellationToken: CancellationToken?,
                              completion: @escaping (Result<T.ResponseType, GiniError>) -> Void) {
-        if let apiMethod = resource.method as? APIMethod {
-            switch apiMethod {
-            case .createDocument(_, _, _, let documentType):
-                switch documentType {
-                case .none:
-                    completion(.success(SessionManagerMock.v3DocumentId as! T.ResponseType))
-                case .some:
-                    completion(.success(SessionManagerMock.partialDocumentId as! T.ResponseType))
-                }
-            default: break
-                
+        guard let apiMethod = resource.method as? APIMethod else {
+            return
+        }
+
+        switch apiMethod {
+        case .createDocument(_, _, _, let documentType):
+            let mockId = mockIdForDocumentType(documentType)
+
+            guard let typedResponse = mockId as? T.ResponseType else {
+                assertionFailure("Mock response type mismatch")
+                return
             }
+
+            completion(.success(typedResponse))
+
+        default:
+            break
+        }
+    }
+
+    private func mockIdForDocumentType(_ documentType: Document.TypeV2?) -> Any {
+        switch documentType {
+        case .none:
+            return SessionManagerMock.v3DocumentId
+        case .some:
+            return SessionManagerMock.partialDocumentId
         }
     }
 }

--- a/HealthAPILibrary/GiniHealthAPILibrary/Tests/GiniHealthAPILibraryTests/SessionManagerMock.swift
+++ b/HealthAPILibrary/GiniHealthAPILibrary/Tests/GiniHealthAPILibraryTests/SessionManagerMock.swift
@@ -10,7 +10,7 @@ import XCTest
 @testable import GiniHealthAPILibrary
 
 final class SessionManagerMock: SessionManagerProtocol {
-    
+
     static let v3DocumentId = "626626a0-749f-11e2-bfd6-000000000000"
     static let partialDocumentId = "5e06e343-9dff-4924-99ac-7d5b3abf592c"
     static let compositeDocumentId = "8d0c628d-95e8-4cf2-b4ea-d2daf03d8a32"
@@ -26,124 +26,136 @@ final class SessionManagerMock: SessionManagerProtocol {
     var paymentRequests: [PaymentRequest] = []
     var extractionFeedbackBody: Data?
 
-
     init(keyStore: KeyStore = KeychainStore(),
          urlSession: URLSession = URLSession(configuration: .default)) {
-        // This method will remain empty; mock implementation does not perform login
+        /// This method will remain empty; mock implementation does not perform login
     }
-    
+
     func initializeWithV3MockedDocuments() {
         documents = [
             load(fromFile: "document", type: "json")
         ]
     }
-    
+
     func initializeWithPaymentProvidersResponse() {
         providersResponse = load(fromFile: "providers", type: "json")
     }
-    
+
     func initializeWithPaymentRequests() {
         paymentRequests = load(fromFile: "paymentRequests", type: "json")
     }
-    
+
     func initializeWithV2MockedDocuments() {
         documents = [
             load(fromFile: "partialDocument", type: "json"),
             load(fromFile: "compositeDocument", type: "json")
         ]
     }
-    
+
     func logIn(completion: @escaping (Result<Token, GiniError>) -> Void) {
-        // This method will remain empty; mock implementation does not perform login
+        /// This method will remain empty; mock implementation does not perform login
     }
-    
+
     func logOut() {
-        // This method will remain empty; mock implementation does not perform login
+        /// This method will remain empty; mock implementation does not perform login
     }
-    
-    //swiftlint:disable all
+
     func data<T: Resource>(resource: T,
                            cancellationToken: CancellationToken?,
                            completion: @escaping (Result<T.ResponseType, GiniError>) -> Void) {
-        if let apiMethod = resource.method as? APIMethod {
-            switch apiMethod {
-            case .document(let id):
-                handleDocument(id: id, method: resource.params.method, completion: completion)
-            case .createDocument(_, _, _, _):
-                completion(.success(SessionManagerMock.compositeDocumentId as! T.ResponseType))
-            case .createPaymentRequest:
-                completion(.success(SessionManagerMock.paymentRequestId as! T.ResponseType))
-            case .paymentProvider(_):
-                let providerResponse: PaymentProviderResponse = load(fromFile: "provider", type: "json")
-                completion(.success(providerResponse as! T.ResponseType))
-            case .paymentProviders:
-                let paymentProvidersResponse: [PaymentProviderResponse] = load(fromFile: "providers", type: "json")
-                completion(.success(paymentProvidersResponse as! T.ResponseType))
-            case .paymentRequest(_):
-                if resource.params.method == .delete {
-                    completion(.success(SessionManagerMock.paymentRequestId as! T.ResponseType))
-                } else {
-                    let paymentRequest: PaymentRequest = load(fromFile: "paymentRequest", type: "json")
-                    completion(.success(paymentRequest as! T.ResponseType))
-                }
-            case .paymentRequests(_, _):
-                completion(.success(paymentRequests as! T.ResponseType))
-            case .feedback(_):
-                extractionFeedbackBody = resource.request.httpBody ?? nil
-                completion(.success("Feedback was sent" as! T.ResponseType))
-            case .payment(_):
-                let payment: Payment = load(fromFile: "payment", type: "json")
-                completion(.success(payment as! T.ResponseType))
-            case .pdfWithQRCode(_,_):
-                let pdfData = loadFile(withName: "pdfWithQR", ofType: "pdf")
-                completion(.success(pdfData as! T.ResponseType))
-            default:
-                let error = GiniError.unknown(response: nil, data: nil)
-                completion(.failure(error))
+        guard let apiMethod = resource.method as? APIMethod else {
+            failFast(description: "Unexpected resource.method \(resource.method) in mock data(...)",
+                     completion: completion)
+            return
+        }
+
+        switch apiMethod {
+        case .document(let id):
+            handleDocument(id: id,
+                           method: resource.params.method,
+                           completion: completion)
+        case .createDocument:
+            deliver(SessionManagerMock.compositeDocumentId, to: completion)
+        case .createPaymentRequest:
+            deliver(SessionManagerMock.paymentRequestId, to: completion)
+        case .paymentProvider:
+            let providerResponse: PaymentProviderResponse = load(fromFile: "provider", type: "json")
+            deliver(providerResponse, to: completion)
+        case .paymentProviders:
+            let paymentProvidersResponse: [PaymentProviderResponse] = load(fromFile: "providers", type: "json")
+            deliver(paymentProvidersResponse, to: completion)
+        case .paymentRequest:
+            if resource.params.method == .delete {
+                deliver(SessionManagerMock.paymentRequestId, to: completion)
+            } else {
+                let paymentRequest: PaymentRequest = load(fromFile: "paymentRequest", type: "json")
+                deliver(paymentRequest, to: completion)
             }
+        case .paymentRequests:
+            deliver(paymentRequests, to: completion)
+        case .feedback:
+            extractionFeedbackBody = resource.request.httpBody
+            deliver("Feedback was sent", to: completion)
+        case .payment:
+            let payment: Payment = load(fromFile: "payment", type: "json")
+            deliver(payment, to: completion)
+        case .pdfWithQRCode:
+            let pdfData = loadFile(withName: "pdfWithQR", ofType: "pdf")
+            deliver(pdfData, to: completion)
+        default:
+            completion(.failure(.unknown(response: nil, data: nil)))
         }
     }
 
-    private func handleDocument<T>(id: String, method: HTTPMethod,
+    private func handleDocument<T>(id: String,
+                                   method: HTTPMethod,
                                    completion: @escaping CompletionResult<T>) {
-
         switch (id, method) {
         case (SessionManagerMock.v3DocumentId, .get):
             let document: Document = load(fromFile: "document", type: "json")
-            completion(.success(document as! T))
+            deliver(document, to: completion)
         case (SessionManagerMock.v3DocumentId, .delete):
             documents.removeAll(where: { $0.id == id })
-            completion(.success("Deleted" as! T))
+            deliver("Deleted", to: completion)
         case (SessionManagerMock.partialDocumentId, .get):
             let document: Document = load(fromFile: "partialDocument", type: "json")
-            completion(.success(document as! T))
+            deliver(document, to: completion)
         case (SessionManagerMock.partialDocumentId, .delete):
             documents.removeAll(where: { $0.id == id })
-            completion(.success("Deleted" as! T))
+            deliver("Deleted", to: completion)
         case (SessionManagerMock.compositeDocumentId, .get):
             let document: Document = load(fromFile: "compositeDocument", type: "json")
-            completion(.success(document as! T))
+            deliver(document, to: completion)
         case (SessionManagerMock.compositeDocumentId, .delete):
             documents.removeAll(where: { $0.id == id })
-            completion(.success("Deleted" as! T))
+            deliver("Deleted", to: completion)
         default:
-            fatalError("Document id not found in tests")
+            XCTFail("Document id \(id) not found in tests")
+            completion(.failure(.unknown(response: nil, data: nil)))
         }
     }
 
     func download<T: Resource>(resource: T,
                                cancellationToken: CancellationToken?,
                                completion: @escaping (Result<T.ResponseType, GiniError>) -> Void) {
-        if let apiMethod = resource.method as? APIMethod {
-            switch apiMethod {
-            case .file(_):
-                let imageData = UIImage(named: "Gini-Test-Payment-Provider",
-                                        in: Bundle.module,
-                                        compatibleWith: nil)?.pngData()
-                completion(.success(imageData as! T.ResponseType))
-            default:
-                break
+        guard let apiMethod = resource.method as? APIMethod else {
+            failFast(description: "Unexpected resource.method \(resource.method) in mock download(...)",
+                     completion: completion)
+            return
+        }
+
+        switch apiMethod {
+        case .file:
+            guard let imageData = UIImage(named: "Gini-Test-Payment-Provider",
+                                          in: Bundle.module,
+                                          compatibleWith: nil)?.pngData() else {
+                XCTFail("Gini-Test-Payment-Provider asset missing from test bundle")
+                completion(.failure(.unknown(response: nil, data: nil)))
+                return
             }
+            deliver(imageData, to: completion)
+        default:
+            break
         }
     }
 
@@ -152,23 +164,14 @@ final class SessionManagerMock: SessionManagerProtocol {
                              cancellationToken: CancellationToken?,
                              completion: @escaping (Result<T.ResponseType, GiniError>) -> Void) {
         guard let apiMethod = resource.method as? APIMethod else {
+            failFast(description: "Unexpected resource.method \(resource.method) in mock upload(...)",
+                     completion: completion)
             return
         }
 
         switch apiMethod {
         case .createDocument(_, _, _, let documentType):
-            let mockId = mockIdForDocumentType(documentType)
-
-            guard let typedResponse = mockId as? T.ResponseType else {
-                /// Fail fast so async tests surface the mismatch instead of hanging on completion.
-                let mismatch = "SessionManagerMock: expected T.ResponseType == String, got \(T.ResponseType.self)"
-                XCTFail(mismatch)
-                completion(.failure(.parseError(message: mismatch, response: nil, data: nil)))
-                return
-            }
-
-            completion(.success(typedResponse))
-
+            deliver(mockIdForDocumentType(documentType), to: completion)
         default:
             break
         }
@@ -181,5 +184,41 @@ final class SessionManagerMock: SessionManagerProtocol {
         case .some:
             return SessionManagerMock.partialDocumentId
         }
+    }
+
+    // MARK: - Response routing
+
+    /**
+     Deliver `value` to `completion` typed as `Response`. Runtime-checks the cast
+     via `as?` and fails-fast on mismatch instead of force-casting — mirrors the
+     helper on the Bank API's SessionManagerMock so async tests surface type
+     drift as a clear XCTFail rather than a crash.
+     */
+    private func deliver<Response>(_ value: Any,
+                                   to completion: @escaping (Result<Response, GiniError>) -> Void,
+                                   file: StaticString = #file,
+                                   line: UInt = #line) {
+        if let typed = value as? Response {
+            completion(.success(typed))
+        } else {
+            XCTFail("Type mismatch: expected \(Response.self), got \(type(of: value))",
+                    file: file, line: line)
+            completion(.failure(.parseError(message: "Type mismatch in SessionManagerMock",
+                                            response: nil,
+                                            data: nil)))
+        }
+    }
+
+    /**
+     Called from the top-level `resource.method as? APIMethod` guards — records
+     an XCTFail so unexpected inputs surface immediately, then completes with a
+     `.unknown` failure so callers awaiting the completion aren't left hanging.
+     */
+    private func failFast<T>(description: String,
+                             completion: @escaping (Result<T, GiniError>) -> Void,
+                             file: StaticString = #file,
+                             line: UInt = #line) {
+        XCTFail(description, file: file, line: line)
+        completion(.failure(.unknown(response: nil, data: nil)))
     }
 }

--- a/HealthAPILibrary/GiniHealthAPILibrary/Tests/GiniHealthAPILibraryTests/SessionManagerMock.swift
+++ b/HealthAPILibrary/GiniHealthAPILibrary/Tests/GiniHealthAPILibraryTests/SessionManagerMock.swift
@@ -160,7 +160,10 @@ final class SessionManagerMock: SessionManagerProtocol {
             let mockId = mockIdForDocumentType(documentType)
 
             guard let typedResponse = mockId as? T.ResponseType else {
-                assertionFailure("Mock response type mismatch")
+                /// Fail fast so async tests surface the mismatch instead of hanging on completion.
+                let mismatch = "SessionManagerMock: expected T.ResponseType == String, got \(T.ResponseType.self)"
+                XCTFail(mismatch)
+                completion(.failure(.parseError(message: mismatch, response: nil, data: nil)))
                 return
             }
 
@@ -171,7 +174,7 @@ final class SessionManagerMock: SessionManagerProtocol {
         }
     }
 
-    private func mockIdForDocumentType(_ documentType: Document.TypeV2?) -> Any {
+    private func mockIdForDocumentType(_ documentType: Document.TypeV2?) -> String {
         switch documentType {
         case .none:
             return SessionManagerMock.v3DocumentId

--- a/HealthAPILibrary/GiniHealthAPILibrary/Tests/GiniHealthAPILibraryTests/URLProtocolMock.swift
+++ b/HealthAPILibrary/GiniHealthAPILibrary/Tests/GiniHealthAPILibraryTests/URLProtocolMock.swift
@@ -1,4 +1,4 @@
-// 
+//
 //  URLProtocolMock.swift
 //  GiniHealthAPILibraryTests
 //
@@ -8,8 +8,27 @@
 import Foundation
 import XCTest
 
+/**
+ URLProtocol stub whose per-request behaviour is defined by `handler`.
+
+ Register with an `URLSessionConfiguration`:
+
+     let config = URLSessionConfiguration.ephemeral
+     config.protocolClasses = [URLProtocolMock.self]
+     URLProtocolMock.handler = { request in
+         (URLProtocolMock.makeResponse(for: request, statusCode: 200), Data())
+     }
+ */
 class URLProtocolMock: URLProtocol {
     static var handler: ((URLRequest) -> (HTTPURLResponse, Data?))?
+
+    /**
+     Optional error injector. When set, takes precedence over `handler` and
+     surfaces the returned `Error` via `URLProtocolClient.urlProtocol(_:didFailWithError:)`
+     — the same pathway URLSession uses for real network errors like
+     `NSURLErrorNotConnectedToInternet`.
+     */
+    static var errorHandler: ((URLRequest) -> Error)?
 
     override class func canInit(with request: URLRequest) -> Bool {
         true
@@ -20,6 +39,10 @@ class URLProtocolMock: URLProtocol {
     }
 
     override func startLoading() {
+        if let errorHandler = URLProtocolMock.errorHandler {
+            client?.urlProtocol(self, didFailWithError: errorHandler(request))
+            return
+        }
         guard let handler = URLProtocolMock.handler else {
             fatalError("Handler is not set.")
         }
@@ -33,6 +56,38 @@ class URLProtocolMock: URLProtocol {
     }
 
     override func stopLoading() {
-        // This method will remain empty; no implementation is needed.
+        /// no-op — nothing to tear down
+    }
+
+    // MARK: - Helpers
+
+    /**
+     Fallback URL for the rare case where a `URLRequest` arrives without one —
+     the returned `HTTPURLResponse` needs a non-optional URL, so we lean on this
+     known-good constant instead of force-unwrapping at every call site.
+     */
+    static let fallbackURL: URL = {
+        guard let url = URL(string: "https://user.gini.net") else {
+            fatalError("URLProtocolMock.fallbackURL literal is malformed")
+        }
+        return url
+    }()
+
+    /**
+     Build an `HTTPURLResponse` with the requested status code — the initializer
+     is optional, so callers would otherwise force-unwrap; this helper wraps the
+     invariant in one place.
+     */
+    static func makeResponse(for request: URLRequest,
+                             statusCode: Int,
+                             headers: [String: String]? = nil) -> HTTPURLResponse {
+        let url = request.url ?? fallbackURL
+        guard let response = HTTPURLResponse(url: url,
+                                             statusCode: statusCode,
+                                             httpVersion: nil,
+                                             headerFields: headers) else {
+            fatalError("Failed to build HTTPURLResponse with status \(statusCode) for \(url)")
+        }
+        return response
     }
 }


### PR DESCRIPTION
SonarQube fixes for GiniHealthAPILibrary: SessionManager auth and DocumentService nesting reduction, SessionManagerMock cleanup.

Part of the SonarQube cleanup split from `release/SonarQube-issues` — one PR per SDK for easier review. No public API changes; independent of the sibling SonarQube PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)