### PR TITLE
refactor(GiniHealthSDK): Fix SonarQube issues

### DIFF
--- a/HealthSDK/GiniHealthSDK/Sources/GiniHealthSDK/Core/GiniHealth.swift
+++ b/HealthSDK/GiniHealthSDK/Sources/GiniHealthSDK/Core/GiniHealth.swift
@@ -13,10 +13,10 @@ import GiniInternalPaymentSDK
 /**
  Delegate to inform about the current status of the Gini Health SDK.
  Makes use of callback for handling payment request creation.
- 
+
  */
 public protocol GiniHealthDelegate: AnyObject {
-    
+
     /**
      Called when the payment request was successfully created.
 
@@ -31,7 +31,7 @@ public protocol GiniHealthDelegate: AnyObject {
      - Parameter error: The error to evaluate.
      */
     func shouldHandleErrorInternally(error: GiniHealthError) -> Bool
-    
+
     /**
      Called when the Gini Health SDK has been dismissed.
      */
@@ -123,12 +123,12 @@ public struct DataForReview {
         self.paymentComponentsController = PaymentComponentsController(giniHealth: self)
         self.paymentComponentsController.delegate = self
     }
-    
+
     /**
      Initializes a new instance of GiniHealth.
-     
+
      This initializer creates a GiniHealth instance by first constructing a Client object with the provided client credentials (id, secret, domain)
-     
+
      - Parameters:
        - id: The client ID provided by Gini when you register your application. This is a unique identifier for your application.
        - secret: The client secret provided by Gini alongside the client ID. This is used to authenticate your application to the Gini API.
@@ -169,7 +169,7 @@ public struct DataForReview {
         self.paymentComponentsController = PaymentComponentsController(giniHealth: self)
         self.paymentComponentsController.delegate = self
     }
-    
+
     /**
      Initiates the payment flow for a specified document and payment information.
 
@@ -182,7 +182,7 @@ public struct DataForReview {
     public func startPaymentFlow(documentId: String?, paymentInfo: GiniHealthSDK.PaymentInfo?, navigationController: UINavigationController, trackingDelegate: GiniHealthTrackingDelegate?) {
         paymentComponentsController.startPaymentFlow(documentId: documentId, paymentInfo: paymentInfo, navigationController: navigationController, trackingDelegate: trackingDelegate)
     }
-    
+
     /**
      Fetches bank logos for the available payment providers.
 
@@ -212,7 +212,7 @@ public struct DataForReview {
             }
         }
     }
-    
+
     /**
      Sets a configuration used to customize the look of the Gini Health SDK, for example to change texts and colors displayed to the user.
 
@@ -240,16 +240,7 @@ public struct DataForReview {
                self.documentService.extractions(for: createdDocument,
                                                 cancellationToken: CancellationToken()) { result in
                    DispatchQueue.main.async {
-                       switch result {
-                       case let .success(extractionResult):
-                               if let paymentStateExtraction = extractionResult.extractions.first(where: { $0.name == ExtractionType.paymentState.rawValue })?.value, paymentStateExtraction == PaymentState.payable.rawValue {
-                               completion(.success(true))
-                           } else {
-                               completion(.success(false))
-                           }
-                       case .failure(let error):
-                           completion(.failure(.apiError(error)))
-                       }
+                       self.handleExtractionResult(result, completion: completion)
                    }
                }
            case .failure(let error):
@@ -258,6 +249,20 @@ public struct DataForReview {
        }
    }
 
+    private func handleExtractionResult(_ result: Result<ExtractionResult, GiniError>,
+                                        completion: @escaping (Result<Bool, GiniHealthError>) -> Void)  {
+
+        switch result {
+        case let .success(extractionResult):
+            if let paymentStateExtraction = extractionResult.extractions.first(where: { $0.name == ExtractionType.paymentState.rawValue })?.value, paymentStateExtraction == PaymentState.payable.rawValue {
+                completion(.success(true))
+            } else {
+                completion(.success(false))
+            }
+        case .failure(let error):
+            completion(.failure(.apiError(error)))
+        }
+    }
     /**
      Checks if the document contains multiple invoices.
 
@@ -274,23 +279,28 @@ public struct DataForReview {
             switch result {
             case let .success(createdDocument):
                 self.documentService.extractions(for: createdDocument,
-                                                 cancellationToken: CancellationToken()) { result in
+                                                 cancellationToken: CancellationToken()) { [weak self] result in
                     DispatchQueue.main.async {
-                        switch result {
-                        case let .success(extractionResult):
-                                if let containsMultipleDocsExtraction = extractionResult.extractions.first(where: { $0.name == ExtractionType.containsMultipleDocs.rawValue })?.value, containsMultipleDocsExtraction == Constants.hasMultipleDocuments {
-                                completion(.success(true))
-                            } else {
-                                completion(.success(false))
-                            }
-                        case .failure(let error):
-                            completion(.failure(.apiError(error)))
-                        }
+                        self?.handleMultipleDocsExtractionResult(result, completion: completion)
                     }
                 }
             case .failure(let error):
                 completion(.failure(.apiError(error)))
             }
+        }
+    }
+
+    private func handleMultipleDocsExtractionResult(_ result: Result<ExtractionResult, GiniError>,
+                                                    completion: @escaping (Result<Bool, GiniHealthError>) -> Void) {
+        switch result {
+        case let .success(extractionResult):
+            if let containsMultipleDocsExtraction = extractionResult.extractions.first(where: { $0.name == ExtractionType.containsMultipleDocs.rawValue })?.value, containsMultipleDocsExtraction == Constants.hasMultipleDocuments {
+                completion(.success(true))
+            } else {
+                completion(.success(false))
+            }
+        case .failure(let error):
+            completion(.failure(.apiError(error)))
         }
     }
 
@@ -313,7 +323,7 @@ public struct DataForReview {
             }
         }
     }
-    
+
     /**
      Retrieves payment extractions for the given document.
 
@@ -327,32 +337,45 @@ public struct DataForReview {
                 completion(.failure(.apiError(GiniError.toGiniHealthSDKError(error: .requestCancelled))))
                 return
             }
-            switch result {
-            case let .success(createdDocument):
-                self.documentService
-                        .extractions(for: createdDocument,
-                                     cancellationToken: CancellationToken()) { result in
-                            DispatchQueue.main.async {
-                                switch result {
-                                case let .success(extractionResult):
-                                    if let paymentExtractionsContainer = extractionResult.payment, let paymentExtractions = paymentExtractionsContainer.first {
-                                        completion(.success(paymentExtractions))
-                                    } else {
-                                        completion(.failure(.noPaymentDataExtracted))
-                                    }
-                                case let .failure(error):
-                                    completion(.failure(.apiError(error)))
-                                }
-                            }
-                        }
-            case let .failure(error):
-                DispatchQueue.main.async {
-                    completion(.failure(.apiError(error)))
-                }
-            }
+            self.handleFetchedDocument(result: result, completion: completion)
         }
     }
 
+    private func handleFetchedDocument(result: Result<Document, GiniError>,
+                                       completion: @escaping (Result<[Extraction], GiniHealthError>) -> Void) {
+        switch result {
+        case let .success(document):
+            fetchExtractions(for: document, completion: completion)
+
+        case let .failure(error):
+            DispatchQueue.main.async {
+                completion(.failure(.apiError(error)))
+            }
+        }
+    }
+    
+    private func fetchExtractions(for document: Document,
+                                  completion: @escaping (Result<[Extraction], GiniHealthError>) -> Void) {
+        documentService.extractions(for: document, cancellationToken: CancellationToken()) { result in
+            DispatchQueue.main.async { [weak self] in
+                self?.handlePaymentExtractionResult(result, completion: completion)
+            }
+        }
+    }
+    
+    private func handlePaymentExtractionResult(_ result: Result<ExtractionResult, GiniError>,
+                                               completion: @escaping (Result<[Extraction], GiniHealthError>) -> Void) {
+        switch result {
+        case let .success(extractionResult):
+            if let paymentExtractionsContainer = extractionResult.payment, let paymentExtractions = paymentExtractionsContainer.first {
+                completion(.success(paymentExtractions))
+            } else {
+                completion(.failure(.noPaymentDataExtracted))
+            }
+        case let .failure(error):
+            completion(.failure(.apiError(error)))
+        }
+    }
     /**
      Retrieves all extractions for the given document, including medical information.
 
@@ -369,17 +392,13 @@ public struct DataForReview {
             switch result {
             case let .success(createdDocument):
                 self.documentService
-                        .extractions(for: createdDocument,
-                                     cancellationToken: CancellationToken()) { result in
-                            DispatchQueue.main.async {
-                                switch result {
-                                case let .success(extractionResult):
-                                    completion(.success(extractionResult.extractions))
-                                case let .failure(error):
-                                    completion(.failure(.apiError(error)))
-                                }
-                            }
+                    .extractions(for: createdDocument,
+                                 cancellationToken: CancellationToken()) { result in
+
+                        DispatchQueue.main.async {
+                            self.handleGetAllExtractionsResult(result, completion: completion)
                         }
+                    }
             case let .failure(error):
                 DispatchQueue.main.async {
                     completion(.failure(.apiError(error)))
@@ -387,6 +406,17 @@ public struct DataForReview {
             }
         }
     }
+
+    private func handleGetAllExtractionsResult(_ result: Result<ExtractionResult, GiniError>,
+                                               completion: @escaping (Result<[Extraction], GiniHealthError>) -> Void) {
+        switch result {
+        case let .success(extractionResult):
+            completion(.success(extractionResult.extractions))
+        case let .failure(error):
+            completion(.failure(.apiError(error)))
+        }
+    }
+
 
     /**
      Submits extraction feedback for the specified document.
@@ -439,7 +469,7 @@ public struct DataForReview {
             }
         }
     }
-    
+
     /**
      Deletes a payment request.
 
@@ -459,7 +489,7 @@ public struct DataForReview {
             }
         }
     }
-    
+
     /**
      Deletes a batch of payment requests.
 
@@ -479,7 +509,7 @@ public struct DataForReview {
             }
         }
     }
-    
+
     /**
      Opens the selected payment provider app using the given payment request ID and universal link.
 
@@ -499,7 +529,7 @@ public struct DataForReview {
             urlOpener.openLink(url: resultUrl, completion: completion)
         }
     }
-    
+
     /**
      Fetches payment extractions for a given document, for use on the payment review screen.
 
@@ -530,7 +560,7 @@ public struct DataForReview {
             }
         }
     }
-    
+
     /**
      Fetches document and payment extractions for the payment review screen.
 
@@ -550,17 +580,7 @@ public struct DataForReview {
                     .extractions(for: document,
                                  cancellationToken: CancellationToken()) { result in
                         DispatchQueue.main.async {
-                            switch result {
-                            case let .success(extractionResult):
-                                if let paymentExtractionsContainer = extractionResult.payment, let paymentExtractions = paymentExtractionsContainer.first {
-                                    let fetchedData = DataForReview(document: document, extractions: paymentExtractions)
-                                    completion(.success(fetchedData))
-                                } else {
-                                    completion(.failure(.noPaymentDataExtracted))
-                                }
-                            case let .failure(error):
-                                completion(.failure(.apiError(error)))
-                            }
+                            self.handleFetchDataForReviewResult(document: document, result: result, completion: completion)
                         }
                     }
             case let .failure(error):
@@ -570,7 +590,24 @@ public struct DataForReview {
             }
         }
     }
-    
+
+    private func handleFetchDataForReviewResult(document: Document, result: Result<ExtractionResult, GiniError>,
+                                                completion: @escaping (Result<DataForReview, GiniHealthError>) -> Void) {
+
+        switch result {
+        case let .success(extractionResult):
+            if let paymentExtractionsContainer = extractionResult.payment, let paymentExtractions = paymentExtractionsContainer.first {
+                let fetchedData = DataForReview(document: document, extractions: paymentExtractions)
+                completion(.success(fetchedData))
+            } else {
+                completion(.failure(.noPaymentDataExtracted))
+            }
+        case let .failure(error):
+            completion(.failure(.apiError(error)))
+        }
+
+    }
+
     /**
      Retrieves a payment request by ID.
 
@@ -612,7 +649,7 @@ public struct DataForReview {
             }
         }
     }
-    
+
     /**
      Retrieves the payment associated with the specified payment request.
 
@@ -644,11 +681,11 @@ extension GiniHealth: PaymentComponentsControllerProtocol {
     public func isLoadingStateChanged(isLoading: Bool) {
         paymentDelegate?.isLoadingStateChanged(isLoading: isLoading)
     }
-    
+
     public func didFetchedPaymentProviders() {
         paymentDelegate?.didFetchedPaymentProviders()
     }
-    
+
     public func didDismissPaymentComponents() {
         delegate?.didDismissHealthSDK()
     }

--- a/HealthSDK/GiniHealthSDK/Sources/GiniHealthSDK/Core/GiniHealth.swift
+++ b/HealthSDK/GiniHealthSDK/Sources/GiniHealthSDK/Core/GiniHealth.swift
@@ -278,10 +278,13 @@ public struct DataForReview {
             }
             switch result {
             case let .success(createdDocument):
+                // Strong self on the inner extractions closure keeps `self` alive until
+                // `completion` fires — `[weak self]` here would silently drop the callback
+                // if the caller released `GiniHealth` mid-request.
                 self.documentService.extractions(for: createdDocument,
-                                                 cancellationToken: CancellationToken()) { [weak self] result in
+                                                 cancellationToken: CancellationToken()) { result in
                     DispatchQueue.main.async {
-                        self?.handleMultipleDocsExtractionResult(result, completion: completion)
+                        self.handleMultipleDocsExtractionResult(result, completion: completion)
                     }
                 }
             case .failure(let error):
@@ -356,9 +359,12 @@ public struct DataForReview {
     
     private func fetchExtractions(for document: Document,
                                   completion: @escaping (Result<[Extraction], GiniHealthError>) -> Void) {
+        // Strong self capture keeps `GiniHealth` alive until `completion` fires — a
+        // `[weak self]` here would silently drop the callback if the caller released
+        // the SDK between initiating the request and its response.
         documentService.extractions(for: document, cancellationToken: CancellationToken()) { result in
-            DispatchQueue.main.async { [weak self] in
-                self?.handlePaymentExtractionResult(result, completion: completion)
+            DispatchQueue.main.async {
+                self.handlePaymentExtractionResult(result, completion: completion)
             }
         }
     }

--- a/HealthSDK/GiniHealthSDK/Sources/GiniHealthSDK/Core/GiniHealth.swift
+++ b/HealthSDK/GiniHealthSDK/Sources/GiniHealthSDK/Core/GiniHealth.swift
@@ -250,8 +250,7 @@ public struct DataForReview {
    }
 
     private func handleExtractionResult(_ result: Result<ExtractionResult, GiniError>,
-                                        completion: @escaping (Result<Bool, GiniHealthError>) -> Void)  {
-
+                                        completion: @escaping (Result<Bool, GiniHealthError>) -> Void) {
         switch result {
         case let .success(extractionResult):
             if let paymentStateExtraction = extractionResult.extractions.first(where: { $0.name == ExtractionType.paymentState.rawValue })?.value, paymentStateExtraction == PaymentState.payable.rawValue {
@@ -422,7 +421,6 @@ public struct DataForReview {
             completion(.failure(.apiError(error)))
         }
     }
-
 
     /**
      Submits extraction feedback for the specified document.
@@ -612,7 +610,6 @@ public struct DataForReview {
         case let .failure(error):
             completion(.failure(.apiError(error)))
         }
-
     }
 
     /**

--- a/HealthSDK/GiniHealthSDK/Sources/GiniHealthSDK/Core/GiniHealth.swift
+++ b/HealthSDK/GiniHealthSDK/Sources/GiniHealthSDK/Core/GiniHealth.swift
@@ -597,7 +597,8 @@ public struct DataForReview {
         }
     }
 
-    private func handleFetchDataForReviewResult(document: Document, result: Result<ExtractionResult, GiniError>,
+    private func handleFetchDataForReviewResult(document: Document,
+                                                result: Result<ExtractionResult, GiniError>,
                                                 completion: @escaping (Result<DataForReview, GiniHealthError>) -> Void) {
 
         switch result {

--- a/HealthSDK/GiniHealthSDK/Sources/GiniHealthSDK/Core/PaymentComponentsController+Helpers.swift
+++ b/HealthSDK/GiniHealthSDK/Sources/GiniHealthSDK/Core/PaymentComponentsController+Helpers.swift
@@ -647,38 +647,61 @@ extension PaymentComponentsController: PaymentComponentViewProtocol {
         GiniUtilites.Log("Tapped on Bank Picker on :\(documentId ?? "")", event: .success)
         if GiniHealthConfiguration.shared.useBottomPaymentComponentView {
             let bankSelectionBottomSheet = bankSelectionBottomSheet()
-            navigationControllerProvided?.giniTopMostViewController().present(bankSelectionBottomSheet, animated: true)
+            navigationControllerProvided?.giniTopMostViewController().present(bankSelectionBottomSheet,
+                                                                              animated: true)
         }
     }
     
     /// Handles the action when the pay invoice button is tapped on the payment component view, using the provided document ID.
     public func didTapOnPayInvoice(documentId: String?) {
         GiniUtilites.Log("Tapped on Pay Invoice on :\(documentId ?? "")", event: .success)
-        if GiniHealthConfiguration.shared.showPaymentReviewScreen || !GiniHealthConfiguration.shared.useInvoiceWithoutDocument {
-            loadPaymentReviewScreenFor(trackingDelegate: self) { [weak self] viewController, error in
-                if let error = error {
-                    self?.handleError(error)
-                } else if let viewController = viewController {
-                    self?.presentOrPushPaymentReviewScreen(viewController)
-                }
-            }
+
+        if shouldShowPaymentReviewScreen() {
+            handlePaymentReviewFlow()
         } else {
-            if supportsOpenWith() {
-                guard let paymentInfo else { return }
-                createPaymentRequest(paymentInfo: paymentInfo) { [weak self] result in
-                    self?.handlePaymentRequestResult(result)
-                }
-            } else if supportsGPC() {
-                if canOpenPaymentProviderApp() {
-                    guard let paymentInfo else { return }
-                    processPaymentRequest(paymentInfo: paymentInfo)
-                } else {
-                    presentInstallAppBottomSheet()
-                }
+            handleExternalPaymentFlow()
+        }
+    }
+
+    private func shouldShowPaymentReviewScreen() -> Bool {
+        return GiniHealthConfiguration.shared.showPaymentReviewScreen ||
+        !GiniHealthConfiguration.shared.useInvoiceWithoutDocument
+    }
+
+    private func handlePaymentReviewFlow() {
+        loadPaymentReviewScreenFor(trackingDelegate: self) { [weak self] viewController, error in
+            if let error = error {
+                self?.handleError(error)
+            } else if let viewController = viewController {
+                self?.presentOrPushPaymentReviewScreen(viewController)
             }
         }
     }
-    
+
+    private func handleExternalPaymentFlow() {
+        guard let paymentInfo = paymentInfo else { return }
+
+        if supportsOpenWith() {
+            handleOpenWithPayment(paymentInfo: paymentInfo)
+        } else if supportsGPC() {
+            handleGPCPayment(paymentInfo: paymentInfo)
+        }
+    }
+
+    private func handleOpenWithPayment(paymentInfo: GiniInternalPaymentSDK.PaymentInfo) {
+        createPaymentRequest(paymentInfo: paymentInfo) { [weak self] result in
+            self?.handlePaymentRequestResult(result)
+        }
+    }
+
+    private func handleGPCPayment(paymentInfo: GiniInternalPaymentSDK.PaymentInfo) {
+        if canOpenPaymentProviderApp() {
+            processPaymentRequest(paymentInfo: paymentInfo)
+        } else {
+            presentInstallAppBottomSheet()
+        }
+    }
+
     public func didDismissPaymentComponent() {
         notifySDKWasDismissedIfNeeded()
     }

--- a/HealthSDK/GiniHealthSDK/Sources/GiniHealthSDK/Core/PaymentComponentsController+Helpers.swift
+++ b/HealthSDK/GiniHealthSDK/Sources/GiniHealthSDK/Core/PaymentComponentsController+Helpers.swift
@@ -679,25 +679,27 @@ extension PaymentComponentsController: PaymentComponentViewProtocol {
     }
 
     private func handleExternalPaymentFlow() {
-        guard let paymentInfo = paymentInfo else { return }
-
         if supportsOpenWith() {
-            handleOpenWithPayment(paymentInfo: paymentInfo)
+            handleOpenWithPayment()
         } else if supportsGPC() {
-            handleGPCPayment(paymentInfo: paymentInfo)
+            handleGPCPayment()
         }
     }
 
-    private func handleOpenWithPayment(paymentInfo: GiniInternalPaymentSDK.PaymentInfo) {
+    private func handleOpenWithPayment() {
+        guard let paymentInfo else { return }
         createPaymentRequest(paymentInfo: paymentInfo) { [weak self] result in
             self?.handlePaymentRequestResult(result)
         }
     }
 
-    private func handleGPCPayment(paymentInfo: GiniInternalPaymentSDK.PaymentInfo) {
+    private func handleGPCPayment() {
         if canOpenPaymentProviderApp() {
+            guard let paymentInfo else { return }
             processPaymentRequest(paymentInfo: paymentInfo)
         } else {
+            // The install-app sheet must remain reachable when `paymentInfo` is nil —
+            // do not hoist a `guard let paymentInfo` above this branch.
             presentInstallAppBottomSheet()
         }
     }

--- a/HealthSDK/GiniHealthSDK/Tests/GiniHealthSDKTests/GiniHealthDocumentHandlingTests.swift
+++ b/HealthSDK/GiniHealthSDK/Tests/GiniHealthSDKTests/GiniHealthDocumentHandlingTests.swift
@@ -230,6 +230,46 @@ final class GiniHealthDocumentHandlingTests: GiniHealthTestCase {
             XCTAssertNotNil(error, "Error should not be nil when document is missing")
         }
     }
+
+    // MARK: - Submit Feedback
+
+    func testSubmitFeedbackReturnsSuccessWhenSuccessful() throws {
+        let extractionsContainer: GiniHealthSDK.ExtractionsContainer = try XCTUnwrap(
+            GiniHealthSDKTests.load(fromFile: "extractionResultWithIBAN"))
+        let updatedExtractions = GiniHealthSDK.ExtractionResult(extractionsContainer: extractionsContainer).extractions
+
+        let result = try XCTUnwrap(waitForResult {
+            giniHealth.submitFeedback(docId: MockSessionManager.payableDocumentID,
+                                      updatedExtractions: updatedExtractions,
+                                      completion: $0)
+        })
+
+        switch result {
+        case .success:
+            break // Expected
+        case .failure(let error):
+            XCTFail("Expected success but received error: \(error)")
+        }
+    }
+
+    func testSubmitFeedbackReturnsErrorWhenFailure() throws {
+        let extractionsContainer: GiniHealthSDK.ExtractionsContainer = try XCTUnwrap(
+            GiniHealthSDKTests.load(fromFile: "extractionResultWithIBAN"))
+        let updatedExtractions = GiniHealthSDK.ExtractionResult(extractionsContainer: extractionsContainer).extractions
+
+        let result = try XCTUnwrap(waitForResult {
+            giniHealth.submitFeedback(docId: MockSessionManager.failurePayableDocumentID,
+                                      updatedExtractions: updatedExtractions,
+                                      completion: $0)
+        })
+
+        switch result {
+        case .success:
+            XCTFail("Expected failure but received success")
+        case .failure(let error):
+            XCTAssertNotNil(error, "Error should not be nil when the feedback request fails")
+        }
+    }
 }
 
 

--- a/HealthSDK/GiniHealthSDK/Tests/GiniHealthSDKTests/GiniHealthExtractionsHandlingTests.swift
+++ b/HealthSDK/GiniHealthSDK/Tests/GiniHealthSDKTests/GiniHealthExtractionsHandlingTests.swift
@@ -375,114 +375,98 @@ final class GiniHealthExtractionsHandlingTests: GiniHealthTestCase {
 
     // MARK: - Silent-drop regression tests (PR #1260)
     //
-    // The two tests below prove that dropping the strong reference to `GiniHealth`
-    // between the `fetchDocument` completion and the `extractions` completion does
-    // not silently drop the caller's `completion`. Before PR #1260, the inner
-    // extractions closures in `checkIfDocumentContainsMultipleInvoices` and
-    // `fetchExtractions` (used by `getExtractions`) captured `[weak self]` and
-    // called `self?.handleXxxExtractionResult(...)` — when `self` was nil, the
-    // method call became a no-op and `completion` was never invoked. The fix
+    // The two tests below prove that dropping the caller's strong reference to
+    // `GiniHealth` between the `fetchDocument` completion and the `extractions`
+    // completion does not silently drop the caller's `completion`. Before PR
+    // #1260, the inner extractions closures in
+    // `checkIfDocumentContainsMultipleInvoices` and `fetchExtractions` (used
+    // by `getExtractions`) captured `[weak self]` and called
+    // `self?.handleXxxExtractionResult(...)` — when `self` was nil, the method
+    // call became a no-op and `completion` was never invoked. The fix
     // switched the inner captures to strong `self`, so the closure keeps the
     // SDK alive until the callback runs.
     //
-    // These tests use `DelayableMockSessionManager` to introduce a 100ms window
-    // between the (synchronous) `fetchDocument` return and the extractions
-    // callback firing. The test then drops its strong reference to `GiniHealth`
-    // during that window. Any regression that re-introduces `[weak self]` on the
-    // inner closures makes the completion silently drop and the test time out.
+    // These tests use `DelayableMockSessionManager` to introduce a 100ms
+    // window between the (synchronous) `fetchDocument` return and the
+    // extractions callback firing. The test then drops its strong reference
+    // to `GiniHealth` during that window. Any regression that re-introduces
+    // `[weak self]` on the inner closures makes the completion silently drop
+    // and times the test out.
+    //
+    // Note: the tests do NOT assert that `GiniHealth` deallocates after the
+    // callback fires. `GiniHealth` and `PaymentComponentsController` currently
+    // hold each other strongly (see HEAL-563 for the pre-existing retain
+    // cycle), so the SDK stays alive even after the caller releases its
+    // strong reference. The invariant these tests protect is *completion
+    // fires*, not *SDK is released*.
 
     /// Regression test — `getExtractions` completion must fire even when the
     /// caller releases `GiniHealth` between the request start and the response.
     func testGetExtractionsFiresCompletionWhenSDKReleasedMidRequest() {
-        weak var weakSut: GiniHealth?
+        let sessionManager = DelayableMockSessionManager(extractionsDelay: 0.1)
+        let documentService = DefaultDocumentService(sessionManager: sessionManager,
+                                                     apiVersion: 5)
+        let paymentService = PaymentService(sessionManager: sessionManager,
+                                            apiVersion: 5)
+        let clientConfigurationService = ClientConfigurationService(sessionManager: sessionManager,
+                                                                    apiVersion: 5)
+        let api = GiniHealthAPI(documentService: documentService,
+                                paymentService: paymentService,
+                                clientConfigurationService: clientConfigurationService)
+        var sut: GiniHealth? = GiniHealth(giniApiLib: api)
+
+        let completionExpectation = self.expectation(description: "Completion fires after caller drops SDK reference")
         var receivedResult: Result<[GiniHealthSDK.Extraction], GiniHealthError>?
 
-        autoreleasepool {
-            let sessionManager = DelayableMockSessionManager(extractionsDelay: 0.1)
-            let documentService = DefaultDocumentService(sessionManager: sessionManager,
-                                                         apiVersion: 5)
-            let paymentService = PaymentService(sessionManager: sessionManager,
-                                                apiVersion: 5)
-            let clientConfigurationService = ClientConfigurationService(sessionManager: sessionManager,
-                                                                        apiVersion: 5)
-            let api = GiniHealthAPI(documentService: documentService,
-                                    paymentService: paymentService,
-                                    clientConfigurationService: clientConfigurationService)
-            var sut: GiniHealth? = GiniHealth(giniApiLib: api)
-            weakSut = sut
-
-            let completionExpectation = self.expectation(description: "Completion fires after SDK is released")
-
-            sut?.getExtractions(docId: MockSessionManager.extractionsWithPaymentDocumentID) { result in
-                receivedResult = result
-                completionExpectation.fulfill()
-            }
-
-            // Drop the caller's strong reference before the extractions callback fires.
-            // Only the pending closure keeps `sut` alive from here on.
-            sut = nil
-
-            wait(for: [completionExpectation], timeout: 2)
+        sut?.getExtractions(docId: MockSessionManager.extractionsWithPaymentDocumentID) { result in
+            receivedResult = result
+            completionExpectation.fulfill()
         }
 
+        // Drop the caller's strong reference before the extractions callback
+        // fires. Only the pending closure keeps the SDK alive from here on.
+        sut = nil
+
+        wait(for: [completionExpectation], timeout: 2)
+
         XCTAssertNotNil(receivedResult,
-                        "Completion must fire even when the SDK is released mid-request")
+                        "Completion must fire even when the caller releases the SDK mid-request")
         if case .failure(let error) = receivedResult {
             XCTFail("Expected success from the extractionsWithPayment fixture, got failure: \(error)")
         }
-
-        // Poll for deallocation rather than asserting instantly — after the
-        // main-queue completion block returns, ARC still needs a run-loop tick
-        // to release its strong self capture. A real retain cycle would keep
-        // `weakSut` non-nil past the timeout.
-        let deallocExpectation = expectation(for: NSPredicate { _, _ in weakSut == nil },
-                                             evaluatedWith: nil,
-                                             handler: nil)
-        wait(for: [deallocExpectation], timeout: 3)
     }
 
     /// Regression test — `checkIfDocumentContainsMultipleInvoices` completion
     /// must fire even when the caller releases `GiniHealth` mid-request.
     func testCheckIfDocumentContainsMultipleInvoicesFiresCompletionWhenSDKReleasedMidRequest() {
-        weak var weakSut: GiniHealth?
+        let sessionManager = DelayableMockSessionManager(extractionsDelay: 0.1)
+        let documentService = DefaultDocumentService(sessionManager: sessionManager,
+                                                     apiVersion: 5)
+        let paymentService = PaymentService(sessionManager: sessionManager,
+                                            apiVersion: 5)
+        let clientConfigurationService = ClientConfigurationService(sessionManager: sessionManager,
+                                                                    apiVersion: 5)
+        let api = GiniHealthAPI(documentService: documentService,
+                                paymentService: paymentService,
+                                clientConfigurationService: clientConfigurationService)
+        var sut: GiniHealth? = GiniHealth(giniApiLib: api)
+
+        let completionExpectation = self.expectation(description: "Completion fires after caller drops SDK reference")
         var receivedResult: Result<Bool, GiniHealthError>?
 
-        autoreleasepool {
-            let sessionManager = DelayableMockSessionManager(extractionsDelay: 0.1)
-            let documentService = DefaultDocumentService(sessionManager: sessionManager,
-                                                         apiVersion: 5)
-            let paymentService = PaymentService(sessionManager: sessionManager,
-                                                apiVersion: 5)
-            let clientConfigurationService = ClientConfigurationService(sessionManager: sessionManager,
-                                                                        apiVersion: 5)
-            let api = GiniHealthAPI(documentService: documentService,
-                                    paymentService: paymentService,
-                                    clientConfigurationService: clientConfigurationService)
-            var sut: GiniHealth? = GiniHealth(giniApiLib: api)
-            weakSut = sut
-
-            let completionExpectation = self.expectation(description: "Completion fires after SDK is released")
-
-            sut?.checkIfDocumentContainsMultipleInvoices(docId: MockSessionManager.notPayableDocumentID) { result in
-                receivedResult = result
-                completionExpectation.fulfill()
-            }
-
-            sut = nil
-
-            wait(for: [completionExpectation], timeout: 2)
+        sut?.checkIfDocumentContainsMultipleInvoices(docId: MockSessionManager.notPayableDocumentID) { result in
+            receivedResult = result
+            completionExpectation.fulfill()
         }
 
+        sut = nil
+
+        wait(for: [completionExpectation], timeout: 2)
+
         XCTAssertNotNil(receivedResult,
-                        "Completion must fire even when the SDK is released mid-request")
+                        "Completion must fire even when the caller releases the SDK mid-request")
         if case .failure(let error) = receivedResult {
             XCTFail("Expected success from the extractionResultWithoutIBAN fixture, got failure: \(error)")
         }
-
-        // Poll for deallocation — see companion test above for rationale.
-        let deallocExpectation = expectation(for: NSPredicate { _, _ in weakSut == nil },
-                                             evaluatedWith: nil,
-                                             handler: nil)
-        wait(for: [deallocExpectation], timeout: 3)
     }
 }

--- a/HealthSDK/GiniHealthSDK/Tests/GiniHealthSDKTests/GiniHealthExtractionsHandlingTests.swift
+++ b/HealthSDK/GiniHealthSDK/Tests/GiniHealthSDKTests/GiniHealthExtractionsHandlingTests.swift
@@ -372,4 +372,98 @@ final class GiniHealthExtractionsHandlingTests: GiniHealthTestCase {
         XCTAssertNotNil(receivedDoctorExtraction, "Doctor name extraction should not be nil")
         XCTAssertEqual(receivedDoctorExtraction?.value, expectedDoctorName, "Doctor name extraction value should match expected name")
     }
+
+    // MARK: - Silent-drop regression tests (PR #1260)
+    //
+    // The two tests below prove that dropping the strong reference to `GiniHealth`
+    // between the `fetchDocument` completion and the `extractions` completion does
+    // not silently drop the caller's `completion`. Before PR #1260, the inner
+    // extractions closures in `checkIfDocumentContainsMultipleInvoices` and
+    // `fetchExtractions` (used by `getExtractions`) captured `[weak self]` and
+    // called `self?.handleXxxExtractionResult(...)` — when `self` was nil, the
+    // method call became a no-op and `completion` was never invoked. The fix
+    // switched the inner captures to strong `self`, so the closure keeps the
+    // SDK alive until the callback runs.
+    //
+    // These tests use `DelayableMockSessionManager` to introduce a 100ms window
+    // between the (synchronous) `fetchDocument` return and the extractions
+    // callback firing. The test then drops its strong reference to `GiniHealth`
+    // during that window. Any regression that re-introduces `[weak self]` on the
+    // inner closures makes the completion silently drop and the test time out.
+
+    /// Regression test — `getExtractions` completion must fire even when the
+    /// caller releases `GiniHealth` between the request start and the response.
+    func testGetExtractionsFiresCompletionWhenSDKReleasedMidRequest() {
+        let sessionManager = DelayableMockSessionManager(extractionsDelay: 0.1)
+        let documentService = DefaultDocumentService(sessionManager: sessionManager,
+                                                     apiVersion: 5)
+        let paymentService = PaymentService(sessionManager: sessionManager,
+                                            apiVersion: 5)
+        let clientConfigurationService = ClientConfigurationService(sessionManager: sessionManager,
+                                                                    apiVersion: 5)
+        let api = GiniHealthAPI(documentService: documentService,
+                                paymentService: paymentService,
+                                clientConfigurationService: clientConfigurationService)
+        var sut: GiniHealth? = GiniHealth(giniApiLib: api)
+        weak var weakSut = sut
+
+        let expectation = self.expectation(description: "Completion fires after SDK is released")
+        var receivedResult: Result<[GiniHealthSDK.Extraction], GiniHealthError>?
+
+        sut?.getExtractions(docId: MockSessionManager.extractionsWithPaymentDocumentID) { result in
+            receivedResult = result
+            expectation.fulfill()
+        }
+
+        // Drop the caller's strong reference before the extractions callback fires.
+        // Only the pending closure keeps `sut` alive from here on.
+        sut = nil
+
+        waitForExpectations(timeout: 2)
+
+        XCTAssertNotNil(receivedResult,
+                        "Completion must fire even when the SDK is released mid-request")
+        if case .failure(let error) = receivedResult {
+            XCTFail("Expected success from the extractionsWithPayment fixture, got failure: \(error)")
+        }
+        XCTAssertNil(weakSut,
+                     "SDK should be deallocated after completion fires — no permanent retain cycle")
+    }
+
+    /// Regression test — `checkIfDocumentContainsMultipleInvoices` completion
+    /// must fire even when the caller releases `GiniHealth` mid-request.
+    func testCheckIfDocumentContainsMultipleInvoicesFiresCompletionWhenSDKReleasedMidRequest() {
+        let sessionManager = DelayableMockSessionManager(extractionsDelay: 0.1)
+        let documentService = DefaultDocumentService(sessionManager: sessionManager,
+                                                     apiVersion: 5)
+        let paymentService = PaymentService(sessionManager: sessionManager,
+                                            apiVersion: 5)
+        let clientConfigurationService = ClientConfigurationService(sessionManager: sessionManager,
+                                                                    apiVersion: 5)
+        let api = GiniHealthAPI(documentService: documentService,
+                                paymentService: paymentService,
+                                clientConfigurationService: clientConfigurationService)
+        var sut: GiniHealth? = GiniHealth(giniApiLib: api)
+        weak var weakSut = sut
+
+        let expectation = self.expectation(description: "Completion fires after SDK is released")
+        var receivedResult: Result<Bool, GiniHealthError>?
+
+        sut?.checkIfDocumentContainsMultipleInvoices(docId: MockSessionManager.notPayableDocumentID) { result in
+            receivedResult = result
+            expectation.fulfill()
+        }
+
+        sut = nil
+
+        waitForExpectations(timeout: 2)
+
+        XCTAssertNotNil(receivedResult,
+                        "Completion must fire even when the SDK is released mid-request")
+        if case .failure(let error) = receivedResult {
+            XCTFail("Expected success from the extractionResultWithoutIBAN fixture, got failure: \(error)")
+        }
+        XCTAssertNil(weakSut,
+                     "SDK should be deallocated after completion fires — no permanent retain cycle")
+    }
 }

--- a/HealthSDK/GiniHealthSDK/Tests/GiniHealthSDKTests/GiniHealthExtractionsHandlingTests.swift
+++ b/HealthSDK/GiniHealthSDK/Tests/GiniHealthSDKTests/GiniHealthExtractionsHandlingTests.swift
@@ -394,76 +394,95 @@ final class GiniHealthExtractionsHandlingTests: GiniHealthTestCase {
     /// Regression test — `getExtractions` completion must fire even when the
     /// caller releases `GiniHealth` between the request start and the response.
     func testGetExtractionsFiresCompletionWhenSDKReleasedMidRequest() {
-        let sessionManager = DelayableMockSessionManager(extractionsDelay: 0.1)
-        let documentService = DefaultDocumentService(sessionManager: sessionManager,
-                                                     apiVersion: 5)
-        let paymentService = PaymentService(sessionManager: sessionManager,
-                                            apiVersion: 5)
-        let clientConfigurationService = ClientConfigurationService(sessionManager: sessionManager,
-                                                                    apiVersion: 5)
-        let api = GiniHealthAPI(documentService: documentService,
-                                paymentService: paymentService,
-                                clientConfigurationService: clientConfigurationService)
-        var sut: GiniHealth? = GiniHealth(giniApiLib: api)
-        weak var weakSut = sut
-
-        let expectation = self.expectation(description: "Completion fires after SDK is released")
+        weak var weakSut: GiniHealth?
         var receivedResult: Result<[GiniHealthSDK.Extraction], GiniHealthError>?
 
-        sut?.getExtractions(docId: MockSessionManager.extractionsWithPaymentDocumentID) { result in
-            receivedResult = result
-            expectation.fulfill()
+        autoreleasepool {
+            let sessionManager = DelayableMockSessionManager(extractionsDelay: 0.1)
+            let documentService = DefaultDocumentService(sessionManager: sessionManager,
+                                                         apiVersion: 5)
+            let paymentService = PaymentService(sessionManager: sessionManager,
+                                                apiVersion: 5)
+            let clientConfigurationService = ClientConfigurationService(sessionManager: sessionManager,
+                                                                        apiVersion: 5)
+            let api = GiniHealthAPI(documentService: documentService,
+                                    paymentService: paymentService,
+                                    clientConfigurationService: clientConfigurationService)
+            var sut: GiniHealth? = GiniHealth(giniApiLib: api)
+            weakSut = sut
+
+            let completionExpectation = self.expectation(description: "Completion fires after SDK is released")
+
+            sut?.getExtractions(docId: MockSessionManager.extractionsWithPaymentDocumentID) { result in
+                receivedResult = result
+                completionExpectation.fulfill()
+            }
+
+            // Drop the caller's strong reference before the extractions callback fires.
+            // Only the pending closure keeps `sut` alive from here on.
+            sut = nil
+
+            wait(for: [completionExpectation], timeout: 2)
         }
-
-        // Drop the caller's strong reference before the extractions callback fires.
-        // Only the pending closure keeps `sut` alive from here on.
-        sut = nil
-
-        waitForExpectations(timeout: 2)
 
         XCTAssertNotNil(receivedResult,
                         "Completion must fire even when the SDK is released mid-request")
         if case .failure(let error) = receivedResult {
             XCTFail("Expected success from the extractionsWithPayment fixture, got failure: \(error)")
         }
-        XCTAssertNil(weakSut,
-                     "SDK should be deallocated after completion fires — no permanent retain cycle")
+
+        // Poll for deallocation rather than asserting instantly — after the
+        // main-queue completion block returns, ARC still needs a run-loop tick
+        // to release its strong self capture. A real retain cycle would keep
+        // `weakSut` non-nil past the timeout.
+        let deallocExpectation = expectation(for: NSPredicate { _, _ in weakSut == nil },
+                                             evaluatedWith: nil,
+                                             handler: nil)
+        wait(for: [deallocExpectation], timeout: 3)
     }
 
     /// Regression test — `checkIfDocumentContainsMultipleInvoices` completion
     /// must fire even when the caller releases `GiniHealth` mid-request.
     func testCheckIfDocumentContainsMultipleInvoicesFiresCompletionWhenSDKReleasedMidRequest() {
-        let sessionManager = DelayableMockSessionManager(extractionsDelay: 0.1)
-        let documentService = DefaultDocumentService(sessionManager: sessionManager,
-                                                     apiVersion: 5)
-        let paymentService = PaymentService(sessionManager: sessionManager,
-                                            apiVersion: 5)
-        let clientConfigurationService = ClientConfigurationService(sessionManager: sessionManager,
-                                                                    apiVersion: 5)
-        let api = GiniHealthAPI(documentService: documentService,
-                                paymentService: paymentService,
-                                clientConfigurationService: clientConfigurationService)
-        var sut: GiniHealth? = GiniHealth(giniApiLib: api)
-        weak var weakSut = sut
-
-        let expectation = self.expectation(description: "Completion fires after SDK is released")
+        weak var weakSut: GiniHealth?
         var receivedResult: Result<Bool, GiniHealthError>?
 
-        sut?.checkIfDocumentContainsMultipleInvoices(docId: MockSessionManager.notPayableDocumentID) { result in
-            receivedResult = result
-            expectation.fulfill()
+        autoreleasepool {
+            let sessionManager = DelayableMockSessionManager(extractionsDelay: 0.1)
+            let documentService = DefaultDocumentService(sessionManager: sessionManager,
+                                                         apiVersion: 5)
+            let paymentService = PaymentService(sessionManager: sessionManager,
+                                                apiVersion: 5)
+            let clientConfigurationService = ClientConfigurationService(sessionManager: sessionManager,
+                                                                        apiVersion: 5)
+            let api = GiniHealthAPI(documentService: documentService,
+                                    paymentService: paymentService,
+                                    clientConfigurationService: clientConfigurationService)
+            var sut: GiniHealth? = GiniHealth(giniApiLib: api)
+            weakSut = sut
+
+            let completionExpectation = self.expectation(description: "Completion fires after SDK is released")
+
+            sut?.checkIfDocumentContainsMultipleInvoices(docId: MockSessionManager.notPayableDocumentID) { result in
+                receivedResult = result
+                completionExpectation.fulfill()
+            }
+
+            sut = nil
+
+            wait(for: [completionExpectation], timeout: 2)
         }
-
-        sut = nil
-
-        waitForExpectations(timeout: 2)
 
         XCTAssertNotNil(receivedResult,
                         "Completion must fire even when the SDK is released mid-request")
         if case .failure(let error) = receivedResult {
             XCTFail("Expected success from the extractionResultWithoutIBAN fixture, got failure: \(error)")
         }
-        XCTAssertNil(weakSut,
-                     "SDK should be deallocated after completion fires — no permanent retain cycle")
+
+        // Poll for deallocation — see companion test above for rationale.
+        let deallocExpectation = expectation(for: NSPredicate { _, _ in weakSut == nil },
+                                             evaluatedWith: nil,
+                                             handler: nil)
+        wait(for: [deallocExpectation], timeout: 3)
     }
 }

--- a/HealthSDK/GiniHealthSDK/Tests/GiniHealthSDKTests/MockHelpers/DelayableMockSessionManager.swift
+++ b/HealthSDK/GiniHealthSDK/Tests/GiniHealthSDKTests/MockHelpers/DelayableMockSessionManager.swift
@@ -1,0 +1,73 @@
+//
+//  DelayableMockSessionManager.swift
+//
+//  Copyright © 2026 Gini GmbH. All rights reserved.
+//
+
+import Foundation
+@testable import GiniHealthAPILibrary
+
+/**
+ Session-manager mock that mirrors `MockSessionManager`'s fixture routing but
+ defers `.extractions` API-method callbacks by `extractionsDelay` seconds.
+
+ Used by the silent-drop regression tests: the deferred callback opens a real
+ window between the initial `fetchDocument` completion (which fires
+ synchronously through the base mock) and the extractions completion — long
+ enough for a test to drop its strong reference to `GiniHealth` before the
+ pending closure fires. Any regression that re-introduces `[weak self]` on the
+ inner extractions closures in `GiniHealth.swift` would silently drop the
+ caller's completion; these tests would then time out.
+ */
+final class DelayableMockSessionManager: SessionManagerProtocol {
+
+    private let base = MockSessionManager()
+    let extractionsDelay: TimeInterval
+
+    init(extractionsDelay: TimeInterval = 0.1) {
+        self.extractionsDelay = extractionsDelay
+    }
+
+    func data<T>(resource: T,
+                 cancellationToken: GiniHealthAPILibrary.CancellationToken?,
+                 completion: @escaping GiniHealthAPILibrary.CompletionResult<T.ResponseType>) where T: GiniHealthAPILibrary.Resource {
+        if let apiMethod = resource.method as? APIMethod, case .extractions = apiMethod {
+            let base = self.base
+            DispatchQueue.global().asyncAfter(deadline: .now() + extractionsDelay) {
+                base.data(resource: resource,
+                          cancellationToken: cancellationToken,
+                          completion: completion)
+            }
+        } else {
+            base.data(resource: resource,
+                      cancellationToken: cancellationToken,
+                      completion: completion)
+        }
+    }
+
+    func upload<T>(resource: T,
+                   data: Data,
+                   cancellationToken: GiniHealthAPILibrary.CancellationToken?,
+                   completion: @escaping GiniHealthAPILibrary.CompletionResult<T.ResponseType>) where T: GiniHealthAPILibrary.Resource {
+        base.upload(resource: resource,
+                    data: data,
+                    cancellationToken: cancellationToken,
+                    completion: completion)
+    }
+
+    func download<T>(resource: T,
+                     cancellationToken: GiniHealthAPILibrary.CancellationToken?,
+                     completion: @escaping GiniHealthAPILibrary.CompletionResult<T.ResponseType>) where T: GiniHealthAPILibrary.Resource {
+        base.download(resource: resource,
+                      cancellationToken: cancellationToken,
+                      completion: completion)
+    }
+
+    func logIn(completion: @escaping (Result<GiniHealthAPILibrary.Token, GiniHealthAPILibrary.GiniError>) -> Void) {
+        base.logIn(completion: completion)
+    }
+
+    func logOut() {
+        base.logOut()
+    }
+}

--- a/HealthSDK/GiniHealthSDK/Tests/GiniHealthSDKTests/MockHelpers/MockSessionManager.swift
+++ b/HealthSDK/GiniHealthSDK/Tests/GiniHealthSDKTests/MockHelpers/MockSessionManager.swift
@@ -271,12 +271,6 @@ final class MockSessionManager: SessionManagerProtocol {
         }
     }
 
