### PR TITLE
Release/gini bank sdk 4.5.1

### DIFF
--- a/BankSDK/GiniBankSDK/Package-release.swift
+++ b/BankSDK/GiniBankSDK/Package-release.swift
@@ -16,7 +16,7 @@ let package = Package(
     dependencies: [
         // Dependencies declare other packages that this package depends on.
         // .package(url: /* package url */, from: "1.0.0"),
-        .package(name: "GiniCaptureSDK", url: "https://github.com/gini/capture-sdk-ios.git", .exact("4.5.0")),
+        .package(name: "GiniCaptureSDK", url: "https://github.com/gini/capture-sdk-ios.git", .exact("4.5.1")),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/BankSDK/GiniBankSDK/Sources/GiniBankSDK/GiniBankSDKVersion.swift
+++ b/BankSDK/GiniBankSDK/Sources/GiniBankSDK/GiniBankSDKVersion.swift
@@ -5,4 +5,4 @@
 //  Copyright © 2024 Gini GmbH. All rights reserved.
 //
 
-public let GiniBankSDKVersion = "4.5.0"
+public let GiniBankSDKVersion = "4.5.1"

--- a/BankSDK/GiniBankSDKExample/GiniBankSDKExampleUITests/Scripts/bs_shared.sh
+++ b/BankSDK/GiniBankSDKExample/GiniBankSDKExampleUITests/Scripts/bs_shared.sh
@@ -71,7 +71,7 @@ fi
 # ── BrowserStack project ──────────────────────────────────────────────────────
 # Convention: GiniBankSDK-iOS-<release version>. Update the default here once per
 # release; override per run via the BS_PROJECT environment variable.
-BS_PROJECT="${BS_PROJECT:-GiniBankSDK-iOS-4.5.0}"
+BS_PROJECT="${BS_PROJECT:-GiniBankSDK-iOS-4.5.1}"
 
 # ── upload_media ──────────────────────────────────────────────────────────────
 # Uploads a media file to BrowserStack and stores the returned media_url in a

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Analysis/CaptureSuggestionsView.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Analysis/CaptureSuggestionsView.swift
@@ -157,7 +157,7 @@ extension CaptureSuggestionsView {
 
     func start(after seconds: TimeInterval = 4) {
         DispatchQueue.main.asyncAfter(deadline: .now() + seconds, execute: { [weak self] in
-            guard let self = self, let superview = self.superview else { return }
+            guard let self = self, let superview = self.superview, self.window != nil else { return }
 
             if let parentVC = self.parentViewController,
                parentVC.presentedViewController != nil {
@@ -203,7 +203,7 @@ extension CaptureSuggestionsView {
                        options: [UIView.AnimationOptions.curveEaseInOut], animations: {
             self.layoutIfNeeded()
         }, completion: {[weak self] _ in
-            guard let self = self else { return }
+            guard let self = self, self.window != nil else { return }
             self.changeView(toState: nextState)
         })
     }

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Analysis/CaptureSuggestionsView.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Analysis/CaptureSuggestionsView.swift
@@ -156,7 +156,7 @@ final class CaptureSuggestionsView: UIView {
 extension CaptureSuggestionsView {
 
     func start(after seconds: TimeInterval = 4) {
-        DispatchQueue.main.asyncAfter(deadline: .now() + seconds, execute: { [weak self] in
+        DispatchQueue.main.asyncAfter(deadline: .now() + seconds) { [weak self] in
             guard let self = self, let superview = self.superview, self.window != nil else { return }
 
             if let parentVC = self.parentViewController,
@@ -179,7 +179,7 @@ extension CaptureSuggestionsView {
                 guard let self, self.window != nil else { return }
                 self.changeView(toState: .hidden)
             })
-        })
+        }
     }
 
     private func changeView(toState state: CaptureSuggestionsState) {

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Analysis/CaptureSuggestionsView.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Analysis/CaptureSuggestionsView.swift
@@ -176,6 +176,7 @@ extension CaptureSuggestionsView {
                     UIAccessibility.post(notification: .announcement, argument: "\(title) \(description)")
                 }
             }, completion: { [weak self] _ in
+                // View detached from window (analysis screen dismissed) — stop the announcement loop.
                 guard let self, self.window != nil else { return }
                 self.changeView(toState: .hidden)
             })

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Analysis/CaptureSuggestionsView.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/Core/Screens/Analysis/CaptureSuggestionsView.swift
@@ -176,7 +176,8 @@ extension CaptureSuggestionsView {
                     UIAccessibility.post(notification: .announcement, argument: "\(title) \(description)")
                 }
             }, completion: { [weak self] _ in
-                self?.changeView(toState: .hidden)
+                guard let self, self.window != nil else { return }
+                self.changeView(toState: .hidden)
             })
         })
     }

--- a/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/GiniCaptureSDKVersion.swift
+++ b/CaptureSDK/GiniCaptureSDK/Sources/GiniCaptureSDK/GiniCaptureSDKVersion.swift
@@ -5,4 +5,4 @@
 //  Copyright © 2024 Gini GmbH. All rights reserved.
 //
 
-public let GiniCaptureSDKVersion = "4.5.0"
+public let GiniCaptureSDKVersion = "4.5.1"

--- a/HealthAPILibrary/GiniHealthAPILibrary/Sources/GiniHealthAPILibrary/Documents/Core/SSLPinning/SSLPinningManager.swift
+++ b/HealthAPILibrary/GiniHealthAPILibrary/Sources/GiniHealthAPILibrary/Documents/Core/SSLPinning/SSLPinningManager.swift
@@ -7,7 +7,6 @@
 
 import CryptoKit
 import Foundation
-import CommonCrypto
 
 struct SSLPinningManager {
     // Custom error types for SSL pinning
@@ -105,37 +104,16 @@ private extension SSLPinningManager {
     }
 }
 
-//MARK: - private methods for capability with old ios versions
-
 private extension SSLPinningManager {
     func trustCopyPublicKey(_ trust: SecTrust) -> SecKey? {
-        if #available(iOS 14, *) {
-            return SecTrustCopyKey(trust)
-        } else {
-            return SecTrustCopyPublicKey(trust)
-        }
+        SecTrustCopyKey(trust)
     }
-    
+
     func trustCopyCertificateChain(_ trust: SecTrust) -> [SecCertificate]? {
-        if #available(iOS 15, *) {
-            return (SecTrustCopyCertificateChain(trust) as? [SecCertificate])
-        } else {
-            return (0..<SecTrustGetCertificateCount(trust)).compactMap { index in
-                SecTrustGetCertificateAtIndex(trust, index)
-            }
-        }
+        SecTrustCopyCertificateChain(trust) as? [SecCertificate]
     }
 
     func sha256(data: Data) -> Data {
-        if #available(iOS 13.0, *) {
-            return Data(SHA256.hash(data: data))
-        } else {
-            //code to support ios < 13, import CommonCrypto should be removed with this code
-            var hash = [UInt8](repeating: 0,  count: Int(CC_SHA256_DIGEST_LENGTH))
-            data.withUnsafeBytes { buffer in
-                _ = CC_SHA256(buffer.baseAddress!, CC_LONG(buffer.count), &hash)
-            }
-            return Data(hash)
-        }
+        Data(SHA256.hash(data: data))
     }
 }

