### PR TITLE
Pp 3494 fix voiceover tips leak

### DIFF
--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Analysis/CaptureSuggestionsView.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Analysis/CaptureSuggestionsView.swift
@@ -157,7 +157,7 @@ extension CaptureSuggestionsView {
 
     func start(after seconds: TimeInterval = 4) {
         DispatchQueue.main.asyncAfter(deadline: .now() + seconds, execute: { [weak self] in
-            guard let self = self, let superview = self.superview else { return }
+            guard let self = self, let superview = self.superview, self.window != nil else { return }
 
             if let parentVC = self.parentViewController,
                parentVC.presentedViewController != nil {
@@ -203,7 +203,7 @@ extension CaptureSuggestionsView {
                        options: [UIView.AnimationOptions.curveEaseInOut], animations: {
             self.layoutIfNeeded()
         }, completion: {[weak self] _ in
-            guard let self = self else { return }
+            guard let self = self, self.window != nil else { return }
             self.changeView(toState: nextState)
         })
     }

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Analysis/CaptureSuggestionsView.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Analysis/CaptureSuggestionsView.swift
@@ -156,7 +156,7 @@ final class CaptureSuggestionsView: UIView {
 extension CaptureSuggestionsView {
 
     func start(after seconds: TimeInterval = 4) {
-        DispatchQueue.main.asyncAfter(deadline: .now() + seconds, execute: { [weak self] in
+        DispatchQueue.main.asyncAfter(deadline: .now() + seconds) { [weak self] in
             guard let self = self, let superview = self.superview, self.window != nil else { return }
 
             if let parentVC = self.parentViewController,
@@ -179,7 +179,7 @@ extension CaptureSuggestionsView {
                 guard let self, self.window != nil else { return }
                 self.changeView(toState: .hidden)
             })
-        })
+        }
     }
 
     private func changeView(toState state: CaptureSuggestionsState) {

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Analysis/CaptureSuggestionsView.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Analysis/CaptureSuggestionsView.swift
@@ -176,6 +176,7 @@ extension CaptureSuggestionsView {
                     UIAccessibility.post(notification: .announcement, argument: "\(title) \(description)")
                 }
             }, completion: { [weak self] _ in
+                // View detached from window (analysis screen dismissed) — stop the announcement loop.
                 guard let self, self.window != nil else { return }
                 self.changeView(toState: .hidden)
             })

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Analysis/CaptureSuggestionsView.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Analysis/CaptureSuggestionsView.swift
@@ -176,7 +176,8 @@ extension CaptureSuggestionsView {
                     UIAccessibility.post(notification: .announcement, argument: "\(title) \(description)")
                 }
             }, completion: { [weak self] _ in
-                self?.changeView(toState: .hidden)
+                guard let self, self.window != nil else { return }
+                self.changeView(toState: .hidden)
             })
         })
     }


### PR DESCRIPTION
## Pull Request Description

<!-- Briefly explain **what** this PR does and **why**. Mention the motivation, feature, or issue it's addressing. -->

[PP-3494](https://ginis.atlassian.net/browse/PP-3494)<!-- Closes ticket number PP-####; Replace with JIRA ticket if relevant -->

This PR updates the CaptureSDK analysis “capture suggestions” banner animation loop to stop scheduling state changes when the view is no longer attached to a window, preventing VoiceOver announcements from continuing after the analysis UI is no longer on-screen.

<!--

Some description of HOW you achieved it. Perhaps give a high level description of the chnages you did. Did you need to refactor something? What tradeoffs did you take?

-->


<!--

Explain how you verified the changes.
A clear testing scenario helps colleagues who may not be familiar with this part of the code quickly understand and verify the changes. Include steps they can follow to see the impact in action.

You can include: 
- Simulators/Devices you used (e.g. iPhone 13, iPad Pro) 
- iOS versions tested (e.g. 16.0, 17.5) 
- Manual checks (e.g. flow tested: onboarding, permissions, error states) 
- Unit tests added or updated 
 
 Include screenshots, screen recordings, or simulator gifs for UI changes. 
 
 - Optional: Anything that needs extra attention in review? Are there TODOs, known limitations, or follow-up work? 
 
 -->

[PP-3494]: https://ginis.atlassian.net/browse/PP-3494?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