-    /// Helper function to decode body
-    private func decodeBody(from body: Data?) -> [String]? {
-        guard let body = body else { return nil }
-        return try? JSONDecoder().decode([String].self, from: body)
-    }
-
     /// Helper function to handle extraction results
     private func handleExtractionResults<ResponseType>(fromFile fileName: String,
                                                        completion: @escaping GiniHealthAPILibrary.CompletionResult<ResponseType>) {

--- a/HealthSDK/GiniHealthSDK/Tests/GiniHealthSDKTests/MockHelpers/Utils.swift
+++ b/HealthSDK/GiniHealthSDK/Tests/GiniHealthSDKTests/MockHelpers/Utils.swift
@@ -43,3 +43,9 @@ func load<T: Decodable>(fromFile named: String, type: String = "json") -> T? {
     
     return try? JSONDecoder().decode(T.self, from: jsonData)
 }
+
+/// Helper function to decode body
+func decodeBody(from body: Data?) -> [String]? {
+    guard let body = body else { return nil }
+    return try? JSONDecoder().decode([String].self, from: body)
+}

--- a/HealthSDK/GiniHealthSDK/Tests/GiniHealthSDKTests/MockHelpers/Utils.swift
+++ b/HealthSDK/GiniHealthSDK/Tests/GiniHealthSDKTests/MockHelpers/Utils.swift
@@ -44,7 +44,7 @@ func load<T: Decodable>(fromFile named: String, type: String = "json") -> T? {
     return try? JSONDecoder().decode(T.self, from: jsonData)
 }
 
-/// Helper function to decode body
+/** Decodes an optional `Data` body as a JSON `[String]`, returning `nil` on failure. */
 func decodeBody(from body: Data?) -> [String]? {
     guard let body = body else { return nil }
     return try? JSONDecoder().decode([String].self, from: body)

--- a/HealthSDK/GiniHealthSDK/Tests/GiniHealthSDKTests/PaymentInvoiceRoutingTests.swift
+++ b/HealthSDK/GiniHealthSDK/Tests/GiniHealthSDKTests/PaymentInvoiceRoutingTests.swift
@@ -15,19 +15,21 @@ import UIKit
  Swift Testing coverage for the payment-invoice tap routing changes introduced
  in PR #1260 on `PaymentComponentsController+Helpers.swift`.
 
- Covers `didTapOnPayInvoice(documentId:)` and the routing it does through the
- four private helpers (`shouldShowPaymentReviewScreen`, `handlePaymentReviewFlow`,
- `handleExternalPaymentFlow`, `handleOpenWithPayment`, `handleGPCPayment`), plus
- the three public predicates the external flow branches on (`supportsOpenWith`,
- `supportsGPC`, `canOpenPaymentProviderApp`).
+ Covers `didTapOnPayInvoice(documentId:)`, `didTapOnBankPicker(documentId:)`,
+ the routing done through the four private helpers (`shouldShowPaymentReviewScreen`,
+ `handlePaymentReviewFlow`, `handleExternalPaymentFlow`, `handleOpenWithPayment`,
+ `handleGPCPayment`), the three public predicates the external flow branches
+ on (`supportsOpenWith`, `supportsGPC`, `canOpenPaymentProviderApp`), and the
+ payment-provider persistence helpers (`storeDefaultPaymentProvider`,
+ `savedPaymentProvider`).
 
  The private helpers cannot be invoked directly, so they are covered by driving
  `didTapOnPayInvoice(documentId:)` with the state that routes into each branch
  and observing side effects on the spy `UINavigationController` and the delegate.
 
- The suite is `.serialized` because tests mutate `GiniHealthConfiguration.shared`.
- The class-based suite saves and restores the two toggled flags in `init`/`deinit`
- so tests are order-independent.
+ The suite is `.serialized` because tests mutate `GiniHealthConfiguration.shared`
+ and `UserDefaults.standard`. The class-based suite saves and restores all
+ mutated global state in `init`/`deinit` so tests are order-independent.
  */
 @Suite("Payment invoice tap routing (PR #1260)", .serialized)
 @MainActor
@@ -40,9 +42,14 @@ final class PaymentInvoiceRoutingTests {
     private let sut: PaymentComponentsController
     private let spyNavigationController: SpyNavigationController
     private let delegateSpy: PaymentComponentsControllerDelegateSpy
+    private let healthDelegateSpy: GiniHealthDelegateSpy
 
     private let savedShowPaymentReviewScreen: Bool
     private let savedUseInvoiceWithoutDocument: Bool
+    private let savedUseBottomPaymentComponentView: Bool
+    private let savedDefaultPaymentProviderData: Data?
+
+    private static let defaultPaymentProviderKey = "defaultPaymentProvider"
 
     init() {
         let sessionManager = MockSessionManager()
@@ -64,22 +71,31 @@ final class PaymentInvoiceRoutingTests {
         delegateSpy = PaymentComponentsControllerDelegateSpy()
         sut.delegate = delegateSpy
 
+        healthDelegateSpy = GiniHealthDelegateSpy()
+        giniHealth.delegate = healthDelegateSpy
+
         savedShowPaymentReviewScreen = GiniHealthConfiguration.shared.showPaymentReviewScreen
         savedUseInvoiceWithoutDocument = GiniHealthConfiguration.shared.useInvoiceWithoutDocument
+        savedUseBottomPaymentComponentView = GiniHealthConfiguration.shared.useBottomPaymentComponentView
+        savedDefaultPaymentProviderData = UserDefaults.standard.data(forKey: Self.defaultPaymentProviderKey)
+        UserDefaults.standard.removeObject(forKey: Self.defaultPaymentProviderKey)
     }
 
     deinit {
         GiniHealthConfiguration.shared.showPaymentReviewScreen = savedShowPaymentReviewScreen
         GiniHealthConfiguration.shared.useInvoiceWithoutDocument = savedUseInvoiceWithoutDocument
+        GiniHealthConfiguration.shared.useBottomPaymentComponentView = savedUseBottomPaymentComponentView
+        if let savedDefaultPaymentProviderData {
+            UserDefaults.standard.set(savedDefaultPaymentProviderData, forKey: Self.defaultPaymentProviderKey)
+        } else {
+            UserDefaults.standard.removeObject(forKey: Self.defaultPaymentProviderKey)
+        }
     }
 
     // MARK: - `didTapOnPayInvoice` config-based routing
 
     @Test("Review flow is routed to when `useInvoiceWithoutDocument` is false (isLoading toggles)")
-    func routesToReviewFlow_whenUseInvoiceWithoutDocumentIsFalse() throws {
-        // Route into `handlePaymentReviewFlow` → `loadPaymentReviewScreenFor` which
-        // sets `isLoading = true` on the `!useInvoiceWithoutDocument` branch when
-        // a document id is set. That toggle is observable through the delegate.
+    func routesToReviewFlowWhenUseInvoiceWithoutDocumentIsFalse() throws {
         GiniHealthConfiguration.shared.showPaymentReviewScreen = false
         GiniHealthConfiguration.shared.useInvoiceWithoutDocument = false
         sut.documentId = MockSessionManager.payableDocumentID
@@ -91,18 +107,16 @@ final class PaymentInvoiceRoutingTests {
     }
 
     @Test("External flow (no-op branches) is routed to when both flags favor external")
-    func routesToExternalFlow_whenBothFlagsFalse() throws {
+    func routesToExternalFlowWhenBothFlagsFalse() throws {
         GiniHealthConfiguration.shared.showPaymentReviewScreen = false
         GiniHealthConfiguration.shared.useInvoiceWithoutDocument = true
 
-        // A provider that supports neither openWith nor GPC means `handleExternalPaymentFlow`
-        // falls through both branches. No navigation event is emitted, and no `isLoading`
-        // toggle fires — proof that `shouldShowPaymentReviewScreen` returned false.
         sut.selectedPaymentProvider = Self.makeProvider(gpcOnIOS: false, openWithOnIOS: false)
         sut.paymentInfo = nil
 
-        // The initial `loadPaymentProviders()` call fired from PCC init settles
+        // The initial `loadPaymentProviders()` fired from PCC init settles
         // asynchronously on main; clear its `isLoading = false` echo before acting.
+        drainMainRunLoop()
         delegateSpy.loadingStateChanges.removeAll()
 
         sut.didTapOnPayInvoice(documentId: nil)
@@ -116,8 +130,7 @@ final class PaymentInvoiceRoutingTests {
     // MARK: - GPC branch — the key PR #1260 regression
 
     @Test("Install-app sheet is reachable via GPC when `paymentInfo` is nil (PR #1260 regression)")
-    func installAppSheet_isPresented_onGPCPath_whenPaymentInfoIsNil() throws {
-        // Route into `handleExternalPaymentFlow`
+    func installAppSheetIsPresentedOnGPCPathWhenPaymentInfoIsNil() throws {
         GiniHealthConfiguration.shared.showPaymentReviewScreen = false
         GiniHealthConfiguration.shared.useInvoiceWithoutDocument = true
 
@@ -126,8 +139,6 @@ final class PaymentInvoiceRoutingTests {
         // `defaultInstalledPaymentProvider()`.
         drainMainRunLoop()
 
-        // A GPC-supporting provider whose scheme cannot be opened → `canOpenPaymentProviderApp`
-        // returns false → the else branch of `handleGPCPayment` runs.
         sut.selectedPaymentProvider = Self.makeProvider(gpcOnIOS: true,
                                                          openWithOnIOS: false,
                                                          scheme: "unopenable-scheme-\(UUID().uuidString)")
@@ -143,7 +154,7 @@ final class PaymentInvoiceRoutingTests {
     }
 
     @Test("Install-app sheet is reachable via GPC when `paymentInfo` is present too")
-    func installAppSheet_isPresented_onGPCPath_whenPaymentInfoIsPresent() throws {
+    func installAppSheetIsPresentedOnGPCPathWhenPaymentInfoIsPresent() throws {
         GiniHealthConfiguration.shared.showPaymentReviewScreen = false
         GiniHealthConfiguration.shared.useInvoiceWithoutDocument = true
 
@@ -161,20 +172,18 @@ final class PaymentInvoiceRoutingTests {
         #expect(presentedView is InstallAppBottomView)
     }
 
-    // MARK: - `handleOpenWithPayment` guard
+    // MARK: - `handleOpenWithPayment`
 
     @Test("Open-with branch is a no-op when `paymentInfo` is nil")
-    func openWithBranch_isNoOp_whenPaymentInfoIsNil() throws {
+    func openWithBranchIsNoOpWhenPaymentInfoIsNil() throws {
         GiniHealthConfiguration.shared.showPaymentReviewScreen = false
         GiniHealthConfiguration.shared.useInvoiceWithoutDocument = true
+
+        drainMainRunLoop()
 
         sut.selectedPaymentProvider = Self.makeProvider(gpcOnIOS: false, openWithOnIOS: true)
         sut.paymentInfo = nil
 
-        // Drain the pending `loadPaymentProviders()` main-queue callback that PCC's
-        // init fires — otherwise it may race with `didTapOnPayInvoice` and overwrite
-        // `selectedPaymentProvider` with `defaultInstalledPaymentProvider()` (nil).
-        drainMainRunLoop()
         delegateSpy.loadingStateChanges.removeAll()
 
         sut.didTapOnPayInvoice(documentId: nil)
@@ -186,10 +195,87 @@ final class PaymentInvoiceRoutingTests {
         #expect(delegateSpy.loadingStateChanges.isEmpty)
     }
 
+    @Test("Open-with branch drives payment request creation when `paymentInfo` is present")
+    func openWithBranchCreatesPaymentRequestWhenPaymentInfoIsPresent() async throws {
+        GiniHealthConfiguration.shared.showPaymentReviewScreen = false
+        GiniHealthConfiguration.shared.useInvoiceWithoutDocument = true
+
+        try await settleMainQueue()
+
+        sut.selectedPaymentProvider = Self.makeProvider(gpcOnIOS: false, openWithOnIOS: true)
+        sut.paymentInfo = Self.makePaymentInfo()
+
+        sut.didTapOnPayInvoice(documentId: nil)
+
+        // `handleOpenWithPayment` → PCC.createPaymentRequest → giniSDK.createPaymentRequest
+        // → mock returns success synchronously → PCC completes with paymentRequestId and
+        // fires `giniSDK.delegate?.didCreatePaymentRequest(paymentRequestId:)`. Yield the
+        // main actor so any main-queue hops in the chain settle before asserting.
+        try await settleMainQueue(hops: 6)
+
+        #expect(!healthDelegateSpy.createdPaymentRequestIds.isEmpty,
+                "handleOpenWithPayment should reach PCC.createPaymentRequest and fire didCreatePaymentRequest on the health delegate")
+        #expect(!spyNavigationController.presented.contains { $0.viewController is InstallAppBottomView },
+                "OpenWith branch must not present the install-app sheet")
+    }
+
+    // MARK: - Bank picker
+
+    @Test("Bank picker presents the bank selection bottom sheet when bottom view is enabled")
+    func bankPickerPresentsBankSelectionSheetWhenBottomViewEnabled() throws {
+        GiniHealthConfiguration.shared.useBottomPaymentComponentView = true
+
+        drainMainRunLoop()
+
+        sut.didTapOnBankPicker(documentId: nil)
+
+        #expect(spyNavigationController.presented.count == 1)
+        let presented = try #require(spyNavigationController.presented.first?.viewController)
+        #expect(presented is BanksBottomView,
+                "Presented view controller should be the bank selection bottom sheet")
+    }
+
+    @Test("Bank picker does nothing when bottom view is disabled")
+    func bankPickerIsNoOpWhenBottomViewDisabled() throws {
+        GiniHealthConfiguration.shared.useBottomPaymentComponentView = false
+
+        drainMainRunLoop()
+
+        sut.didTapOnBankPicker(documentId: nil)
+
+        #expect(spyNavigationController.presented.isEmpty)
+    }
+
+    // MARK: - Review flow error branch
+
+    @Test("Review flow surfaces error via handleError when data-for-review fails")
+    func reviewFlowSurfacesErrorWhenDataForReviewFails() async throws {
+        GiniHealthConfiguration.shared.showPaymentReviewScreen = false
+        GiniHealthConfiguration.shared.useInvoiceWithoutDocument = false
+        sut.documentId = MockSessionManager.failurePayableDocumentID
+
+        try await settleMainQueue()
+        delegateSpy.loadingStateChanges.removeAll()
+
+        sut.didTapOnPayInvoice(documentId: nil)
+
+        // Chain: `handlePaymentReviewFlow` → `loadPaymentReviewScreenFor` calls
+        // `fetchDataForReview` (mock returns extractions failure) → completion fires
+        // with `error != nil` → `handleError(error)` → `showErrorsIfAny` dispatches
+        // to main.async → `showErrorAlertView` → presents the alert on the spy nav.
+        // Multi-hop chain — yield the main actor several times to let it settle.
+        try await settleMainQueue(hops: 6)
+
+        #expect(delegateSpy.loadingStateChanges.contains(false),
+                "handleError should toggle isLoading back to false via the delegate")
+        #expect(spyNavigationController.presented.contains(where: { $0.viewController is UIAlertController }),
+                "handleError should surface an alert to the user")
+    }
+
     // MARK: - Public predicates
 
     @Test("`supportsOpenWith` reflects the selected provider's iOS support")
-    func supportsOpenWith_reflectsProviderPlatforms() {
+    func supportsOpenWithReflectsProviderPlatforms() {
         sut.selectedPaymentProvider = nil
         #expect(sut.supportsOpenWith() == false)
 
@@ -201,7 +287,7 @@ final class PaymentInvoiceRoutingTests {
     }
 
     @Test("`supportsGPC` reflects the selected provider's iOS support")
-    func supportsGPC_reflectsProviderPlatforms() {
+    func supportsGPCReflectsProviderPlatforms() {
         sut.selectedPaymentProvider = nil
         #expect(sut.supportsGPC() == false)
 
@@ -213,28 +299,83 @@ final class PaymentInvoiceRoutingTests {
     }
 
     @Test("`canOpenPaymentProviderApp` is false when GPC is not supported")
-    func canOpenPaymentProviderApp_isFalse_whenGPCUnsupported() {
+    func canOpenPaymentProviderAppIsFalseWhenGPCUnsupported() {
         sut.selectedPaymentProvider = Self.makeProvider(gpcOnIOS: false, openWithOnIOS: false)
         #expect(sut.canOpenPaymentProviderApp() == false)
     }
 
     @Test("`canOpenPaymentProviderApp` is false when scheme cannot be opened")
-    func canOpenPaymentProviderApp_isFalse_whenSchemeUnopenable() {
+    func canOpenPaymentProviderAppIsFalseWhenSchemeUnopenable() {
         sut.selectedPaymentProvider = Self.makeProvider(gpcOnIOS: true,
                                                          openWithOnIOS: false,
                                                          scheme: "unopenable-scheme-\(UUID().uuidString)")
-        // GPC is supported but the scheme cannot be opened by the simulator.
         #expect(sut.canOpenPaymentProviderApp() == false)
+    }
+
+    // MARK: - Payment-provider persistence
+
+    @Test("`storeDefaultPaymentProvider` persists an encoded provider to UserDefaults")
+    func storeDefaultPaymentProviderPersistsToUserDefaults() throws {
+        let provider = Self.makeProvider(gpcOnIOS: true, openWithOnIOS: false)
+
+        sut.storeDefaultPaymentProvider(paymentProvider: provider)
+
+        let storedData = try #require(UserDefaults.standard.data(forKey: Self.defaultPaymentProviderKey),
+                                        "Encoded provider should be stored under the default-payment-provider key")
+        let decoded = try JSONDecoder().decode(GiniHealthSDK.PaymentProvider.self, from: storedData)
+        #expect(decoded.id == provider.id)
+        #expect(decoded.name == provider.name)
+    }
+
+    @Test("`savedPaymentProvider` returns the stored provider when its id is in the known providers list")
+    func savedPaymentProviderReturnsStoredProviderWhenIdIsKnown() throws {
+        let provider = Self.makeProvider(gpcOnIOS: true, openWithOnIOS: false)
+        sut.storeDefaultPaymentProvider(paymentProvider: provider)
+
+        // `savedPaymentProvider` only returns the decoded provider if its id is in
+        // `paymentProviders`. Preload the SDK's known list with the same id.
+        sut.paymentProviders = [provider.toHealthPaymentProvider()]
+
+        let saved = try #require(sut.savedPaymentProvider(),
+                                  "Saved provider should be returned when its id is in the known providers list")
+        #expect(saved.id == provider.id)
+    }
+
+    @Test("`savedPaymentProvider` returns nil when the stored provider's id is not in the known list")
+    func savedPaymentProviderReturnsNilWhenIdIsUnknown() throws {
+        let stored = Self.makeProvider(gpcOnIOS: true, openWithOnIOS: false)
+        sut.storeDefaultPaymentProvider(paymentProvider: stored)
+
+        // Populate the known providers with a DIFFERENT id so the stored one won't match.
+        let unrelated = Self.makeProvider(gpcOnIOS: false, openWithOnIOS: true)
+        sut.paymentProviders = [unrelated.toHealthPaymentProvider()]
+
+        #expect(sut.savedPaymentProvider() == nil,
+                "Stored provider is discarded when its id is not among the known providers")
+    }
+
+    @Test("`savedPaymentProvider` returns nil when nothing has been stored")
+    func savedPaymentProviderReturnsNilWhenNothingStored() {
+        #expect(sut.savedPaymentProvider() == nil)
     }
 
     // MARK: - Helpers
 
     /// Pumps the main run loop for a brief window so `DispatchQueue.main.async`
     /// blocks scheduled from `loadPaymentProviders()` (fired inside PCC init) can
-    /// settle before the test drives the SUT. Without this, the async callback
-    /// resets `selectedPaymentProvider` mid-test and the assertion becomes flaky.
+    /// settle before the test drives the SUT.
     private func drainMainRunLoop() {
         RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.05))
+    }
+
+    /// Yields the main actor for `hops` iterations, each sleeping for a short
+    /// window so `DispatchQueue.main.async` blocks scheduled by the SDK chain
+    /// can settle. Unlike `RunLoop.main.run(until:)`, this actually suspends
+    /// the current `@MainActor` context and lets other main-queue work run.
+    private func settleMainQueue(hops: Int = 3) async throws {
+        for _ in 0..<hops {
+            try await Task.sleep(nanoseconds: 20_000_000) // 20 ms per hop
+        }
     }
 
     // MARK: - Fixture builders
@@ -299,6 +440,31 @@ private final class SpyNavigationController: UINavigationController {
  and (for `isLoadingStateChanged`) with which value, without depending on
  the real host-app plumbing.
  */
+/**
+ Records `didCreatePaymentRequest` calls on `GiniHealthDelegate`. Used as an
+ observable signal for payment-request success in tests that would otherwise
+ rely on downstream side effects (like presenting a share-invoice sheet)
+ that the shared mock cannot reliably drive.
+ */
+private final class GiniHealthDelegateSpy: GiniHealthDelegate {
+    var createdPaymentRequestIds: [String] = []
+    var dismissedCount = 0
+    var errorsAskedToHandleInternally: [GiniHealthError] = []
+
+    func didCreatePaymentRequest(paymentRequestId: String) {
+        createdPaymentRequestIds.append(paymentRequestId)
+    }
+
+    func shouldHandleErrorInternally(error: GiniHealthError) -> Bool {
+        errorsAskedToHandleInternally.append(error)
+        return true
+    }
+
+    func didDismissHealthSDK() {
+        dismissedCount += 1
+    }
+}
+
 private final class PaymentComponentsControllerDelegateSpy: PaymentComponentsControllerProtocol {
     var loadingStateChanges: [Bool] = []
     var didFetchedPaymentProvidersCallCount = 0

--- a/HealthSDK/GiniHealthSDK/Tests/GiniHealthSDKTests/PaymentInvoiceRoutingTests.swift
+++ b/HealthSDK/GiniHealthSDK/Tests/GiniHealthSDKTests/PaymentInvoiceRoutingTests.swift
@@ -30,6 +30,7 @@ import UIKit
  so tests are order-independent.
  */
 @Suite("Payment invoice tap routing (PR #1260)", .serialized)
+@MainActor
 final class PaymentInvoiceRoutingTests {
 
     // MARK: - Test fixtures
@@ -100,6 +101,10 @@ final class PaymentInvoiceRoutingTests {
         sut.selectedPaymentProvider = Self.makeProvider(gpcOnIOS: false, openWithOnIOS: false)
         sut.paymentInfo = nil
 
+        // The initial `loadPaymentProviders()` call fired from PCC init settles
+        // asynchronously on main; clear its `isLoading = false` echo before acting.
+        delegateSpy.loadingStateChanges.removeAll()
+
         sut.didTapOnPayInvoice(documentId: nil)
 
         #expect(spyNavigationController.presented.isEmpty)
@@ -115,6 +120,11 @@ final class PaymentInvoiceRoutingTests {
         // Route into `handleExternalPaymentFlow`
         GiniHealthConfiguration.shared.showPaymentReviewScreen = false
         GiniHealthConfiguration.shared.useInvoiceWithoutDocument = true
+
+        // Drain PCC's `loadPaymentProviders()` before setting our provider, otherwise
+        // its main-queue callback overwrites `selectedPaymentProvider` with the (nil)
+        // `defaultInstalledPaymentProvider()`.
+        drainMainRunLoop()
 
         // A GPC-supporting provider whose scheme cannot be opened → `canOpenPaymentProviderApp`
         // returns false → the else branch of `handleGPCPayment` runs.
@@ -137,6 +147,8 @@ final class PaymentInvoiceRoutingTests {
         GiniHealthConfiguration.shared.showPaymentReviewScreen = false
         GiniHealthConfiguration.shared.useInvoiceWithoutDocument = true
 
+        drainMainRunLoop()
+
         sut.selectedPaymentProvider = Self.makeProvider(gpcOnIOS: true,
                                                          openWithOnIOS: false,
                                                          scheme: "unopenable-scheme-\(UUID().uuidString)")
@@ -158,6 +170,12 @@ final class PaymentInvoiceRoutingTests {
 
         sut.selectedPaymentProvider = Self.makeProvider(gpcOnIOS: false, openWithOnIOS: true)
         sut.paymentInfo = nil
+
+        // Drain the pending `loadPaymentProviders()` main-queue callback that PCC's
+        // init fires — otherwise it may race with `didTapOnPayInvoice` and overwrite
+        // `selectedPaymentProvider` with `defaultInstalledPaymentProvider()` (nil).
+        drainMainRunLoop()
+        delegateSpy.loadingStateChanges.removeAll()
 
         sut.didTapOnPayInvoice(documentId: nil)
 
@@ -207,6 +225,16 @@ final class PaymentInvoiceRoutingTests {
                                                          scheme: "unopenable-scheme-\(UUID().uuidString)")
         // GPC is supported but the scheme cannot be opened by the simulator.
         #expect(sut.canOpenPaymentProviderApp() == false)
+    }
+
+    // MARK: - Helpers
+
+    /// Pumps the main run loop for a brief window so `DispatchQueue.main.async`
+    /// blocks scheduled from `loadPaymentProviders()` (fired inside PCC init) can
+    /// settle before the test drives the SUT. Without this, the async callback
+    /// resets `selectedPaymentProvider` mid-test and the assertion becomes flaky.
+    private func drainMainRunLoop() {
+        RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.05))
     }
 
     // MARK: - Fixture builders

--- a/HealthSDK/GiniHealthSDK/Tests/GiniHealthSDKTests/PaymentInvoiceRoutingTests.swift
+++ b/HealthSDK/GiniHealthSDK/Tests/GiniHealthSDKTests/PaymentInvoiceRoutingTests.swift
@@ -213,19 +213,19 @@ final class PaymentInvoiceRoutingTests {
 
     private static func makeProvider(gpcOnIOS: Bool,
                                      openWithOnIOS: Bool,
-                                     scheme: String = "test-scheme") -> PaymentProvider {
-        PaymentProvider(id: "test-provider-\(UUID().uuidString)",
-                        name: "Test Bank",
-                        appSchemeIOS: scheme,
-                        minAppVersion: nil,
-                        colors: ProviderColors(background: "#FFFFFF",
-                                                text: "#000000"),
-                        iconData: Data(),
-                        appStoreUrlIOS: "https://apps.apple.com/test",
-                        universalLinkIOS: "https://example.com/pay",
-                        index: 0,
-                        gpcSupportedPlatforms: gpcOnIOS ? [.ios] : [],
-                        openWithSupportedPlatforms: openWithOnIOS ? [.ios] : [])
+                                     scheme: String = "test-scheme") -> GiniHealthSDK.PaymentProvider {
+        GiniHealthSDK.PaymentProvider(id: "test-provider-\(UUID().uuidString)",
+                                       name: "Test Bank",
+                                       appSchemeIOS: scheme,
+                                       minAppVersion: nil,
+                                       colors: GiniHealthSDK.ProviderColors(background: "#FFFFFF",
+                                                                             text: "#000000"),
+                                       iconData: Data(),
+                                       appStoreUrlIOS: "https://apps.apple.com/test",
+                                       universalLinkIOS: "https://example.com/pay",
+                                       index: 0,
+                                       gpcSupportedPlatforms: gpcOnIOS ? [.ios] : [],
+                                       openWithSupportedPlatforms: openWithOnIOS ? [.ios] : [])
     }
 
     private static func makePaymentInfo() -> GiniInternalPaymentSDK.PaymentInfo {

--- a/HealthSDK/GiniHealthSDK/Tests/GiniHealthSDKTests/PaymentInvoiceRoutingTests.swift
+++ b/HealthSDK/GiniHealthSDK/Tests/GiniHealthSDKTests/PaymentInvoiceRoutingTests.swift
@@ -436,11 +436,6 @@ private final class SpyNavigationController: UINavigationController {
 }
 
 /**
- Records every delegate callback so tests can assert both what was called
- and (for `isLoadingStateChanged`) with which value, without depending on
- the real host-app plumbing.
- */
-/**
  Records `didCreatePaymentRequest` calls on `GiniHealthDelegate`. Used as an
  observable signal for payment-request success in tests that would otherwise
  rely on downstream side effects (like presenting a share-invoice sheet)
@@ -465,6 +460,11 @@ private final class GiniHealthDelegateSpy: GiniHealthDelegate {
     }
 }
 
+/**
+ Records every delegate callback so tests can assert both what was called
+ and (for `isLoadingStateChanged`) with which value, without depending on
+ the real host-app plumbing.
+ */
 private final class PaymentComponentsControllerDelegateSpy: PaymentComponentsControllerProtocol {
     var loadingStateChanges: [Bool] = []
     var didFetchedPaymentProvidersCallCount = 0

--- a/HealthSDK/GiniHealthSDK/Tests/GiniHealthSDKTests/PaymentInvoiceRoutingTests.swift
+++ b/HealthSDK/GiniHealthSDK/Tests/GiniHealthSDKTests/PaymentInvoiceRoutingTests.swift
@@ -1,0 +1,290 @@
+//
+//  PaymentInvoiceRoutingTests.swift
+//
+//  Copyright © 2026 Gini GmbH. All rights reserved.
+//
+
+import Testing
+import UIKit
+@testable import GiniHealthSDK
+@testable import GiniHealthAPILibrary
+@testable import GiniInternalPaymentSDK
+@testable import GiniUtilites
+
+/**
+ Swift Testing coverage for the payment-invoice tap routing changes introduced
+ in PR #1260 on `PaymentComponentsController+Helpers.swift`.
+
+ Covers `didTapOnPayInvoice(documentId:)` and the routing it does through the
+ four private helpers (`shouldShowPaymentReviewScreen`, `handlePaymentReviewFlow`,
+ `handleExternalPaymentFlow`, `handleOpenWithPayment`, `handleGPCPayment`), plus
+ the three public predicates the external flow branches on (`supportsOpenWith`,
+ `supportsGPC`, `canOpenPaymentProviderApp`).
+
+ The private helpers cannot be invoked directly, so they are covered by driving
+ `didTapOnPayInvoice(documentId:)` with the state that routes into each branch
+ and observing side effects on the spy `UINavigationController` and the delegate.
+
+ The suite is `.serialized` because tests mutate `GiniHealthConfiguration.shared`.
+ The class-based suite saves and restores the two toggled flags in `init`/`deinit`
+ so tests are order-independent.
+ */
+@Suite("Payment invoice tap routing (PR #1260)", .serialized)
+final class PaymentInvoiceRoutingTests {
+
+    // MARK: - Test fixtures
+
+    private let giniHealthAPI: GiniHealthAPI
+    private let giniHealth: GiniHealth
+    private let sut: PaymentComponentsController
+    private let spyNavigationController: SpyNavigationController
+    private let delegateSpy: PaymentComponentsControllerDelegateSpy
+
+    private let savedShowPaymentReviewScreen: Bool
+    private let savedUseInvoiceWithoutDocument: Bool
+
+    init() {
+        let sessionManager = MockSessionManager()
+        let documentService = DefaultDocumentService(sessionManager: sessionManager,
+                                                    apiVersion: 5)
+        let paymentService = PaymentService(sessionManager: sessionManager,
+                                            apiVersion: 5)
+        let clientConfigurationService = ClientConfigurationService(sessionManager: sessionManager,
+                                                                    apiVersion: 5)
+        giniHealthAPI = GiniHealthAPI(documentService: documentService,
+                                      paymentService: paymentService,
+                                      clientConfigurationService: clientConfigurationService)
+        giniHealth = GiniHealth(giniApiLib: giniHealthAPI)
+        sut = giniHealth.paymentComponentsController
+
+        spyNavigationController = SpyNavigationController()
+        sut.navigationControllerProvided = spyNavigationController
+
+        delegateSpy = PaymentComponentsControllerDelegateSpy()
+        sut.delegate = delegateSpy
+
+        savedShowPaymentReviewScreen = GiniHealthConfiguration.shared.showPaymentReviewScreen
+        savedUseInvoiceWithoutDocument = GiniHealthConfiguration.shared.useInvoiceWithoutDocument
+    }
+
+    deinit {
+        GiniHealthConfiguration.shared.showPaymentReviewScreen = savedShowPaymentReviewScreen
+        GiniHealthConfiguration.shared.useInvoiceWithoutDocument = savedUseInvoiceWithoutDocument
+    }
+
+    // MARK: - `didTapOnPayInvoice` config-based routing
+
+    @Test("Review flow is routed to when `useInvoiceWithoutDocument` is false (isLoading toggles)")
+    func routesToReviewFlow_whenUseInvoiceWithoutDocumentIsFalse() throws {
+        // Route into `handlePaymentReviewFlow` → `loadPaymentReviewScreenFor` which
+        // sets `isLoading = true` on the `!useInvoiceWithoutDocument` branch when
+        // a document id is set. That toggle is observable through the delegate.
+        GiniHealthConfiguration.shared.showPaymentReviewScreen = false
+        GiniHealthConfiguration.shared.useInvoiceWithoutDocument = false
+        sut.documentId = MockSessionManager.payableDocumentID
+
+        sut.didTapOnPayInvoice(documentId: MockSessionManager.payableDocumentID)
+
+        #expect(delegateSpy.loadingStateChanges.contains(true),
+                "The review flow should toggle `isLoading = true` before fetching data-for-review")
+    }
+
+    @Test("External flow (no-op branches) is routed to when both flags favor external")
+    func routesToExternalFlow_whenBothFlagsFalse() throws {
+        GiniHealthConfiguration.shared.showPaymentReviewScreen = false
+        GiniHealthConfiguration.shared.useInvoiceWithoutDocument = true
+
+        // A provider that supports neither openWith nor GPC means `handleExternalPaymentFlow`
+        // falls through both branches. No navigation event is emitted, and no `isLoading`
+        // toggle fires — proof that `shouldShowPaymentReviewScreen` returned false.
+        sut.selectedPaymentProvider = Self.makeProvider(gpcOnIOS: false, openWithOnIOS: false)
+        sut.paymentInfo = nil
+
+        sut.didTapOnPayInvoice(documentId: nil)
+
+        #expect(spyNavigationController.presented.isEmpty)
+        #expect(spyNavigationController.pushed.isEmpty)
+        #expect(delegateSpy.loadingStateChanges.isEmpty,
+                "External flow with unsupported provider must not toggle `isLoading`")
+    }
+
+    // MARK: - GPC branch — the key PR #1260 regression
+
+    @Test("Install-app sheet is reachable via GPC when `paymentInfo` is nil (PR #1260 regression)")
+    func installAppSheet_isPresented_onGPCPath_whenPaymentInfoIsNil() throws {
+        // Route into `handleExternalPaymentFlow`
+        GiniHealthConfiguration.shared.showPaymentReviewScreen = false
+        GiniHealthConfiguration.shared.useInvoiceWithoutDocument = true
+
+        // A GPC-supporting provider whose scheme cannot be opened → `canOpenPaymentProviderApp`
+        // returns false → the else branch of `handleGPCPayment` runs.
+        sut.selectedPaymentProvider = Self.makeProvider(gpcOnIOS: true,
+                                                         openWithOnIOS: false,
+                                                         scheme: "unopenable-scheme-\(UUID().uuidString)")
+        sut.paymentInfo = nil
+
+        sut.didTapOnPayInvoice(documentId: nil)
+
+        #expect(spyNavigationController.presented.count == 1,
+                "`presentInstallAppBottomSheet` must be reached even when `paymentInfo` is nil")
+        let presentedView = try #require(spyNavigationController.presented.first?.viewController)
+        #expect(presentedView is InstallAppBottomView,
+                "Presented view controller should be the install-app bottom sheet")
+    }
+
+    @Test("Install-app sheet is reachable via GPC when `paymentInfo` is present too")
+    func installAppSheet_isPresented_onGPCPath_whenPaymentInfoIsPresent() throws {
+        GiniHealthConfiguration.shared.showPaymentReviewScreen = false
+        GiniHealthConfiguration.shared.useInvoiceWithoutDocument = true
+
+        sut.selectedPaymentProvider = Self.makeProvider(gpcOnIOS: true,
+                                                         openWithOnIOS: false,
+                                                         scheme: "unopenable-scheme-\(UUID().uuidString)")
+        sut.paymentInfo = Self.makePaymentInfo()
+
+        sut.didTapOnPayInvoice(documentId: nil)
+
+        #expect(spyNavigationController.presented.count == 1)
+        let presentedView = try #require(spyNavigationController.presented.first?.viewController)
+        #expect(presentedView is InstallAppBottomView)
+    }
+
+    // MARK: - `handleOpenWithPayment` guard
+
+    @Test("Open-with branch is a no-op when `paymentInfo` is nil")
+    func openWithBranch_isNoOp_whenPaymentInfoIsNil() throws {
+        GiniHealthConfiguration.shared.showPaymentReviewScreen = false
+        GiniHealthConfiguration.shared.useInvoiceWithoutDocument = true
+
+        sut.selectedPaymentProvider = Self.makeProvider(gpcOnIOS: false, openWithOnIOS: true)
+        sut.paymentInfo = nil
+
+        sut.didTapOnPayInvoice(documentId: nil)
+
+        // Guarded by `guard let paymentInfo else { return }` — no request created,
+        // no bottom sheet presented, no delegate loading-state toggle.
+        #expect(spyNavigationController.presented.isEmpty)
+        #expect(spyNavigationController.pushed.isEmpty)
+        #expect(delegateSpy.loadingStateChanges.isEmpty)
+    }
+
+    // MARK: - Public predicates
+
+    @Test("`supportsOpenWith` reflects the selected provider's iOS support")
+    func supportsOpenWith_reflectsProviderPlatforms() {
+        sut.selectedPaymentProvider = nil
+        #expect(sut.supportsOpenWith() == false)
+
+        sut.selectedPaymentProvider = Self.makeProvider(gpcOnIOS: false, openWithOnIOS: false)
+        #expect(sut.supportsOpenWith() == false)
+
+        sut.selectedPaymentProvider = Self.makeProvider(gpcOnIOS: false, openWithOnIOS: true)
+        #expect(sut.supportsOpenWith() == true)
+    }
+
+    @Test("`supportsGPC` reflects the selected provider's iOS support")
+    func supportsGPC_reflectsProviderPlatforms() {
+        sut.selectedPaymentProvider = nil
+        #expect(sut.supportsGPC() == false)
+
+        sut.selectedPaymentProvider = Self.makeProvider(gpcOnIOS: false, openWithOnIOS: false)
+        #expect(sut.supportsGPC() == false)
+
+        sut.selectedPaymentProvider = Self.makeProvider(gpcOnIOS: true, openWithOnIOS: false)
+        #expect(sut.supportsGPC() == true)
+    }
+
+    @Test("`canOpenPaymentProviderApp` is false when GPC is not supported")
+    func canOpenPaymentProviderApp_isFalse_whenGPCUnsupported() {
+        sut.selectedPaymentProvider = Self.makeProvider(gpcOnIOS: false, openWithOnIOS: false)
+        #expect(sut.canOpenPaymentProviderApp() == false)
+    }
+
+    @Test("`canOpenPaymentProviderApp` is false when scheme cannot be opened")
+    func canOpenPaymentProviderApp_isFalse_whenSchemeUnopenable() {
+        sut.selectedPaymentProvider = Self.makeProvider(gpcOnIOS: true,
+                                                         openWithOnIOS: false,
+                                                         scheme: "unopenable-scheme-\(UUID().uuidString)")
+        // GPC is supported but the scheme cannot be opened by the simulator.
+        #expect(sut.canOpenPaymentProviderApp() == false)
+    }
+
+    // MARK: - Fixture builders
+
+    private static func makeProvider(gpcOnIOS: Bool,
+                                     openWithOnIOS: Bool,
+                                     scheme: String = "test-scheme") -> PaymentProvider {
+        PaymentProvider(id: "test-provider-\(UUID().uuidString)",
+                        name: "Test Bank",
+                        appSchemeIOS: scheme,
+                        minAppVersion: nil,
+                        colors: ProviderColors(background: "#FFFFFF",
+                                                text: "#000000"),
+                        iconData: Data(),
+                        appStoreUrlIOS: "https://apps.apple.com/test",
+                        universalLinkIOS: "https://example.com/pay",
+                        index: 0,
+                        gpcSupportedPlatforms: gpcOnIOS ? [.ios] : [],
+                        openWithSupportedPlatforms: openWithOnIOS ? [.ios] : [])
+    }
+
+    private static func makePaymentInfo() -> GiniInternalPaymentSDK.PaymentInfo {
+        GiniInternalPaymentSDK.PaymentInfo(recipient: "Test Recipient",
+                                            iban: "DE00123456789012345678",
+                                            amount: "1.00:EUR",
+                                            purpose: "Test",
+                                            paymentUniversalLink: "https://example.com/pay",
+                                            paymentProviderId: "test-provider")
+    }
+}
+
+// MARK: - Test doubles
+
+/**
+ Captures `present` and `pushViewController` calls without actually rendering,
+ so tests can observe navigation intent without a live view hierarchy.
+ */
+private final class SpyNavigationController: UINavigationController {
+
+    struct Presentation {
+        let viewController: UIViewController
+        let animated: Bool
+    }
+
+    var presented: [Presentation] = []
+    var pushed: [UIViewController] = []
+
+    override func present(_ viewControllerToPresent: UIViewController,
+                          animated flag: Bool,
+                          completion: (() -> Void)? = nil) {
+        presented.append(Presentation(viewController: viewControllerToPresent, animated: flag))
+        completion?()
+    }
+
+    override func pushViewController(_ viewController: UIViewController, animated: Bool) {
+        pushed.append(viewController)
+    }
+}
+
+/**
+ Records every delegate callback so tests can assert both what was called
+ and (for `isLoadingStateChanged`) with which value, without depending on
+ the real host-app plumbing.
+ */
+private final class PaymentComponentsControllerDelegateSpy: PaymentComponentsControllerProtocol {
+    var loadingStateChanges: [Bool] = []
+    var didFetchedPaymentProvidersCallCount = 0
+    var didDismissPaymentComponentsCallCount = 0
+
+    func isLoadingStateChanged(isLoading: Bool) {
+        loadingStateChanges.append(isLoading)
+    }
+
+    func didFetchedPaymentProviders() {
+        didFetchedPaymentProvidersCallCount += 1
+    }
+
+    func didDismissPaymentComponents() {
+        didDismissPaymentComponentsCallCount += 1
+    }
+}

--- a/HealthSDK/GiniHealthSDKExample/GiniHealthSDKExample/AppCoordinator.swift
+++ b/HealthSDK/GiniHealthSDKExample/GiniHealthSDKExample/AppCoordinator.swift
@@ -14,7 +14,7 @@ import GiniInternalPaymentSDK
 import GiniUtilites
 
 final class AppCoordinator: Coordinator {
-    
+
     /**
      * Determines whether to use the pre-existing navigation controller (`false`)
      * or create a new `UINavigationController` for alternative navigation (`true`).
@@ -44,7 +44,7 @@ final class AppCoordinator: Coordinator {
         selectAPIViewController.clientId = clientID
         return selectAPIViewController
     }()
-    
+
     lazy var giniConfiguration: GiniConfiguration = {
         let giniConfiguration = GiniConfiguration.shared
         giniConfiguration.debugModeOn = true
@@ -88,30 +88,25 @@ final class AppCoordinator: Coordinator {
               "      - Client email domain:  \(clientDomain)",
               "\n\n------------------------------------\n")
     }
-    
+
     func start() {
         self.showSelectAPIScreen()
     }
-    
+
     func processExternalDocument(withUrl url: URL, sourceApplication: String?) {
         
         // 1. Build the document
         let documentBuilder = GiniCaptureDocumentBuilder(documentSource: .appName(name: sourceApplication))
         documentBuilder.importMethod = .openWith
-        
-        documentBuilder.build(with: url) { [weak self] (document) in
-            
+
+        documentBuilder.build(with: url) { [weak self] document in
             guard let self = self else { return }
-            
-            // When a document is imported with "Open with", a dialog allowing to choose between both APIs
-            // is shown in the main screen. Therefore it needs to go to the main screen if it is not there yet.
             self.popToRootViewControllerIfNeeded()
-            
+
             // 2. Validate the document
             if let document = document {
                 do {
-                    try GiniCapture.validate(document,
-                                             withConfig: self.giniConfiguration)
+                    try GiniCapture.validate(document, withConfig: self.giniConfiguration)
                     self.showOpenWithSwitchDialog(for: [GiniCapturePage(document: document, error: nil)])
                 } catch {
                     self.showExternalDocumentNotValidDialog()
@@ -119,7 +114,7 @@ final class AppCoordinator: Coordinator {
             }
         }
     }
-    
+
     func processBankUrl(url: URL) {
         if let invoicesListCoordinator = childCoordinators.last as? InvoicesListCoordinator {
             invoicesListCoordinator.invoicesListNavigationController.popViewController(animated: true)
@@ -128,30 +123,28 @@ final class AppCoordinator: Coordinator {
                 orderListCoordinator.orderListNavigationController.popViewController(animated: true)
             })
         }
-        
+
         guard let components = URLComponents(url: url, resolvingAgainstBaseURL: true) else { return }
-        
-        if let queryItems = components.queryItems {
-            if let paymentRequestId = queryItems.first(where: { $0.name == "paymentRequestId" })?.value {
-                selectAPIViewController.showActivityIndicator()
-                health.getPaymentRequest(by: paymentRequestId) { [weak self] result in
+
+        if let paymentRequestId = components.queryItems?.first(where: { $0.name == "paymentRequestId" })?.value {
+            selectAPIViewController.showActivityIndicator()
+            health.getPaymentRequest(by: paymentRequestId) { [weak self] result in
+                DispatchQueue.main.async {
+                    self?.selectAPIViewController.hideActivityIndicator()
+                }
+                switch result {
+                case .success(let paymentRequest):
+                    GiniUtilites.Log("Successfully obtained payment request", event: .success)
                     DispatchQueue.main.async {
-                        self?.selectAPIViewController.hideActivityIndicator()
+                        self?.showReturnMessage(message: self?.messageFor(status: PaymentStatus(rawValue: paymentRequest.status)) ?? "")
                     }
-                    switch result {
-                    case .success(let paymentRequest):
-                        GiniUtilites.Log("Successfully obtained payment request", event: .success)
-                        DispatchQueue.main.async {
-                            self?.showReturnMessage(message: self?.messageFor(status: PaymentStatus(rawValue: paymentRequest.status)) ?? "")
-                        }
-                    case .failure(let error):
-                        GiniUtilites.Log("Failed to retrieve payment request: \(error.localizedDescription)", event: .error)
-                    }
+                case .failure(let error):
+                    GiniUtilites.Log("Failed to retrieve payment request: \(error.localizedDescription)", event: .error)
                 }
             }
         }
     }
-    
+
     private enum PaymentStatus: String {
         case paid
         case paidAdjusted = "paid_adjusted"
@@ -167,12 +160,12 @@ final class AppCoordinator: Coordinator {
             return "Payment was unsuccessful 😢"
         }
     }
-    
+
     fileprivate func showSelectAPIScreen() {
         self.window.rootViewController = rootViewController
         self.window.makeKeyAndVisible()
     }
-    
+
     fileprivate func showScreenAPI(with pages: [GiniCapturePage]? = nil) {
         let metadata = GiniHealthAPILibrary.Document.Metadata(branchId: documentMetadataBranchId,
                                                               additionalHeaders: [documentMetadataAppFlowKey: "ScreenAPI"])
@@ -182,21 +175,19 @@ final class AppCoordinator: Coordinator {
                                                         client: GiniHealthAPILibrary.Client(id: clientID,
                                                                                             secret: clientPassword,
                                                                                             domain: clientDomain),
-                                                                                            documentMetadata: metadata,
+                                                        documentMetadata: metadata,
                                                         hardcodedInvoicesController: hardcodedInvoicesController)
-        
         screenAPICoordinator.delegate = self
-        
         health.delegate = self
         screenAPICoordinator.giniHealth = health
-        
+
         let apiLib = health.giniApiLib
         screenAPICoordinator.start(healthAPI: apiLib)
         add(childCoordinator: screenAPICoordinator)
-        
+
         rootViewController.present(screenAPICoordinator.rootViewController, animated: true)
     }
-    
+
     private var testDocument: GiniHealthSDK.Document?
     private var testDocumentExtractions: [GiniHealthSDK.Extraction]?
 
@@ -205,84 +196,106 @@ final class AppCoordinator: Coordinator {
         health.setConfiguration(giniHealthConfiguration)
 
         if let document = self.testDocument {
-            self.selectAPIViewController.showActivityIndicator()
-            
-            self.health.fetchDataForReview(documentId: document.id) { result in
-                switch result {
-                case .success(let data):
-                    self.health.documentService.extractions(for: data.document, cancellationToken: CancellationToken()) { [weak self] result in
-                        switch result {
-                        case let .success(extractionResult):
-                            GiniUtilites.Log("Successfully fetched extractions for id: \(document.id)", event: .success)
-                            let invoice = DocumentWithExtractions(documentId: document.id,
-                                                                  extractionResult: extractionResult)
-                            self?.showInvoicesList(invoices: [invoice])
-                        case let .failure(error):
-                            GiniUtilites.Log("Obtaining extractions from document with id \(document.id) failed with error: \(String(describing: error))",
-                                             event: .error)
-                        }
-                    }
-                case .failure(let error):
-                    GiniUtilites.Log("Document data fetching failed: \(String(describing: error))", event: .error)
-                    self.selectAPIViewController.hideActivityIndicator()
-                }
-            }
+            fetchAndShowExistingDocument(document)
         } else {
-            // Upload the test document image
-            let testDocumentImage = UIImage(named: "testDocument")!
-            let testDocumentData = testDocumentImage.jpegData(compressionQuality: 1)!
-            
-            self.selectAPIViewController.showActivityIndicator()
-            
-            self.health.documentService.createDocument(fileName: nil,
-                                                       docType: nil,
-                                                       type: .partial(testDocumentData),
-                                                       metadata: nil) { result in
-                switch result {
-                case .success(let createdDocument):
-                    let partialDocInfo = GiniHealthSDK.PartialDocumentInfo(document: createdDocument.links.document)
-                    self.health.documentService.createDocument(fileName: nil,
-                                                               docType: nil,
-                                                               type: .composite(CompositeDocumentInfo(partialDocuments: [partialDocInfo])),
-                                                               metadata: nil) { [weak self] result in
-                        switch result {
-                        case .success(let compositeDocument):
-                            self?.health.setDocumentForReview(documentId: compositeDocument.id) { [weak self] result in
-                                switch result {
-                                case .success(let extractions):
-                                    self?.testDocument = compositeDocument
-                                    self?.testDocumentExtractions = extractions
+            uploadAndShowNewDocument()
+        }
+    }
 
-                                    self?.health.documentService.extractions(for: compositeDocument, cancellationToken: CancellationToken()) { [weak self] result in
-                                        switch result {
-                                        case let .success(extractionResult):
-                                            GiniUtilites.Log("Successfully fetched extractions for id: \(compositeDocument.id)", event: .success)
-                                            let invoice = DocumentWithExtractions(documentId: compositeDocument.id,
-                                                                                  extractionResult: extractionResult)
-                                            self?.showInvoicesList(invoices: [invoice])
-                                        case let .failure(error):
-                                            GiniUtilites.Log("Obtaining extractions from document with id \(compositeDocument.id) failed with error: \(String(describing: error))",
-                                                             event: .error)
-                                        }
-                                    }
-                                case .failure(let error):
-                                    GiniUtilites.Log("Setting document for review failed: \(String(describing: error))", event: .error)
-                                    self?.selectAPIViewController.hideActivityIndicator()
-                                }
-                            }
-                        case .failure(let error):
-                            GiniUtilites.Log("Document creation failed: \(String(describing: error))", event: .error)
-                            self?.selectAPIViewController.hideActivityIndicator()
-                        }
-                    }
-                case .failure(let error):
-                    GiniUtilites.Log("Document creation failed: \(String(describing: error))", event: .error)
-                    self.selectAPIViewController.hideActivityIndicator()
-                }
+    private func fetchAndShowExistingDocument(_ document: GiniHealthSDK.Document) {
+        selectAPIViewController.showActivityIndicator()
+
+        health.fetchDataForReview(documentId: document.id) { [weak self] result in
+            guard let self = self else { return }
+
+            switch result {
+            case .success(let data):
+                self.fetchExtractionsAndShowInvoice(for: data.document)
+            case .failure(let error):
+                GiniUtilites.Log("Document data fetching failed: \(String(describing: error))", event: .error)
+                self.selectAPIViewController.hideActivityIndicator()
             }
         }
     }
-    
+
+    private func fetchExtractionsAndShowInvoice(for document: GiniHealthSDK.Document) {
+        health.documentService.extractions(for: document, cancellationToken: CancellationToken()) { [weak self] result in
+            guard let self = self else { return }
+
+            switch result {
+            case .success(let extractionResult):
+                GiniUtilites.Log("Successfully fetched extractions for id: \(document.id)", event: .success)
+                let invoice = DocumentWithExtractions(documentId: document.id,
+                                                      extractionResult: extractionResult)
+                self.showInvoicesList(invoices: [invoice])
+            case .failure(let error):
+                GiniUtilites.Log("Obtaining extractions from document with id \(document.id) failed with error: \(String(describing: error))",
+                                 event: .error)
+                self.selectAPIViewController.hideActivityIndicator()
+            }
+        }
+    }
+
+    private func uploadAndShowNewDocument() {
+        guard let testDocumentImage = UIImage(named: "testDocument"),
+              let testDocumentData = testDocumentImage.jpegData(compressionQuality: 1) else {
+            GiniUtilites.Log("Failed to load test document image", event: .error)
+            return
+        }
+
+        selectAPIViewController.showActivityIndicator()
+
+        health.documentService.createDocument(fileName: nil,
+                                              docType: nil,
+                                              type: .partial(testDocumentData),
+                                              metadata: nil) { [weak self] result in
+            guard let self = self else { return }
+
+            switch result {
+            case .success(let createdDocument):
+                self.createCompositeDocument(from: createdDocument)
+            case .failure(let error):
+                GiniUtilites.Log("Document creation failed: \(String(describing: error))", event: .error)
+                self.selectAPIViewController.hideActivityIndicator()
+            }
+        }
+    }
+
+    private func createCompositeDocument(from partialDocument: GiniHealthSDK.Document) {
+        let partialDocInfo = GiniHealthSDK.PartialDocumentInfo(document: partialDocument.links.document)
+
+        health.documentService.createDocument(fileName: nil,
+                                              docType: nil,
+                                              type: .composite(CompositeDocumentInfo(partialDocuments: [partialDocInfo])),
+                                              metadata: nil) { [weak self] result in
+            guard let self = self else { return }
+
+            switch result {
+            case .success(let compositeDocument):
+                self.setDocumentForReview(compositeDocument)
+            case .failure(let error):
+                GiniUtilites.Log("Document creation failed: \(String(describing: error))", event: .error)
+                self.selectAPIViewController.hideActivityIndicator()
+            }
+        }
+    }
+
+    private func setDocumentForReview(_ document: GiniHealthSDK.Document) {
+        health.setDocumentForReview(documentId: document.id) { [weak self] result in
+            guard let self = self else { return }
+
+            switch result {
+            case .success(let extractions):
+                self.testDocument = document
+                self.testDocumentExtractions = extractions
+                self.fetchExtractionsAndShowInvoice(for: document)
+            case .failure(let error):
+                GiniUtilites.Log("Setting document for review failed: \(String(describing: error))", event: .error)
+                self.selectAPIViewController.hideActivityIndicator()
+            }
+        }
+    }
+
     fileprivate func showOpenWithSwitchDialog(for pages: [GiniCapturePage]) {
         let alertViewController = UIAlertController(title: "Importierte Datei",
                                                     message: "Möchten Sie die importierte Datei mit dem " +
@@ -296,7 +309,7 @@ final class AppCoordinator: Coordinator {
         alertViewController.preferredAction = okAction
         rootViewController.present(alertViewController, animated: true)
     }
-    
+
     fileprivate func showExternalDocumentNotValidDialog() {
         let alertViewController = UIAlertController(title: "Ungültiges Dokument",
                                                     message: "Dies ist kein gültiges Dokument",
@@ -318,14 +331,14 @@ final class AppCoordinator: Coordinator {
         alertViewController.preferredAction = okAction
         rootViewController.present(alertViewController, animated: true)
     }
-    
+
     fileprivate func popToRootViewControllerIfNeeded() {
         self.childCoordinators.forEach { coordinator in
             coordinator.rootViewController.dismiss(animated: true)
             self.remove(childCoordinator: coordinator)
         }
     }
-    
+
     fileprivate func showInvoicesList(invoices: [DocumentWithExtractions]? = nil) {
         DispatchQueue.main.async {
             self.selectAPIViewController.hideActivityIndicator()
@@ -356,7 +369,7 @@ final class AppCoordinator: Coordinator {
         giniHealthConfiguration.useInvoiceWithoutDocument = true
         health.setConfiguration(giniHealthConfiguration)
         health.delegate = self
-        
+
         let orderListCoordinator = OrderListCoordinator()
         orderListCoordinator.start(documentService: health.documentService,
                                    hardcodedOrdersController: HardcodedOrdersController(),
@@ -397,12 +410,12 @@ extension AppCoordinator: ScreenAPICoordinatorDelegate {
             rootViewController.showError(title, message: message)
         }
     }
-    
+
     func screenAPI(coordinator: ScreenAPICoordinator, didFinish: ()) {
         coordinator.rootViewController.dismiss(animated: true)
         self.remove(childCoordinator: coordinator)
     }
-    
+
     func presentInvoicesList(invoices: [DocumentWithExtractions]?) {
         self.showInvoicesList(invoices: invoices)
     }
@@ -432,11 +445,11 @@ extension AppCoordinator: GiniHealthDelegate {
         }
         presentError(title: "Error", message: message)
     }
-    
+
     func didCreatePaymentRequest(paymentRequestId: String) {
         GiniUtilites.Log("Created payment request with id \(paymentRequestId)", event: .success)
     }
-    
+
     func didDismissHealthSDK() {
         if shouldUseAlternativeNavigation {
             rootViewController.presentedViewController?.dismiss(animated: true)
@@ -488,7 +501,7 @@ extension AppCoordinator: DebugMenuDelegate {
         giniHealthConfiguration.customLocalization = localization
         health.setConfiguration(giniHealthConfiguration)
     }
-    
+
     func didChangeSliderValue(value: Float) {
         giniHealthConfiguration.popupDurationPaymentReview = TimeInterval(value)
     }
@@ -497,11 +510,11 @@ extension AppCoordinator: DebugMenuDelegate {
         giniHealthConfiguration.shareWithFileName = filename
         health.setConfiguration(giniHealthConfiguration)
     }
-    
+
     func didTapOnBulkDelete() {
         let documentsToDeleteIds = Array(hardcodedInvoicesController.getInvoicesWithExtractions()
             .map { $0.documentId }
-            .prefix(Constants.numberOfDocumentsToBeDeleted)) // Number of documents to delete
+            .prefix(Constants.numberOfDocumentsToBeDeleted))
 
         health.deleteDocuments(documentIds: documentsToDeleteIds) { [weak self] result in
             switch result {

--- a/HealthSDK/GiniHealthSDKExample/GiniHealthSDKExample/AppCoordinator.swift
+++ b/HealthSDK/GiniHealthSDKExample/GiniHealthSDKExample/AppCoordinator.swift
@@ -101,6 +101,8 @@ final class AppCoordinator: Coordinator {
 
         documentBuilder.build(with: url) { [weak self] document in
             guard let self = self else { return }
+            // When a document is imported with "Open with", a dialog allowing to choose between both APIs
+            // is shown in the main screen. Therefore it needs to go to the main screen if it is not there yet.
             self.popToRootViewControllerIfNeeded()
 
             // 2. Validate the document

--- a/HealthSDK/GiniHealthSDKExample/GiniHealthSDKExample/AppCoordinator.swift
+++ b/HealthSDK/GiniHealthSDKExample/GiniHealthSDKExample/AppCoordinator.swift
@@ -106,7 +106,8 @@ final class AppCoordinator: Coordinator {
             // 2. Validate the document
             if let document = document {
                 do {
-                    try GiniCapture.validate(document, withConfig: self.giniConfiguration)
+                    try GiniCapture.validate(document,
+                                             withConfig: self.giniConfiguration)
                     self.showOpenWithSwitchDialog(for: [GiniCapturePage(document: document, error: nil)])
                 } catch {
                     self.showExternalDocumentNotValidDialog()

--- a/HealthSDK/GiniHealthSDKExample/GiniHealthSDKExample/HealthNetworkingService.swift
+++ b/HealthSDK/GiniHealthSDKExample/GiniHealthSDKExample/HealthNetworkingService.swift
@@ -135,28 +135,39 @@ class HealthNetworkingService: GiniCaptureNetworkService {
                 guard let self = self else { return }
                 switch result {
                 case let .success(createdDocument):
-                    self.documentService
-                        .extractions(for: createdDocument,
-                                     cancellationToken: GiniHealthAPILibrary.CancellationToken()) { [weak self] result in
-                            guard self != nil else { return }
-                            switch result {
-                            case let .success(extractionResult):
-                                if let doc = self?.mapDocumentToGiniBankAPI(doc: createdDocument),
-                                   let result = self?.mapExtractionResultToGiniBankAPI(result: extractionResult) {
-                                    completion(.success((doc, result)))
-                                } else {
-                                    completion(.failure(.parseError(message: "Failed to parse extraction result")))
-                                 }
-                            case let .failure(error):
-                                completion(.failure(.unknown(response: error.response, data: error.data)))
-                            }
-                        }
+                    self.fetchExtractionsAndComplete(for: createdDocument, completion: completion)
                 case let .failure(error):
                     completion(.failure(.unknown(response: error.response, data: error.data)))
                 }
             }
     }
-    
+
+    private func fetchExtractionsAndComplete(for document: GiniHealthAPILibrary.Document,
+                                             completion: @escaping GiniBankAPIAnalysisCompletion) {
+        documentService.extractions(for: document,
+                                    cancellationToken: GiniHealthAPILibrary.CancellationToken()) { [weak self] result in
+            guard let self = self else { return }
+
+            switch result {
+            case .success(let extractionResult):
+                self.handleExtractionSuccess(document: document,
+                                             extractionResult: extractionResult,
+                                             completion: completion)
+            case .failure(let error):
+                completion(.failure(.unknown(response: error.response, data: error.data)))
+            }
+        }
+    }
+
+    private func handleExtractionSuccess(document: GiniHealthAPILibrary.Document,
+                                         extractionResult: GiniHealthAPILibrary.ExtractionResult,
+                                         completion: @escaping GiniBankAPIAnalysisCompletion) {
+        let mappedDocument = mapDocumentToGiniBankAPI(doc: document)
+        let mappedResult = mapExtractionResultToGiniBankAPI(result: extractionResult)
+
+        completion(.success((mappedDocument, mappedResult)))
+    }
+
     func upload(document: GiniCaptureSDK.GiniCaptureDocument,
                 metadata: GiniBankAPILibrary.Document.Metadata?,
                 completion: @escaping GiniCaptureSDK.UploadDocumentCompletion) {
@@ -174,12 +185,12 @@ class HealthNetworkingService: GiniCaptureNetworkService {
             }
         }
     }
-    
+
     func log(errorEvent: ErrorEvent,
              completion: @escaping (Result<Void, GiniBankAPILibrary.GiniError>) -> Void) {
         // This method will remain empty; no implementation is needed.
     }
-    
+
     func sendFeedback(document: GiniBankAPILibrary.Document,
                       updatedExtractions: [GiniBankAPILibrary.Extraction],
                       updatedCompoundExtractions: [String : [[GiniBankAPILibrary.Extraction]]]?,

--- a/HealthSDK/GiniHealthSDKExample/GiniHealthSDKExample/HealthNetworkingService.swift
+++ b/HealthSDK/GiniHealthSDKExample/GiniHealthSDKExample/HealthNetworkingService.swift
@@ -135,7 +135,8 @@ class HealthNetworkingService: GiniCaptureNetworkService {
                 guard let self = self else { return }
                 switch result {
                 case let .success(createdDocument):
-                    self.fetchExtractionsAndComplete(for: createdDocument, completion: completion)
+                    self.fetchExtractionsAndComplete(for: createdDocument,
+                                                     completion: completion)
                 case let .failure(error):
                     completion(.failure(.unknown(response: error.response, data: error.data)))
                 }

--- a/HealthSDK/GiniHealthSDKExample/GiniHealthSDKExample/InvoicesList/InvoicesListViewModel.swift
+++ b/HealthSDK/GiniHealthSDKExample/GiniHealthSDKExample/InvoicesList/InvoicesListViewModel.swift
@@ -94,21 +94,26 @@ final class InvoicesListViewModel {
         self.documentService.fetchDocument(with: documentIdToRefetch) { [weak self] result in
             switch result {
             case .success(let document):
-                self?.documentService.extractions(for: document, cancellationToken: CancellationToken()) { resultExtractions in
-                    switch resultExtractions {
-                    case .success(let extractions):
-                        self?.shouldRefetchExtractions = false
-                        self?.documentIdToRefetch = nil
-                        self?.hardcodedInvoicesController.updateDocumentExtractions(documentId: document.id, extractions: extractions)
-                        self?.invoices = self?.hardcodedInvoicesController.getInvoicesWithExtractions() ?? []
-                        DispatchQueue.main.async {
-                            self?.coordinator?.invoicesListViewController?.hideActivityIndicator()
-                            self?.coordinator?.invoicesListViewController?.reloadTableView()
-                        }
-                    case .failure(let error):
-                        self?.errors.append(error.localizedDescription)
-                        self?.showErrorsIfAny()
-                    }
+                /// Success is handled in `handleFetchDocumentResponse` via table view reload.
+                self?.handleFetchDocumentResponse(document)
+            case .failure(let error):
+                self?.errors.append(error.localizedDescription)
+                self?.showErrorsIfAny()
+            }
+        }
+    }
+
+    private func handleFetchDocumentResponse(_ document: GiniHealthSDK.Document) {
+        self.documentService.extractions(for: document, cancellationToken: CancellationToken()) { [weak self] resultExtractions in
+            switch resultExtractions {
+            case .success(let extractions):
+                self?.shouldRefetchExtractions = false
+                self?.documentIdToRefetch = nil
+                self?.hardcodedInvoicesController.updateDocumentExtractions(documentId: document.id, extractions: extractions)
+                self?.invoices = self?.hardcodedInvoicesController.getInvoicesWithExtractions() ?? []
+                DispatchQueue.main.async {
+                    self?.coordinator?.invoicesListViewController?.hideActivityIndicator()
+                    self?.coordinator?.invoicesListViewController?.reloadTableView()
                 }
             case .failure(let error):
                 self?.errors.append(error.localizedDescription)
@@ -163,22 +168,7 @@ final class InvoicesListViewModel {
                 switch result {
                 case .success(let createdDocument):
                     GiniUtilites.Log("Successfully created document with id: \(createdDocument.id)", event: .success)
-                    self?.documentService.extractions(for: createdDocument,
-                                                      cancellationToken: CancellationToken()) { [weak self] result in
-                        switch result {
-                        case let .success(extractionResult):
-                            GiniUtilites.Log("Successfully fetched extractions for id: \(createdDocument.id)", event: .success)
-                            self?.invoices.append(DocumentWithExtractions(documentId: createdDocument.id,
-                                                                          extractionResult: extractionResult))
-                        case let .failure(error):
-                            GiniUtilites.Log("Obtaining extractions from document with id \(createdDocument.id) failed with error: \(String(describing: error))",
-                                             event: .error)
-                            if let message = error.message {
-                                self?.errors.append(message)
-                            }
-                        }
-                        self?.dispatchGroup.leave()
-                    }
+                    self?.handleExtractions(for: createdDocument)
                 case .failure(let error):
                     GiniUtilites.Log("Document creation failed: \(String(describing: error))", event: .error)
                     if let message = error.message {
@@ -187,6 +177,25 @@ final class InvoicesListViewModel {
                     self?.dispatchGroup.leave()
                 }
             }
+        }
+    }
+    
+    private func handleExtractions(for createdDocument: GiniHealthSDK.Document) {
+        self.documentService.extractions(for: createdDocument,
+                                         cancellationToken: CancellationToken()) { [weak self] result in
+            switch result {
+            case let .success(extractionResult):
+                GiniUtilites.Log("Successfully fetched extractions for id: \(createdDocument.id)", event: .success)
+                self?.invoices.append(DocumentWithExtractions(documentId: createdDocument.id,
+                                                              extractionResult: extractionResult))
+            case let .failure(error):
+                GiniUtilites.Log("Obtaining extractions from document with id \(createdDocument.id) failed with error: \(String(describing: error))",
+                                 event: .error)
+                if let message = error.message {
+                    self?.errors.append(message)
+                }
+            }
+            self?.dispatchGroup.leave()
         }
     }
 

--- a/HealthSDK/GiniHealthSDKExample/GiniHealthSDKExample/InvoicesList/InvoicesListViewModel.swift
+++ b/HealthSDK/GiniHealthSDKExample/GiniHealthSDKExample/InvoicesList/InvoicesListViewModel.swift
@@ -94,8 +94,8 @@ final class InvoicesListViewModel {
         self.documentService.fetchDocument(with: documentIdToRefetch) { [weak self] result in
             switch result {
             case .success(let document):
-                /// Success is handled in `handleFetchDocumentResponse` via table view reload.
-                self?.handleFetchDocumentResponse(document)
+                /// Success is handled in `fetchExtractions(for:)` via table view reload.
+                self?.fetchExtractions(for: document)
             case .failure(let error):
                 self?.errors.append(error.localizedDescription)
                 self?.showErrorsIfAny()
@@ -103,7 +103,7 @@ final class InvoicesListViewModel {
         }
     }
 
-    private func handleFetchDocumentResponse(_ document: GiniHealthSDK.Document) {
+    private func fetchExtractions(for document: GiniHealthSDK.Document) {
         self.documentService.extractions(for: document, cancellationToken: CancellationToken()) { [weak self] resultExtractions in
             switch resultExtractions {
             case .success(let extractions):

--- a/HealthSDK/GiniHealthSDKExample/GiniHealthSDKExample/InvoicesList/UIViewController.swift
+++ b/HealthSDK/GiniHealthSDKExample/GiniHealthSDKExample/InvoicesList/UIViewController.swift
@@ -28,7 +28,7 @@ extension UIViewController {
         var confirmActionTitle: String? = NSLocalizedString("ginicapture.camera.errorPopup.pickanotherfileButton",
                                                             bundle: Bundle(for: GiniCapture.self),
                                                             comment: "pick another file button title")
-        
+
         switch error {
         case let validationError as DocumentValidationError:
             message = validationError.message
@@ -36,60 +36,78 @@ extension UIViewController {
             message = customValidationError.message
         case let pickerError as FilePickerError:
             message = pickerError.message
-            switch pickerError {
-            case .maxFilesPickedCountExceeded:
-                confirmActionTitle = NSLocalizedString("ginicapture.camera.errorPopup.reviewPages",
-                                                       bundle: Bundle(for: GiniCapture.self),
-                                                       comment: "review pages button title")
-            case .photoLibraryAccessDenied:
-                cancelActionTitle = NSLocalizedString("ginicapture.camera.filepicker.errorPopup.cancelButton",
-                                                      bundle: Bundle(for: GiniCapture.self),
-                                                      comment: "cancel button title")
-                confirmActionTitle = NSLocalizedString("ginicapture.camera.filepicker.errorPopup.grantAccessButton",
-                                                       bundle: Bundle(for: GiniCapture.self),
-                                                       comment: "grant access button title")
-            case .mixedDocumentsUnsupported:
-                cancelActionTitle = NSLocalizedString("ginicapture.camera.mixedarrayspopup.cancel",
-                                                      bundle: Bundle(for: GiniCapture.self),
-                                                      comment: "cancel button text for popup")
-                confirmActionTitle = NSLocalizedString("ginicapture.camera.mixedarrayspopup.usePhotos",
-                                                       bundle: Bundle(for: GiniCapture.self),
-                                                       comment: "use photos button text in popup")
-            case .failedToOpenDocument, .multiplePdfsUnsupported:
-                break
-            }
+            let titles = filePickerErrorTitles(for: pickerError, defaultCancel: cancelActionTitle,
+                                               defaultConfirm: confirmActionTitle)
+            cancelActionTitle = titles.cancel
+            confirmActionTitle = titles.confirm
+
         case let visionError as CustomAnalysisError:
             message = visionError.message
             confirmActionTitle = nil
             cancelActionTitle = NSLocalizedString("ginicapture.analysis.error.actionTitle",
-                                                   bundle: Bundle(for: GiniCapture.self),
-                                                   comment: "Retry analysis")
+                                                  bundle: Bundle(for: GiniCapture.self),
+                                                  comment: "Retry analysis")
         default:
             message = DocumentValidationError.unknown.message
         }
-        
+
         let dialog = errorDialog(withMessage: message,
                                  cancelActionTitle: cancelActionTitle,
                                  confirmActionTitle: confirmActionTitle,
                                  confirmAction: positiveAction)
-        
+
         present(dialog, animated: true, completion: nil)
     }
-    
+
+
+    private func filePickerErrorTitles(for pickerError: FilePickerError,
+                                       defaultCancel: String,
+                                       defaultConfirm: String?) -> (cancel: String, confirm: String?) {
+
+        var cancelActionTitle = defaultCancel
+        var confirmActionTitle = defaultConfirm
+
+        switch pickerError {
+        case .maxFilesPickedCountExceeded:
+            confirmActionTitle = NSLocalizedString("ginicapture.camera.errorPopup.reviewPages",
+                                                   bundle: Bundle(for: GiniCapture.self),
+                                                   comment: "review pages button title")
+        case .photoLibraryAccessDenied:
+            cancelActionTitle = NSLocalizedString("ginicapture.camera.filepicker.errorPopup.cancelButton",
+                                                  bundle: Bundle(for: GiniCapture.self),
+                                                  comment: "cancel button title")
+            confirmActionTitle = NSLocalizedString("ginicapture.camera.filepicker.errorPopup.grantAccessButton",
+                                                   bundle: Bundle(for: GiniCapture.self),
+                                                   comment: "grant access button title")
+        case .mixedDocumentsUnsupported:
+            cancelActionTitle = NSLocalizedString("ginicapture.camera.mixedarrayspopup.cancel",
+                                                  bundle: Bundle(for: GiniCapture.self),
+                                                  comment: "cancel button text for popup")
+            confirmActionTitle = NSLocalizedString("ginicapture.camera.mixedarrayspopup.usePhotos",
+                                                   bundle: Bundle(for: GiniCapture.self),
+                                                   comment: "use photos button text in popup")
+        case .failedToOpenDocument, .multiplePdfsUnsupported:
+            break
+        }
+
+        return (cancelActionTitle, confirmActionTitle)
+
+    }
+
     fileprivate func errorDialog(withMessage message: String,
                                  title: String? = nil,
                                  cancelActionTitle: String,
                                  confirmActionTitle: String? = nil,
                                  confirmAction: (() -> Void)? = nil) -> UIAlertController {
-        
+
         let alertViewController = UIAlertController(title: nil, message: message, preferredStyle: .alert)
-        
+
         alertViewController.addAction(UIAlertAction(title: cancelActionTitle,
                                                     style: .cancel,
                                                     handler: { _ in
                                                         alertViewController.dismiss(animated: true, completion: nil)
         }))
-        
+
         if let confirmActionTitle = confirmActionTitle, let confirmAction = confirmAction {
             let confirmAlertAction = UIAlertAction(title: confirmActionTitle,
                                                    style: .default,

--- a/HealthSDK/GiniHealthSDKExample/GiniHealthSDKExample/InvoicesList/UIViewController.swift
+++ b/HealthSDK/GiniHealthSDKExample/GiniHealthSDKExample/InvoicesList/UIViewController.swift
@@ -60,7 +60,6 @@ extension UIViewController {
         present(dialog, animated: true, completion: nil)
     }
 
-
     private func filePickerErrorTitles(for pickerError: FilePickerError,
                                        defaultCancel: String,
                                        defaultConfirm: String?) -> (cancel: String, confirm: String?) {

--- a/HealthSDK/GiniHealthSDKExample/GiniHealthSDKExample/InvoicesList/UIViewController.swift
+++ b/HealthSDK/GiniHealthSDKExample/GiniHealthSDKExample/InvoicesList/UIViewController.swift
@@ -36,7 +36,8 @@ extension UIViewController {
             message = customValidationError.message
         case let pickerError as FilePickerError:
             message = pickerError.message
-            let titles = filePickerErrorTitles(for: pickerError, defaultCancel: cancelActionTitle,
+            let titles = filePickerErrorTitles(for: pickerError,
+                                               defaultCancel: cancelActionTitle,
                                                defaultConfirm: confirmActionTitle)
             cancelActionTitle = titles.cancel
             confirmActionTitle = titles.confirm


### PR DESCRIPTION
SonarQube fixes for GiniHealthSDK: GiniHealth extraction handling split into helpers, PaymentComponentsController helper refactors, example app refactors (AppCoordinator, InvoicesListViewModel, networking service).

Part of the SonarQube cleanup split from `release/SonarQube-issues` — one PR per SDK for easier review. No public API changes; independent of the sibling SonarQube PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)