--- a/HealthSDK/GiniHealthSDK/Sources/GiniHealthSDK/Core/SSLPinning/SSLPinningManager.swift
+++ b/HealthSDK/GiniHealthSDK/Sources/GiniHealthSDK/Core/SSLPinning/SSLPinningManager.swift
@@ -7,7 +7,6 @@
 
 import CryptoKit
 import Foundation
-import CommonCrypto
 
 struct SSLPinningManager {
     // Custom error types for SSL pinning
@@ -105,36 +104,16 @@ private extension SSLPinningManager {
     }
 }
 
-//MARK: - private methods for capability with old ios versions
-
 private extension SSLPinningManager {
     func trustCopyPublicKey(_ trust: SecTrust) -> SecKey? {
-        if #available(iOS 14, macOS 11, tvOS 14, watchOS 7, visionOS 1, *) {
-            return SecTrustCopyKey(trust)
-        } else {
-            return SecTrustCopyPublicKey(trust)
-        }
+        SecTrustCopyKey(trust)
     }
 
     func trustCopyCertificateChain(_ trust: SecTrust) -> [SecCertificate]? {
-        if #available(iOS 15, macOS 11, tvOS 14, watchOS 7, visionOS 1, *) {
-            return (SecTrustCopyCertificateChain(trust) as? [SecCertificate])
-        } else {
-            return (0..<SecTrustGetCertificateCount(trust)).compactMap { index in
-                SecTrustGetCertificateAtIndex(trust, index)
-            }
-        }
+        SecTrustCopyCertificateChain(trust) as? [SecCertificate]
     }
 
     func sha256(data: Data) -> Data {
-        if #available(iOS 13.0, macOS 10.15, watchOS 6.0, tvOS 13.0, *) {
-            return Data(SHA256.hash(data: data))
-        } else {
-            var hash = [UInt8](repeating: 0,  count: Int(CC_SHA256_DIGEST_LENGTH))
-            data.withUnsafeBytes { buffer in
-                _ = CC_SHA256(buffer.baseAddress!, CC_LONG(buffer.count), &hash)
-            }
-            return Data(hash)
-        }
+        Data(SHA256.hash(data: data))
     }
 }


