### PR TITLE
feat(GiniBankAPILibrary): Cover SessionManager login + response paths

### DIFF
--- a/BankAPILibrary/GiniBankAPILibrary/Tests/GiniBankAPILibraryTests/Resources/tokenResponse.json
+++ b/BankAPILibrary/GiniBankAPILibrary/Tests/GiniBankAPILibraryTests/Resources/tokenResponse.json
@@ -1,0 +1,6 @@
+{
+    "access_token": "test-access-token",
+    "expires_in": 3600.0,
+    "token_type": "bearer",
+    "scope": "read"
+}

--- a/BankAPILibrary/GiniBankAPILibrary/Tests/GiniBankAPILibraryTests/SessionManagerAuthTests.swift
+++ b/BankAPILibrary/GiniBankAPILibrary/Tests/GiniBankAPILibraryTests/SessionManagerAuthTests.swift
@@ -14,7 +14,9 @@ import Foundation
 @Suite("SessionManager.logIn — alternative token source")
 struct SessionManagerAlternativeTokenTests {
 
-    /// Manual `AlternativeTokenSource` conformance that returns a fixed result.
+    /**
+     Manual `AlternativeTokenSource` conformance that returns a fixed result.
+     */
     private final class StubAlternativeTokenSource: AlternativeTokenSource {
         let result: Result<Token, GiniError>
 
@@ -78,15 +80,19 @@ struct SessionManagerAlternativeTokenTests {
 
 // MARK: - HTTP-driven paths (login + response handling)
 
-/// Serialized because `URLProtocolMock.handler` is a shared static; every test in
-/// this suite mutates it and would otherwise clobber a sibling running in parallel.
-/// Both the login-flow tests and the response-shape tests live in the same suite
-/// for that reason — tests split across sibling `.serialized` suites are still
-/// eligible to run concurrently in Swift Testing.
+/**
+ Serialized because `URLProtocolMock.handler` is a shared static; every test in
+ this suite mutates it and would otherwise clobber a sibling running in parallel.
+ Both the login-flow tests and the response-shape tests live in the same suite
+ for that reason — tests split across sibling `.serialized` suites are still
+ eligible to run concurrently in Swift Testing.
+ */
 @Suite("SessionManager HTTP interactions", .serialized)
 struct SessionManagerHTTPTests {
 
-    /// Mutable call counter for tests that need to route responses by request order.
+    /**
+     Mutable call counter for tests that need to route responses by request order.
+     */
     private final class CallCounter { var count = 0 }
 
     // MARK: Fixtures

--- a/BankAPILibrary/GiniBankAPILibrary/Tests/GiniBankAPILibraryTests/SessionManagerAuthTests.swift
+++ b/BankAPILibrary/GiniBankAPILibrary/Tests/GiniBankAPILibraryTests/SessionManagerAuthTests.swift
@@ -9,6 +9,8 @@ import Testing
 import Foundation
 @testable import GiniBankAPILibrary
 
+// MARK: - Alternative token source
+
 @Suite("SessionManager.logIn — alternative token source")
 struct SessionManagerAlternativeTokenTests {
 
@@ -46,6 +48,284 @@ struct SessionManagerAlternativeTokenTests {
                 break
             } else {
                 Issue.record("Expected .unauthorized, got \(error)")
+            }
+        }
+    }
+
+    @Test("Success stores the returned accessToken and completes with the token")
+    func successStoresAccessToken() async {
+        let token = Token(expiration: Date(timeIntervalSinceNow: 3600),
+                          scope: "read",
+                          type: "bearer",
+                          accessToken: "alt-source-token")
+        let stub = StubAlternativeTokenSource(result: .success(token))
+        let sut = SessionManager(keyStore: KeychainStoreMock(),
+                                 alternativeTokenSource: stub)
+
+        let result: Result<Token, GiniError> = await withCheckedContinuation { continuation in
+            sut.logIn { continuation.resume(returning: $0) }
+        }
+
+        #expect(sut.userAccessToken == "alt-source-token")
+        switch result {
+        case .success(let received):
+            #expect(received.accessToken == "alt-source-token")
+        case .failure(let error):
+            Issue.record("Expected .success, got .failure(\(error))")
+        }
+    }
+}
+
+// MARK: - HTTP-driven paths (login + response handling)
+
+/// Serialized because `URLProtocolMock.handler` is a shared static; every test in
+/// this suite mutates it and would otherwise clobber a sibling running in parallel.
+/// Both the login-flow tests and the response-shape tests live in the same suite
+/// for that reason — tests split across sibling `.serialized` suites are still
+/// eligible to run concurrently in Swift Testing.
+@Suite("SessionManager HTTP interactions", .serialized)
+struct SessionManagerHTTPTests {
+
+    /// Mutable call counter for tests that need to route responses by request order.
+    private final class CallCounter { var count = 0 }
+
+    // MARK: Fixtures
+
+    private static func tokenResponseData() -> Data {
+        let url = Bundle.module.url(forResource: "tokenResponse", withExtension: "json")
+        guard let url, let data = try? Data(contentsOf: url) else {
+            fatalError("tokenResponse.json fixture missing")
+        }
+        return data
+    }
+
+    private static func okResponse(for request: URLRequest) -> HTTPURLResponse {
+        URLProtocolMock.makeResponse(for: request, statusCode: 200)
+    }
+
+    private static func unauthorizedResponse(for request: URLRequest) -> HTTPURLResponse {
+        URLProtocolMock.makeResponse(for: request, statusCode: 401)
+    }
+
+    // MARK: Doubles
+
+    private static func makeConfiguration() -> URLSessionConfiguration {
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [URLProtocolMock.self]
+        return config
+    }
+
+    private static func seededKeychain(withUser: Bool) -> KeychainStoreMock {
+        let store = KeychainStoreMock()
+        try? store.save(item: KeychainManagerItem(key: .clientId, value: "id", service: .auth))
+        try? store.save(item: KeychainManagerItem(key: .clientSecret, value: "secret", service: .auth))
+        try? store.save(item: KeychainManagerItem(key: .clientDomain, value: "gini.net", service: .auth))
+        if withUser {
+            try? store.save(item: KeychainManagerItem(key: .userEmail, value: "old@user.gini", service: .auth))
+            try? store.save(item: KeychainManagerItem(key: .userPassword, value: "old-password", service: .auth))
+        }
+        return store
+    }
+
+    // MARK: Tests
+
+    @Test("Existing user with valid credentials receives access token")
+    func existingUserSuccess() async {
+        defer { URLProtocolMock.handler = nil }
+        URLProtocolMock.handler = { request in
+            (Self.okResponse(for: request), Self.tokenResponseData())
+        }
+
+        let sut = SessionManager(keyStore: Self.seededKeychain(withUser: true),
+                                 urlSessionConfiguration: Self.makeConfiguration())
+
+        let result: Result<Token, GiniError> = await withCheckedContinuation { continuation in
+            sut.logIn { continuation.resume(returning: $0) }
+        }
+
+        #expect(sut.userAccessToken == "test-access-token")
+        switch result {
+        case .success(let token):
+            #expect(token.accessToken == "test-access-token")
+        case .failure(let error):
+            Issue.record("Expected .success, got .failure(\(error))")
+        }
+    }
+
+    @Test("Existing user rejected as unauthorized triggers user recreation")
+    func existingUserUnauthorizedRecreates() async {
+        defer { URLProtocolMock.handler = nil }
+        let counter = CallCounter()
+        let keychain = Self.seededKeychain(withUser: true)
+
+        URLProtocolMock.handler = { request in
+            counter.count += 1
+            let query = request.url?.query ?? ""
+            let path = request.url?.path ?? ""
+
+            /// Call 1: fetch token for the old user → unauthorized, triggers recreation
+            if query.contains("grant_type=password") && counter.count == 1 {
+                return (Self.unauthorizedResponse(for: request), nil)
+            }
+            /// Client credentials fetch during user recreation
+            if query.contains("grant_type=client_credentials") {
+                return (Self.okResponse(for: request), Self.tokenResponseData())
+            }
+            /// User creation call — response body is a String; the SDK only checks status
+            if path == "/api/users" {
+                return (Self.okResponse(for: request), "user-created".data(using: .utf8))
+            }
+            /// Subsequent password token call for the freshly-created user → success
+            if query.contains("grant_type=password") {
+                return (Self.okResponse(for: request), Self.tokenResponseData())
+            }
+            fatalError("Unexpected request: \(request.url?.absoluteString ?? "nil")")
+        }
+
+        let sut = SessionManager(keyStore: keychain,
+                                 urlSessionConfiguration: Self.makeConfiguration())
+
+        let result: Result<Token, GiniError> = await withCheckedContinuation { continuation in
+            sut.logIn { continuation.resume(returning: $0) }
+        }
+
+        #expect(sut.userAccessToken == "test-access-token")
+        #expect(keychain.fetch(service: .auth, key: .userEmail) != "old@user.gini",
+                "user credentials should have been rotated during recreation")
+        switch result {
+        case .success:
+            break
+        case .failure(let error):
+            Issue.record("Expected .success after recreation, got .failure(\(error))")
+        }
+    }
+
+    @Test("No stored user credentials triggers new-user creation and returns token")
+    func newUserCreation() async {
+        defer { URLProtocolMock.handler = nil }
+        let keychain = Self.seededKeychain(withUser: false)
+
+        URLProtocolMock.handler = { request in
+            let query = request.url?.query ?? ""
+            let path = request.url?.path ?? ""
+
+            if query.contains("grant_type=client_credentials") {
+                return (Self.okResponse(for: request), Self.tokenResponseData())
+            }
+            if path == "/api/users" {
+                return (Self.okResponse(for: request), "user-created".data(using: .utf8))
+            }
+            if query.contains("grant_type=password") {
+                return (Self.okResponse(for: request), Self.tokenResponseData())
+            }
+            fatalError("Unexpected request: \(request.url?.absoluteString ?? "nil")")
+        }
+
+        let sut = SessionManager(keyStore: keychain,
+                                 urlSessionConfiguration: Self.makeConfiguration())
+
+        let result: Result<Token, GiniError> = await withCheckedContinuation { continuation in
+            sut.logIn { continuation.resume(returning: $0) }
+        }
+
+        #expect(sut.userAccessToken == "test-access-token")
+        #expect(keychain.fetch(service: .auth, key: .userEmail) != nil,
+                "new user credentials should be persisted after creation")
+        #expect(keychain.fetch(service: .auth, key: .userPassword) != nil,
+                "new user password should be persisted after creation")
+        switch result {
+        case .success:
+            break
+        case .failure(let error):
+            Issue.record("Expected .success after new-user creation, got .failure(\(error))")
+        }
+    }
+
+    // MARK: - Response-handling shape tests
+    //
+    // These drive `SessionManager.data(resource:)` directly (bypassing login) to
+    // exercise the response classification in `handleResponse` / `handleSuccess`.
+
+    private static func makeResponseSut() -> SessionManager {
+        let sut = SessionManager(keyStore: Self.seededKeychain(withUser: false),
+                                 urlSessionConfiguration: Self.makeConfiguration())
+        /// Bypass login for these tests — they only care about response shape.
+        sut.clientAccessToken = "dummy-client-token"
+        sut.userAccessToken = "dummy-user-token"
+        return sut
+    }
+
+    private static func tokenResource() -> UserResource<Token> {
+        UserResource<Token>(method: .token(grantType: .clientCredentials),
+                            userDomain: .default,
+                            httpMethod: .get)
+    }
+
+    @Test("2xx with a decodable body returns .success")
+    func success2xxReturnsDecodedValue() async {
+        defer { URLProtocolMock.handler = nil }
+        URLProtocolMock.handler = { request in
+            (Self.okResponse(for: request), Self.tokenResponseData())
+        }
+
+        let sut = Self.makeResponseSut()
+        let result: Result<Token, GiniError> = await withCheckedContinuation { continuation in
+            sut.data(resource: Self.tokenResource()) { continuation.resume(returning: $0) }
+        }
+
+        switch result {
+        case .success(let token):
+            #expect(token.accessToken == "test-access-token")
+        case .failure(let error):
+            Issue.record("Expected .success, got .failure(\(error))")
+        }
+    }
+
+    @Test("401 with empty body maps to .unauthorized")
+    func unauthorized401MapsToGiniError() async {
+        defer { URLProtocolMock.handler = nil }
+        URLProtocolMock.handler = { request in
+            (Self.unauthorizedResponse(for: request), Data())
+        }
+
+        let sut = Self.makeResponseSut()
+        let result: Result<Token, GiniError> = await withCheckedContinuation { continuation in
+            sut.data(resource: Self.tokenResource()) { continuation.resume(returning: $0) }
+        }
+
+        switch result {
+        case .success:
+            Issue.record("Expected .failure, got .success")
+        case .failure(let error):
+            if case .unauthorized = error {
+                break
+            } else {
+                Issue.record("Expected .unauthorized, got \(error)")
+            }
+        }
+    }
+
+    @Test("2xx with an undecodable body surfaces as .parseError")
+    func success2xxWithEmptyBodyReturnsParseError() async {
+        defer { URLProtocolMock.handler = nil }
+        URLProtocolMock.handler = { request in
+            /// Empty Data — URLSession delivers it as empty, not nil; JSONDecoder rejects it.
+            (Self.okResponse(for: request), Data())
+        }
+
+        let sut = Self.makeResponseSut()
+        let result: Result<Token, GiniError> = await withCheckedContinuation { continuation in
+            sut.data(resource: Self.tokenResource()) { continuation.resume(returning: $0) }
+        }
+
+        switch result {
+        case .success:
+            Issue.record("Expected .failure, got .success")
+        case .failure(let error):
+            if case .parseError = error {
+                break
+            } else {
+                Issue.record("Expected .parseError, got \(error)")
             }
         }
     }