### PR DESCRIPTION
## Pull Request Description

Release **GiniBankSDK 4.5.1** and **GiniCaptureSDK 4.5.1**. Bundles the two fixes already merged into `main` since 4.5.0 and bumps the version constants + release manifests for tagging.

N/A — release cut; individual fixes carry their own tickets (PP-3494, XPL-130).

Changes included:

- **CaptureSDK — PP-3494:** Stop `CaptureSuggestionsView` from posting VoiceOver announcements after the screen/banner is dismissed. Prevents accessibility announcements from leaking past the suggestion view's lifecycle. (`CaptureSuggestionsView.swift`)
- **HealthAPILibrary / HealthSDK — XPL-130:** Drop dead `#available` fallbacks for iOS 13 (CommonCrypto SHA-256), iOS 14 (`SecTrustCopyPublicKey`), and iOS 15 (per-index cert chain enumeration) in `SSLPinningManager`, and remove the now-unused `CommonCrypto` import. Aligns HealthAPILibrary/HealthSDK with BankAPILibrary, whose minimum deployment (iOS 15 / iOS 17 for Health) makes those branches unreachable. Note: CodeQL alert #237 (`swift/weak-password-hashing`) on the SHA-256 call is a false positive — the hash is over an SSL `SubjectPublicKeyInfo` for TLS certificate pinning (RFC 7469 `pin-sha256`), not a password.
- **Version bumps to 4.5.1:** `GiniBankSDKVersion.swift`, `GiniCaptureSDKVersion.swift`, `BankSDK/GiniBankSDK/Package-release.swift`, and the BrowserStack project name in `GiniBankSDKExampleUITests/Scripts/bs_shared.sh`.

## Notes for Reviewers

- Confirm the version constants and `Package-release.swift` are consistent across `GiniBankSDK` and `GiniCaptureSDK` for the 4.5.1 tag cut.
- The functional changes (PP-3494 and XPL-130) landed via #1261 and #1254 respectively and were reviewed there — the diff on this PR should reduce to those two changes plus the version/BrowserStack bumps.
- Suggested spot checks:
  - VoiceOver: trigger a capture suggestion, dismiss the screen, verify no stale announcements are posted.
  - SSL pinning: existing HealthAPILibrary/HealthSDK integration tests around pinning still pass; behaviour on iOS 15+ (Bank) / iOS 17+ (Health) is unchanged.
- No new unit tests added in this PR (release cut).