--- a/BankAPILibrary/GiniBankAPILibrary/Tests/GiniBankAPILibraryTests/TestHelpers/URLProtocolMock.swift
+++ b/BankAPILibrary/GiniBankAPILibrary/Tests/GiniBankAPILibraryTests/TestHelpers/URLProtocolMock.swift
@@ -7,18 +7,20 @@
 
 import Foundation
 
-/// URLProtocol stub whose per-request behaviour is defined by `handler`.
-///
-/// Register with an `URLSessionConfiguration`:
-///
-///     let config = URLSessionConfiguration.ephemeral
-///     config.protocolClasses = [URLProtocolMock.self]
-///     URLProtocolMock.handler = { request in
-///         (URLProtocolMock.makeResponse(for: request, statusCode: 200), Data())
-///     }
-///
-/// Ported from the equivalent helper in the sister `GiniHealthAPILibrary`
-/// test target so the two API libraries can converge on the same pattern.
+/**
+ URLProtocol stub whose per-request behaviour is defined by `handler`.
+
+ Register with an `URLSessionConfiguration`:
+
+     let config = URLSessionConfiguration.ephemeral
+     config.protocolClasses = [URLProtocolMock.self]
+     URLProtocolMock.handler = { request in
+         (URLProtocolMock.makeResponse(for: request, statusCode: 200), Data())
+     }
+
+ Ported from the equivalent helper in the sister `GiniHealthAPILibrary`
+ test target so the two API libraries can converge on the same pattern.
+ */
 final class URLProtocolMock: URLProtocol {
     static var handler: ((URLRequest) -> (HTTPURLResponse, Data?))?
 
@@ -44,9 +46,11 @@ final class URLProtocolMock: URLProtocol {
 
     // MARK: - Helpers
 
-    /// Fallback URL for the rare case where a `URLRequest` arrives without one —
-    /// the returned `HTTPURLResponse` needs a non-optional URL, so we lean on this
-    /// known-good constant instead of force-unwrapping at every call site.
+    /**
+     Fallback URL for the rare case where a `URLRequest` arrives without one —
+     the returned `HTTPURLResponse` needs a non-optional URL, so we lean on this
+     known-good constant instead of force-unwrapping at every call site.
+     */
     static let fallbackURL: URL = {
         guard let url = URL(string: "https://user.gini.net") else {
             fatalError("URLProtocolMock.fallbackURL literal is malformed")
@@ -54,9 +58,11 @@ final class URLProtocolMock: URLProtocol {
         return url
     }()
 
-    /// Build an `HTTPURLResponse` with the requested status code — the initializer
-    /// is optional, so callers would otherwise force-unwrap; this helper wraps the
-    /// invariant in one place.
+    /**
+     Build an `HTTPURLResponse` with the requested status code — the initializer
+     is optional, so callers would otherwise force-unwrap; this helper wraps the
+     invariant in one place.
+     */
     static func makeResponse(for request: URLRequest,
                              statusCode: Int,
                              headers: [String: String]? = nil) -> HTTPURLResponse {

--- a/BankAPILibrary/GiniBankAPILibrary/Tests/GiniBankAPILibraryTests/TestHelpers/URLProtocolMock.swift
+++ b/BankAPILibrary/GiniBankAPILibrary/Tests/GiniBankAPILibraryTests/TestHelpers/URLProtocolMock.swift
@@ -1,0 +1,72 @@
+//
+//  URLProtocolMock.swift
+//  GiniBankAPILibraryTests
+//
+//  Copyright © 2026 Gini GmbH. All rights reserved.
+//
+
+import Foundation
+
+/// URLProtocol stub whose per-request behaviour is defined by `handler`.
+///
+/// Register with an `URLSessionConfiguration`:
+///
+///     let config = URLSessionConfiguration.ephemeral
+///     config.protocolClasses = [URLProtocolMock.self]
+///     URLProtocolMock.handler = { request in
+///         (URLProtocolMock.makeResponse(for: request, statusCode: 200), Data())
+///     }
+///
+/// Ported from the equivalent helper in the sister `GiniHealthAPILibrary`
+/// test target so the two API libraries can converge on the same pattern.
+final class URLProtocolMock: URLProtocol {
+    static var handler: ((URLRequest) -> (HTTPURLResponse, Data?))?
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        guard let handler = URLProtocolMock.handler else {
+            fatalError("URLProtocolMock.handler is not set.")
+        }
+
+        let (response, data) = handler(request)
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        if let data = data {
+            client?.urlProtocol(self, didLoad: data)
+        }
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    override func stopLoading() {
+        /// no-op — nothing to tear down
+    }
+
+    // MARK: - Helpers
+
+    /// Fallback URL for the rare case where a `URLRequest` arrives without one —
+    /// the returned `HTTPURLResponse` needs a non-optional URL, so we lean on this
+    /// known-good constant instead of force-unwrapping at every call site.
+    static let fallbackURL: URL = {
+        guard let url = URL(string: "https://user.gini.net") else {
+            fatalError("URLProtocolMock.fallbackURL literal is malformed")
+        }
+        return url
+    }()
+
+    /// Build an `HTTPURLResponse` with the requested status code — the initializer
+    /// is optional, so callers would otherwise force-unwrap; this helper wraps the
+    /// invariant in one place.
+    static func makeResponse(for request: URLRequest,
+                             statusCode: Int,
+                             headers: [String: String]? = nil) -> HTTPURLResponse {
+        let url = request.url ?? fallbackURL
+        guard let response = HTTPURLResponse(url: url,
+                                             statusCode: statusCode,
+                                             httpVersion: nil,
+                                             headerFields: headers) else {
+            fatalError("Failed to build HTTPURLResponse with status \(statusCode) for \(url)")
+        }
+        return response
+    }
+}


### PR DESCRIPTION
## Pull Request Description

<!-- Briefly explain **what** this PR does and **why**. Mention the motivation, feature, or issue it's addressing. -->

Adds Swift Testing coverage for the SonarQube-flagged uncovered new lines
introduced by #1256. Stacks on `sonarqube/bank-api-library`; merge that first,
then this retargets to `main` automatically.

Sonar quality gate on #1256 fails only on `new_coverage < 80%` (actual 25.5%,
per `sonarcloud.io/api/qualitygates/project_status`). All other conditions pass.
This PR targets the two files driving the miss:

- `SessionManager+Auth.swift` — was 27.7% new coverage (42 uncovered / 69 new lines)
- `SessionManager.swift` — was 2.9% new coverage (34 uncovered / 43 new lines)

**What's added:**

- **URLProtocolMock** ported from `GiniHealthAPILibrary`'s test target — same handler-based shape, so both API libraries now share the pattern.
- **`tokenResponse.json`** fixture matching `Token`'s decoder.
- **7 new `@Test` cases** in `SessionManagerAuthTests.swift`:
  - Alt-token source **success** — stores access token
  - Existing-user **success** — password grant → 200 with token JSON
  - Existing-user **401 → recreation** — chains through client-credentials, `POST /api/users`, then the new user's password grant
  - **New-user creation** — client-only keychain triggers the full create-then-token flow
  - `data(resource:)` **2xx** with a decodable body → `.success`
  - `data(resource:)` **401** with empty body → `.unauthorized`
  - `data(resource:)` **2xx** with an unparseable body → `.parseError`
- Login + response tests share one `.serialized` `@Suite` because `URLProtocolMock.handler` is a shared static; sibling `.serialized` suites can still run in parallel under Swift Testing and would clobber each other.

No production-code changes.

[No ticket — stacked coverage PR for #1256]<!-- Closes ticket number PP-####; Replace with JIRA ticket if relevant -->

## Notes for Reviewers

<!-- Explain how you verified the changes. -->

- Ran the full `GiniBankAPILibrary` test suite locally on iPhone 16 / iOS 18.6:
  **110 XCTest + 42 Swift Testing tests pass, 0 failures.**
- No production code touched — only test target files.
- The `.unauthorized` recreation test uses a call counter to route the four chained HTTP calls (first password → 401, then client_credentials → 200, then `POST /api/users` → 200, then new-user password → 200).
- The chosen fixture status codes and grant-type dispatch match what `UserResource` builds — verified against `UserResource.swift:42-64` and `UserMethod.swift`.
- **Depends on #1256 merging first** (base is `sonarqube/bank-api-library`, not `main`). GitHub will retarget automatically once #1256 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)